### PR TITLE
3D kamera kontrolleri - Kullanıcı geri bildirimlerine göre düzeltmeler

### DIFF
--- a/scene3d/scene3d-update.js
+++ b/scene3d/scene3d-update.js
@@ -9,8 +9,7 @@ import {
     stairMaterial, stairMaterialTop, ventMaterial, trimMaterial,
     balconyRailingMaterial, glassMaterial, halfWallCapMaterial,
     handrailWoodMaterial, balusterMaterial, stepNosingMaterial,
-    textureLoader, pictureFrameMaterial, // İsim hatası da düzeltildi
-    updateDrawingCenter // Çizim merkezi güncellemesi için
+    textureLoader, pictureFrameMaterial // İsim hatası da düzeltildi
     } from "./scene3d-core.js";
 
 // Mesh oluşturma fonksiyonlarını import et
@@ -490,7 +489,4 @@ function buildPictureFrames(sceneObjects) {
             }
         }
     }
-
-    // Çizim merkezi hesapla ve OrbitControls target'ını güncelle
-    updateDrawingCenter();
 }


### PR DESCRIPTION
TEMEL DEĞİŞİKLİKLER:
- Çizim merkezine otomatik odaklanma KALDIRILDI (OrbitControls target sabit)
- Tüm klavye kontrolleri yeniden düzenlendi
- Mouse kullanımında kamera ikonu gizlenir

KLAVYE KONTROLLERİ (YENİDEN YAZILDI):
✓ OKLAR: Kamera yönünde dümdüz hareket (ileri/geri/sola/sağa)
  - Geri ok basılıyken SADECE sağ/sol tuşları tersine döner ✓ CTRL + OKLAR: Kamera pozisyonu SABİT, sadece bakış açısı döner
  - Yukarı/aşağı: Pitch (yukarı/aşağı bakış)
  - Sağ/sol: Yaw (sağa/sola bakış) ✓ SHIFT + SAĞ/SOL: Çizim merkezi etrafında yatay orbit ✓ SHIFT + YUKARI/AŞAĞI: Dümdüz yukarı/aşağı hareket
  - manualHeightMode aktif olur, 180cm seviyesine otomatik dönmez ✓ CTRL + SHIFT + OKLAR: 2x hızlı hareket

MOUSE KONTROLLERİ:
- Sol tık/orta tekerlek/tekerlek çevirme: OrbitControls (değişiklik yok)
- Sağ tık: Custom rotasyon (kamera sabit, proje döner)
- Mouse kullanımı kamera ikonunu gizler (klavye gösterir)

TEKNİK DETAYLAR:
- updateDrawingCenter() -> getDrawingCenter() (sadece hesaplama)
- OrbitControls target artık otomatik değiştirilmiyor
- setupMouseIconHiding() fonksiyonu eklendi
- hideCameraIcon() export fonksiyonu eklendi