### PR TITLE
FPS kamera pozisyonu ve yönü 2D'den sürüklenebilir yapıldı

### DIFF
--- a/draw2d.js
+++ b/draw2d.js
@@ -81,6 +81,26 @@ function drawCameraViewIndicator(ctx2d, zoom) {
     ctx2d.stroke();
     ctx2d.setLineDash([]);
 
+    // Yön handle'ı (aydınlatma sembolü - ampul) - sürüklenebilir
+    const handleX = camX + dirX * viewLineLength;
+    const handleZ = camZ + dirZ * viewLineLength;
+    const handleRadius = 12; // Ampul çapı
+
+    // Ampul dış çemberi
+    ctx2d.beginPath();
+    ctx2d.arc(handleX, handleZ, handleRadius, 0, Math.PI * 2);
+    ctx2d.fillStyle = '#FFD700'; // Altın sarısı
+    ctx2d.fill();
+    ctx2d.strokeStyle = '#FF8C00'; // Koyu turuncu
+    ctx2d.lineWidth = 2 / zoom;
+    ctx2d.stroke();
+
+    // Ampul içi ışık efekti
+    ctx2d.beginPath();
+    ctx2d.arc(handleX, handleZ, handleRadius * 0.6, 0, Math.PI * 2);
+    ctx2d.fillStyle = '#FFF8DC'; // Açık sarı (ışık)
+    ctx2d.fill();
+
     // Görüş alanı (FOV) üçgeni
     const leftAngle = yaw - fovAngle / 2;
     const rightAngle = yaw + fovAngle / 2;
@@ -95,7 +115,7 @@ function drawCameraViewIndicator(ctx2d, zoom) {
     ctx2d.lineTo(camX + leftX, camZ + leftZ);
     ctx2d.lineTo(camX + rightX, camZ + rightZ);
     ctx2d.closePath();
-    ctx2d.fillStyle = 'rgba(255, 165, 0, 0.1)'; // Çok hafif turuncu
+    ctx2d.fillStyle = 'rgba(255, 215, 0, 0.15)'; // Hafif altın sarısı
     ctx2d.fill();
     ctx2d.strokeStyle = 'rgba(255, 165, 0, 0.5)'; // Yarı saydam turuncu
     ctx2d.lineWidth = 2 / zoom;

--- a/pointer-down.js
+++ b/pointer-down.js
@@ -87,6 +87,27 @@ export function onPointerDown(e) {
                  // Sürükleme için başlangıç bilgilerini nesne tipine göre al
                  let dragInfo = { startPointForDragging: pos, dragOffset: { x: 0, y: 0 }, additionalState: {} };
                  switch (clickedObject.type) {
+                     case 'camera':
+                         // Kamera pozisyon veya yön sürükleme
+                         const camInfo = clickedObject.object;
+                         if (clickedObject.handle === 'position') {
+                             dragInfo = {
+                                 startPointForDragging: { x: camInfo.position.x, y: camInfo.position.z },
+                                 dragOffset: { x: camInfo.position.x - pos.x, y: camInfo.position.z - pos.y },
+                                 additionalState: { cameraHandle: 'position' }
+                             };
+                         } else if (clickedObject.handle === 'direction') {
+                             dragInfo = {
+                                 startPointForDragging: pos,
+                                 dragOffset: { x: 0, y: 0 },
+                                 additionalState: {
+                                     cameraHandle: 'direction',
+                                     initialYaw: camInfo.yaw,
+                                     cameraCenter: { x: camInfo.position.x, y: camInfo.position.z }
+                                 }
+                             };
+                         }
+                         break;
                      case 'arcControl':
                          // Arc kontrol noktası sürükleme
                          dragInfo = {

--- a/pointer-move.js
+++ b/pointer-move.js
@@ -2,7 +2,7 @@ import { state, dom, setState } from './main.js';
 import { getSmartSnapPoint } from './snap.js';
 import { screenToWorld, distToSegmentSquared, findNodeAt } from './geometry.js';
 import { positionLengthInput } from './ui.js';
-import { update3DScene } from './scene3d.js';
+import { update3DScene, setCameraPosition, setCameraRotation } from './scene3d.js';
 import { processWalls } from './wall-processor.js';
 import { currentModifierKeys } from './input.js';
 import { onPointerMove as onPointerMoveColumn, getColumnAtPoint, isPointInColumn } from './columns.js';
@@ -187,6 +187,21 @@ export function onPointerMove(e) {
     if (state.isDragging && state.selectedObject) {
         // Nesne tipine göre ilgili onPointerMove fonksiyonunu çağır
         switch (state.selectedObject.type) {
+            case 'camera':
+                // Kamera pozisyon veya yön sürükleme
+                if (state.cameraHandle === 'position') {
+                    // Kamera pozisyonunu sürükle (XZ düzleminde)
+                    const newX = unsnappedPos.x + state.dragOffset.x;
+                    const newZ = unsnappedPos.y + state.dragOffset.y;
+                    setCameraPosition(newX, newZ);
+                } else if (state.cameraHandle === 'direction') {
+                    // Kamera yönünü döndür
+                    const dx = unsnappedPos.x - state.cameraCenter.x;
+                    const dz = unsnappedPos.y - state.cameraCenter.y;
+                    const newYaw = Math.atan2(dx, dz);
+                    setCameraRotation(newYaw);
+                }
+                break;
             case 'arcControl':
                 // Arc kontrol noktası sürükleme
                 const wall = state.selectedObject.object;

--- a/scene3d.js
+++ b/scene3d.js
@@ -1997,5 +1997,33 @@ export function getCameraViewInfo() {
     };
 }
 
+// Kamera pozisyonunu ayarla (2D'den sürüklendiğinde)
+export function setCameraPosition(x, z) {
+    if (!camera || cameraMode !== 'firstPerson') return;
+
+    camera.position.x = x;
+    camera.position.z = z;
+
+    // Yükseklik kontrolü (manuel mod değilse otomatik ayarla)
+    if (!manualHeightMode) {
+        const elevation = checkStairElevation(camera.position);
+        camera.position.y = CAMERA_HEIGHT + elevation;
+    }
+}
+
+// Kamera rotasyonunu ayarla (2D'den sürüklendiğinde)
+export function setCameraRotation(yaw) {
+    if (!camera || cameraMode !== 'firstPerson') return;
+
+    // Mevcut pitch (x rotasyonu) koru
+    const euler = new THREE.Euler(0, 0, 0, 'YXZ');
+    euler.setFromQuaternion(camera.quaternion);
+
+    // Sadece yaw'u (y rotasyonu) değiştir
+    euler.y = yaw;
+
+    camera.quaternion.setFromEuler(euler);
+}
+
 // İlk kurulum
 setupFirstPersonKeyControls();


### PR DESCRIPTION
- 2D sahnede kamera göz sembolü sürüklenebilir (pozisyon ayarlama)
- Ampul sembolü ile kamera yönü sürüklenebilir (rotation ayarlama)
- Kamera ucunda altın sarısı aydınlatma sembolü eklendi
- Mouse ile kamerayı istediğiniz yere yerleştirebilirsiniz
- Ampul sembolünü çevirerek bakış yönünü ayarlayabilirsiniz
- setCameraPosition ve setCameraRotation fonksiyonları eklendi
- FPS modunda kamera kontrolü tam interaktif hale geldi