### PR TITLE
Import turf.js for room polygon calculations

### DIFF
--- a/general-files/xml-io.js
+++ b/general-files/xml-io.js
@@ -12,6 +12,7 @@ import { processWalls } from '../wall/wall-processor.js';
 import { saveState } from './history.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
 import { fitDrawingToScreen } from '../draw/zoom.js';
+import * as turf from '../libs/turf.js';
 
 // XML'deki koordinatları cm'ye çevirmek için ölçek
 const SCALE = 100;


### PR DESCRIPTION
- Added missing turf.js import to xml-io.js
- Required for calculating room.polygon, room.center, and room.area
- Fixes missing room names on canvas after XML import