### PR TITLE
Fix: Use planar area calculation for XML imports instead of geographic

### DIFF
--- a/draw/geometry.js
+++ b/draw/geometry.js
@@ -147,7 +147,7 @@ export function getOrCreateNode(x, y) {
 }
 
 // Bir poligonun (koordinat dizisi) alanını hesaplar
-function calculatePlanarArea(coords) {
+export function calculatePlanarArea(coords) {
     let area = 0;
     const points = coords[0]; // Dış halka koordinatları
     if (!points || points.length < 3) return 0; // Geçersiz poligon

--- a/general-files/xml-io.js
+++ b/general-files/xml-io.js
@@ -3,7 +3,7 @@
 // GÜNCELLENDİ: Merdiven rotasyonu 90° CCW (-90) olarak ayarlandı ve boyutları (en/boy) buna göre düzeltildi.
 
 import { state, setState, dom, VECTORDRAW_AREA_TYPES } from './main.js';
-import { getOrCreateNode, distToSegmentSquared } from '../draw/geometry.js';
+import { getOrCreateNode, distToSegmentSquared, calculatePlanarArea } from '../draw/geometry.js';
 import { wallExists } from '../wall/wall-handler.js';
 import { createColumn } from '../architectural-objects/columns.js';
 import { createBeam } from '../architectural-objects/beams.js';
@@ -614,8 +614,8 @@ export function importFromXML(xmlString) {
                     const centerPoint = turf.center(room.polygon);
                     room.center = centerPoint.geometry.coordinates;
 
-                    // Alan hesapla (m²)
-                    room.area = turf.area(room.polygon) / 10000; // cm² to m²
+                    // Alan hesapla (m²) - Planar area calculation (Shoelace formula)
+                    room.area = calculatePlanarArea(room.polygon.geometry.coordinates) / 10000; // cm² to m²
 
                     console.log(`  Room ${idx} (${room.name}): center=[${room.center[0].toFixed(2)}, ${room.center[1].toFixed(2)}], area=${room.area.toFixed(2)} m²`);
                 } catch (e) {


### PR DESCRIPTION
Problem: XML imports showed absurdly large room areas (e.g., 40978641512545.145 m²) because turf.area() uses geographic (lat/lon) calculations on planar cm coordinates.

Solution:
- Export calculatePlanarArea() from geometry.js
- Use calculatePlanarArea() (Shoelace formula) instead of turf.area() in XML import
- This matches the calculation method used during wall modifications

This ensures consistent and correct area calculations for planar 2D coordinates.