### PR TITLE
FPS kamera butonunu aktif hale getir

### DIFF
--- a/scene3d.js
+++ b/scene3d.js
@@ -264,8 +264,8 @@ export function init3D(canvasElement) {
 
 }
 
-// GÜNCELLENDİ: 'sceneObjects' export'a eklendi
-export { scene, camera, renderer, controls, sceneObjects };
+// GÜNCELLENDİ: 'sceneObjects' ve 'pointerLockControls' export'a eklendi
+export { scene, camera, renderer, controls, sceneObjects, pointerLockControls };
 
 // --- Duvar Segmenti Oluşturma (Duvar Tipine Göre) ---
 // GÜNCELLENDİ: Korkuluk ve şapka uzamaları düzeltildi
@@ -1668,8 +1668,8 @@ export function toggleCameraMode() {
         camera.position.set(center.x, CAMERA_HEIGHT, center.z + 200);
         camera.rotation.set(0, 0, 0);
 
-        // PointerLockControls'ü aktifleştir
-        pointerLockControls.lock();
+        // PointerLockControls'ü kontrol olarak ayarla
+        // Lock işlemi ui.js'de buton tıklama event'i içinde yapılacak
         controls = pointerLockControls;
 
     } else {

--- a/ui.js
+++ b/ui.js
@@ -2,7 +2,7 @@
 // Son Güncelleme: Sahanlık kotu (125-135) mantığı confirmStairChange ve ilgili listener'larda düzeltildi.
 import { state, setState, dom, resize, MAHAL_LISTESI, WALL_HEIGHT } from './main.js';
 import { saveState } from './history.js';
-import { update3DScene, toggleCameraMode } from './scene3d.js';
+import { update3DScene, toggleCameraMode, pointerLockControls } from './scene3d.js';
 import { applyStretchModification } from './geometry.js';
 import { processWalls } from './wall-processor.js';
 import { worldToScreen } from './geometry.js';
@@ -607,9 +607,24 @@ export function setupUIListeners() {
 
     // FPS KAMERA BUTONU LISTENER'I
     dom.bFirstPerson.addEventListener('click', () => {
-        toggleCameraMode();
+        const wasActive = dom.bFirstPerson.classList.contains('active');
+
         // Butonu toggle et
         dom.bFirstPerson.classList.toggle('active');
+
+        // Kamera modunu değiştir
+        toggleCameraMode();
+
+        // Eğer FPS moduna geçildiyse (buton aktif olduysa), pointer lock'u başlat
+        if (!wasActive && pointerLockControls) {
+            // Buton tıklama event'i içinde olduğumuz için direkt lock() çağrısı güvenli
+            try {
+                pointerLockControls.lock();
+            } catch (e) {
+                console.warn('Pointer lock başlatılamadı:', e);
+                console.info('İpucu: 3D sahneye tıklayarak FPS modunu aktif edebilirsiniz');
+            }
+        }
     });
 }
 // --- setupUIListeners Sonu ---


### PR DESCRIPTION
FPS butonuna tıklandığında pointer lock direkt aktif olacak şekilde güncellendi.

Değişiklikler:
- scene3d.js: pointerLockControls export edildi ve toggleCameraMode'dan lock() çağrısı kaldırıldı
- ui.js: FPS butonu event handler'ı güncellendi, pointer lock direkt buton tıklamasında aktif ediliyor

Bu sayede kullanıcı FPS butonuna tıkladığında artık direkt FPS modu aktif olacak.