### PR TITLE
Fix XML import to support CloseArea structure

### DIFF
--- a/general-files/xml-io.js
+++ b/general-files/xml-io.js
@@ -91,7 +91,7 @@ export function importFromXML(xmlString) {
 
     // 1. Duvarları (VdWall) oluştur ve nodeları kaydet
     // Yeni yapı: CloseArea içindeki Walls dizisini kontrol et
-    const closeAreas = entities.querySelectorAll("O[T='CloseArea']");
+    const closeAreas = entities.querySelectorAll("O[F='_Item'][T='CloseArea']");
     console.log(`${closeAreas.length} CloseArea bulundu`);
 
     closeAreas.forEach((closeArea, idx) => {


### PR DESCRIPTION
The CloseArea elements in the XML have the attribute F='_Item', not just T='CloseArea'. Updated the selector from:
  O[T='CloseArea']
to:
  O[F='_Item'][T='CloseArea']

This should now correctly find and parse CloseArea elements containing walls.