### PR TITLE
Fix: Beam selection and rotation, stair direction from XML imports

### DIFF
--- a/architectural-objects/beams.js
+++ b/architectural-objects/beams.js
@@ -102,7 +102,7 @@ export function getBeamAtPoint(point) {
 export function isPointInBeam(point, beam) {
     const cx = beam.center.x;
     const cy = beam.center.y;
-    const rot = -(beam.rotation || 0) * Math.PI / 180;
+    const rot = (beam.rotation || 0) * Math.PI / 180;
     const dx = point.x - cx;
     const dy = point.y - cy;
     const localX = dx * Math.cos(rot) - dy * Math.sin(rot);


### PR DESCRIPTION
Problems fixed:
1. Beams could not be selected after XML import
   - Fixed rotation sign inconsistency in isPointInBeam()
   - Rotation now matches getBeamCorners() calculation

2. Beams were rotated 90° incorrectly
   - Applied rotation negation when Y-axis is flipped
   - Mirrors rotation to account for coordinate transformation

3. All stairs showed as "up" direction regardless of actual direction
   - Parse original XML Height sign to determine direction
   - Swap elevations when Height is negative (down stairs)

Changes:
- beams.js:105: Removed negative sign from rotation calculation
- xml-io.js:498: Store original Height value before transformation
- xml-io.js:529-534: Detect and apply stair direction from XML
- xml-io.js:574: Negate beam rotation for Y-axis flip compensation