### PR TITLE
FPS kamera kontrollerinde pointer lock sorunu düzeltildi

### DIFF
--- a/scene3d.js
+++ b/scene3d.js
@@ -73,6 +73,26 @@ export function init3D(canvasElement) {
     // PointerLockControls'ü başlat
     pointerLockControls = new PointerLockControls(camera, renderer.domElement);
 
+    // PointerLock olaylarını dinle
+    pointerLockControls.addEventListener('unlock', () => {
+        // Kullanıcı ESC tuşuna bastığında veya pointer lock kalktığında
+        // otomatik olarak orbit moda geri dön
+        if (cameraMode === 'firstPerson') {
+            cameraMode = 'orbit';
+            orbitControls.enabled = true;
+            controls = orbitControls;
+
+            // FPS kamera butonunu pasif hale getir
+            if (dom.bFirstPerson) {
+                dom.bFirstPerson.classList.remove('active');
+            }
+
+            // Kamera pozisyonunu izometrik görünüme geri getir
+            camera.position.set(1500, 1800, 1500);
+            orbitControls.update();
+        }
+    });
+
     // Varsayılan olarak OrbitControls aktif
     controls = orbitControls;
 


### PR DESCRIPTION
FPS kamera modu aktifken pointer lock nedeniyle kullanıcı hiçbir UI elementi ile etkileşemiyordu. ESC tuşuna basıldığında pointer lock kalkar ama uygulama bunu yakalamıyordu.

Düzeltme:
- PointerLockControls'e 'unlock' event listener eklendi
- Kullanıcı ESC tuşuna bastığında otomatik olarak orbit moda geri dönülüyor
- FPS kamera butonu pasif hale getiriliyor
- Kamera pozisyonu izometrik görünüme geri getiriliyor

Bu sayede kullanıcı ESC tuşuna basarak FPS kamera modundan çıkıp normal etkileşime geri dönebilir.