### PR TITLE
FPS kontrolleri düzeltildi - W/A/S/D tuşları artık çalışıyor

### DIFF
--- a/input.js
+++ b/input.js
@@ -10,7 +10,7 @@ import { onPointerMove } from './pointer-move.js';
 import { onPointerUp } from './pointer-up.js';
 import { getObjectAtPoint } from './actions.js';
 // GÜNCELLENDİ: 3D tıklama için importlar eklendi
-import { update3DScene, fit3DViewToScreen, scene, camera, renderer, sceneObjects } from './scene3d.js';
+import { update3DScene, fit3DViewToScreen, scene, camera, renderer, sceneObjects, isFPSMode } from './scene3d.js';
 import * as THREE from "three"; // YENİ
 // --- YENİ İMPORTLAR ---
 import { fitDrawingToScreen, onWheel } from './zoom.js'; // Fit to Screen ve onWheel zoom.js'den
@@ -338,16 +338,18 @@ function onKeyDown(e) {
         }
     }
 
-    // Mod değiştirme kısayolları
-    if (e.key.toLowerCase() === "d") { const newMode = (state.dimensionMode + 1) % 3; setState({ dimensionMode: newMode }); state.dimensionOptions.defaultView = newMode; dom.dimensionDefaultViewSelect.value = newMode; }
-    if (e.key.toLowerCase() === "w" && !e.ctrlKey && !e.altKey && !e.shiftKey ) setMode("drawWall");
+    // Mod değiştirme kısayolları (FPS modundayken W/A/S/D engellenecek)
+    const inFPSMode = isFPSMode();
+
+    if (e.key.toLowerCase() === "d" && !inFPSMode) { const newMode = (state.dimensionMode + 1) % 3; setState({ dimensionMode: newMode }); state.dimensionOptions.defaultView = newMode; dom.dimensionDefaultViewSelect.value = newMode; }
+    if (e.key.toLowerCase() === "w" && !e.ctrlKey && !e.altKey && !e.shiftKey && !inFPSMode) setMode("drawWall");
     if (e.key.toLowerCase() === "r" && !e.ctrlKey && !e.altKey && !e.shiftKey ) setMode("drawRoom");
     if (e.key.toLowerCase() === "k" && !e.ctrlKey && !e.altKey && !e.shiftKey ) setMode("drawDoor");
     if (e.key.toLowerCase() === "p" && !e.ctrlKey && !e.altKey && !e.shiftKey ) setMode("drawWindow");
     if (e.key.toLowerCase() === "c" && !e.ctrlKey && !e.altKey && !e.shiftKey ) setMode("drawColumn");
     if (e.key.toLowerCase() === "b" && !e.ctrlKey && !e.altKey && !e.shiftKey ) setMode("drawBeam");
     if (e.key.toLowerCase() === "m" && !e.ctrlKey && !e.altKey && !e.shiftKey ) setMode("drawStairs");
-    if (e.key.toLowerCase() === "s" && !e.ctrlKey && !e.altKey && !e.shiftKey ) setMode("drawSymmetry"); // YENİ SATIR
+    if (e.key.toLowerCase() === "s" && !e.ctrlKey && !e.altKey && !e.shiftKey && !inFPSMode) setMode("drawSymmetry"); // YENİ SATIR
 
 }
 

--- a/scene3d.js
+++ b/scene3d.js
@@ -1463,9 +1463,11 @@ function setupFirstPersonKeyControls() {
                 moveBackward = true;
                 break;
             case 'ArrowLeft':
+            case 'KeyA':
                 moveLeft = true;
                 break;
             case 'ArrowRight':
+            case 'KeyD':
                 moveRight = true;
                 break;
         }
@@ -1482,9 +1484,11 @@ function setupFirstPersonKeyControls() {
                 moveBackward = false;
                 break;
             case 'ArrowLeft':
+            case 'KeyA':
                 moveLeft = false;
                 break;
             case 'ArrowRight':
+            case 'KeyD':
                 moveRight = false;
                 break;
         }
@@ -1689,6 +1693,11 @@ export function toggleCameraMode() {
         camera.position.set(1500, 1800, 1500);
         orbitControls.update();
     }
+}
+
+// FPS modunda mıyız kontrol fonksiyonu
+export function isFPSMode() {
+    return cameraMode === 'firstPerson';
 }
 
 // İlk kurulum


### PR DESCRIPTION
FPS modundayken W/A/S/D tuşları mod değiştirmek yerine hareket için kullanılacak.

Değişiklikler:
- scene3d.js: A ve D tuşları FPS kontrollerine eklendi (KeyA, KeyD)
- scene3d.js: isFPSMode() fonksiyonu export edildi
- input.js: isFPSMode import edildi
- input.js: FPS modundayken W/A/S/D kısayolları engelleniyor

FPS Kontrolleri:
- W: İleri
- S: Geri
- A: Sola
- D: Sağa
- Fare: Etrafına bak
- ESC: Pointer lock'u kapat