### PR TITLE
Remove incorrect turf.js import - use global instead

### DIFF
--- a/general-files/xml-io.js
+++ b/general-files/xml-io.js
@@ -12,7 +12,8 @@ import { processWalls } from '../wall/wall-processor.js';
 import { saveState } from './history.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
 import { fitDrawingToScreen } from '../draw/zoom.js';
-import * as turf from '../libs/turf.js';
+
+// turf.js global olarak index.html'den yükleniyor (CDN)
 
 // XML'deki koordinatları cm'ye çevirmek için ölçek
 const SCALE = 100;


### PR DESCRIPTION
- turf.js is loaded globally via CDN in index.html
- Other files (symmetry.js, main.js, etc.) use turf as global variable
- No need to import, just use window.turf directly
- Added comment explaining turf is loaded from CDN