### PR TITLE
3D Göster moduna klavye kontrollerini entegre et - FPS modunu kaldır

### DIFF
--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -136,12 +136,9 @@ export function toggle3DView() {
     dom.mainContainer.classList.toggle('show-3d');
     dom.b3d.classList.toggle('active');
 
-    // FPS kamera butonunu göster/gizle
+    // FPS kamera butonu kaldırıldı - artık tek mod var: 3D Göster
     if (dom.mainContainer.classList.contains('show-3d')) {
-        dom.bFirstPerson.style.display = 'inline-block';
-        setMode("select"); // <-- EKLENDİ: 3D açılırken modu "select" yap
-    } else {
-        dom.bFirstPerson.style.display = 'none';
+        setMode("select"); // 3D açılırken modu "select" yap
     }
 
     setTimeout(() => {
@@ -643,16 +640,8 @@ export function setupUIListeners() {
     });
     // MERDİVEN POPUP LISTENER'LARI SONU
 
-    // FPS KAMERA BUTONU LISTENER'I
-    dom.bFirstPerson.addEventListener('click', () => {
-        // Butonu toggle et
-        dom.bFirstPerson.classList.toggle('active');
-
-        // Kamera modunu değiştir
-        toggleCameraMode();
-
-        // NOT: Pointer lock kullanmıyoruz - klavye kontrolleri yeterli
-        // Mouse serbest kalıyor, kullanıcı FPS modunda bile mouse ile UI'ya erişebilir
-    });
+    // FPS KAMERA BUTONU KALDIRILDI
+    // Artık tek mod var: 3D Göster (hem mouse hem klavye kontrolleri içerir)
+    // dom.bFirstPerson.addEventListener('click', () => { ... });
 }
 // --- setupUIListeners Sonu ---

--- a/scene3d/scene3d-core.js
+++ b/scene3d/scene3d-core.js
@@ -5,7 +5,6 @@ import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { PointerLockControls } from "three/addons/controls/PointerLockControls.js";
 import { state, WALL_HEIGHT, dom } from "../general-files/main.js";
-import { setupMouseControls } from "./scene3d-camera.js";
 
 // --- Global Değişkenler ---
 export let scene, camera, renderer, controls; // 'controls' MEVCUT aktif kontrol olacak
@@ -177,9 +176,6 @@ export function init3D(canvasElement) {
         opacity: solidOpacity, // solidOpacity'yi init3D içinden alır
         side: THREE.DoubleSide
     });
-
-    // Mouse kontrollerini başlat (FPS modu için)
-    setupMouseControls(canvasElement);
 }
 
 /**


### PR DESCRIPTION
Bu commit, FPS modu ve 3D Göster modunu tek bir modda birleştirir. Artık sadece "3D Göster" modu vardır ve bu modda hem mouse (OrbitControls) hem de klavye kontrolleri çalışır.

Değişiklikler:

1. FPS Mouse Kontrollerini Kaldırma:
   - setupMouseControls fonksiyonu tamamen kaldırıldı
   - FPS'e özgü mouse kontrolleri (pan, rotate in place) kaldırıldı
   - Normal OrbitControls (mouse ile orbit, zoom vs) korundu

2. Klavye Kontrollerini 3D Göster Moduna Entegre Etme:
   - Klavye kontrolleri artık cameraMode kontrolü olmadan çalışır
   - setupFirstPersonKeyControls her zaman aktif
   - updateFirstPersonCamera her zaman çalışır (mod kontrolü yok)
   - Hareket (WASD, oklar), rotasyon ve diğer tüm klavye özellikleri 3D Göster modunda da çalışır

3. Kamera İkonu:
   - getCameraViewInfo her zaman isFPS: true döner
   - Kamera ikonu 3D Göster modunda da görünür (klavye kullanımında)
   - setCameraPosition ve setCameraRotation mod kontrolü olmadan çalışır

4. FPS Modu UI'ını Kaldırma:
   - "FPS Kamera" butonu listener'ı kaldırıldı
   - toggle3DView fonksiyonundan FPS butonu gösterme/gizleme mantığı kaldırıldı
   - Buton zaten display: none durumda (HTML'de)

Sonuç:
- Tek mod: "3D Göster"
- Bu modda hem OrbitControls (mouse) hem de klavye kontrolleri çalışır
- Kamera ikonu klavye kullanımında görünür
- Kapı toleransı 50cm, Z yüksekliği, lamba üçgeni ve geri gidiş özellikleri korundu

Dosya Değişiklikleri:
- scene3d/scene3d-camera.js: FPS mouse kontrolleri kaldırıldı, mod kontrolleri kaldırıldı
- scene3d/scene3d-core.js: setupMouseControls import ve çağrısı kaldırıldı
- ui.js: FPS butonu gösterme/gizleme ve listener kaldırıldı