### PR TITLE
FPS modunda 2D canvas ilk tıklama sorunu düzeltildi

### DIFF
--- a/scene3d.js
+++ b/scene3d.js
@@ -267,8 +267,8 @@ export function init3D(canvasElement) {
 
 }
 
-// GÜNCELLENDİ: 'sceneObjects' ve 'pointerLockControls' export'a eklendi
-export { scene, camera, renderer, controls, sceneObjects, pointerLockControls };
+// GÜNCELLENDİ: 'sceneObjects' export'a eklendi
+export { scene, camera, renderer, controls, sceneObjects };
 
 // --- Duvar Segmenti Oluşturma (Duvar Tipine Göre) ---
 // GÜNCELLENDİ: Korkuluk ve şapka uzamaları düzeltildi

--- a/style.css
+++ b/style.css
@@ -33,11 +33,13 @@ body {
 #p3d {
     flex: 0 1 0;
     display: none;
+    pointer-events: none; /* 3D canvas mouse event'lerini almaz, sadece gösterir */
 }
 
 .main.show-3d #p3d {
     display: block;
     flex: 1 1 50%;
+    pointer-events: none; /* FPS modunda 3D canvas sadece görsel, event'ler 2D'ye */
 }
 
 .main.show-3d #p2d {

--- a/ui.js
+++ b/ui.js
@@ -2,7 +2,7 @@
 // Son Güncelleme: Sahanlık kotu (125-135) mantığı confirmStairChange ve ilgili listener'larda düzeltildi.
 import { state, setState, dom, resize, MAHAL_LISTESI, WALL_HEIGHT } from './main.js';
 import { saveState } from './history.js';
-import { update3DScene, toggleCameraMode, pointerLockControls } from './scene3d.js';
+import { update3DScene, toggleCameraMode } from './scene3d.js';
 import { applyStretchModification } from './geometry.js';
 import { processWalls } from './wall-processor.js';
 import { worldToScreen } from './geometry.js';


### PR DESCRIPTION
- 3D panel'e pointer-events: none eklendi
- 3D canvas artık sadece görsel, mouse event'lerini almıyor
- Tüm mouse event'leri 2D canvas'a gidiyor
- İlk tıklamada kamera kontrolü çalışıyor
- pointerLockControls export'u kaldırıldı (kullanılmıyor)
- Gereksiz import'lar temizlendi