### PR TITLE
FPS modda controls3d.update hatası düzeltildi

### DIFF
--- a/main.js
+++ b/main.js
@@ -291,7 +291,10 @@ function animate() {
         // First-person kamera güncellemesi
         updateFirstPersonCamera(delta);
 
-        controls3d.update();
+        // PointerLockControls'un update() metodu yok, sadece OrbitControls'da var
+        if (controls3d && controls3d.update) {
+            controls3d.update();
+        }
         renderer3d.render(scene3d, camera3d);
     }
 }


### PR DESCRIPTION
PointerLockControls'un update() metodu olmadığı için hata veriyordu. Artık sadece update() metodu varsa çağrılıyor.

Hata:
- controls3d.update is not a function

Çözüm:
- controls3d.update() çağrısından önce kontrol eklendi
- if (controls3d && controls3d.update) kontrolü eklendi