### PR TITLE
Improve arc wall control point handling

### DIFF
--- a/pointer/pointer-up.js
+++ b/pointer/pointer-up.js
@@ -194,7 +194,7 @@ export function onPointerUp(e) {
         preDragWallStates: new Map(),
         preDragNodeStates: new Map(),
         dragWallInitialVector: null,
-        selectedObject: didClick ? state.selectedObject : null, // Kamera da dahil tüm seçimler temizlenir
+        selectedObject: (didClick || state.selectedObject?.type === "arcControl") ? state.selectedObject : null, // arcControl sürüklemesi sonrası seçimi koru
         dragOriginalNodes: null,
         isSweeping: false,
         sweepWalls: [],

--- a/wall/wall-panel.js
+++ b/wall/wall-panel.js
@@ -105,20 +105,50 @@ function setupWallPanelListeners() {
     arcWallCheckbox.addEventListener('change', (e) => {
         if (wallPanelWall) {
             wallPanelWall.isArc = e.target.checked;
-            // İlk kez arc aktif edildiğinde kontrol noktalarını oluştur
-            if (wallPanelWall.isArc && !wallPanelWall.arcControl1) {
-                const dx = wallPanelWall.p2.x - wallPanelWall.p1.x;
-                const dy = wallPanelWall.p2.y - wallPanelWall.p1.y;
-                const wallLength = Math.hypot(dx, dy);
-                // Duvarın normalini bul (duvara dik)
-                const nx = -dy / wallLength;
-                const ny = dx / wallLength;
-                // Kontrol noktalarını duvarın uçlarından duvara dik olarak ve duvar uzunluğunun yarısı kadar yerleştir
-                // İkisi de birbirine paralel (aynı normal yönünde)
-                const offset = wallLength / 2;
-                wallPanelWall.arcControl1 = { x: wallPanelWall.p1.x + nx * offset, y: wallPanelWall.p1.y + ny * offset };
-                wallPanelWall.arcControl2 = { x: wallPanelWall.p2.x + nx * offset, y: wallPanelWall.p2.y + ny * offset };
+
+            if (wallPanelWall.isArc) {
+                if (!wallPanelWall.arcControl1) {
+                    // İlk kez arc aktif edildiğinde kontrol noktalarını oluştur
+                    const dx = wallPanelWall.p2.x - wallPanelWall.p1.x;
+                    const dy = wallPanelWall.p2.y - wallPanelWall.p1.y;
+                    const wallLength = Math.hypot(dx, dy);
+                    // Duvarın normalini bul (duvara dik)
+                    const nx = -dy / wallLength;
+                    const ny = dx / wallLength;
+                    // Kontrol noktalarını duvarın uçlarından duvara dik olarak ve duvar uzunluğunun yarısı kadar yerleştir
+                    const offset = wallLength / 2;
+                    wallPanelWall.arcControl1 = { x: wallPanelWall.p1.x + nx * offset, y: wallPanelWall.p1.y + ny * offset };
+                    wallPanelWall.arcControl2 = { x: wallPanelWall.p2.x + nx * offset, y: wallPanelWall.p2.y + ny * offset };
+                } else {
+                    // Kontrol noktaları zaten var, duvar üzerinden 180° ters çevir
+                    const p1 = wallPanelWall.p1;
+                    const p2 = wallPanelWall.p2;
+                    const dx = p2.x - p1.x;
+                    const dy = p2.y - p1.y;
+                    const lenSq = dx * dx + dy * dy;
+
+                    if (lenSq > 1e-6) {
+                        // arcControl1'i flip et
+                        const t1 = ((wallPanelWall.arcControl1.x - p1.x) * dx + (wallPanelWall.arcControl1.y - p1.y) * dy) / lenSq;
+                        const proj1X = p1.x + t1 * dx;
+                        const proj1Y = p1.y + t1 * dy;
+                        wallPanelWall.arcControl1 = {
+                            x: 2 * proj1X - wallPanelWall.arcControl1.x,
+                            y: 2 * proj1Y - wallPanelWall.arcControl1.y
+                        };
+
+                        // arcControl2'yi flip et
+                        const t2 = ((wallPanelWall.arcControl2.x - p1.x) * dx + (wallPanelWall.arcControl2.y - p1.y) * dy) / lenSq;
+                        const proj2X = p1.x + t2 * dx;
+                        const proj2Y = p1.y + t2 * dy;
+                        wallPanelWall.arcControl2 = {
+                            x: 2 * proj2X - wallPanelWall.arcControl2.x,
+                            y: 2 * proj2Y - wallPanelWall.arcControl2.y
+                        };
+                    }
+                }
             }
+
             saveState();
             if (dom.mainContainer.classList.contains('show-3d')) { setTimeout(update3DScene, 0); }
         }


### PR DESCRIPTION
Two improvements to arc wall (yay duvar) bezier control points:

1. Flip control points 180° when toggling arc checkbox
   - When an arc wall is selected and arc checkbox is toggled on, if control points already exist, they are now flipped to the opposite side of the wall (180° rotation)
   - This is done by reflecting control points across the wall line
   - Provides better control over arc direction

2. Preserve selection after dragging arc control points
   - Previously, dragging arcControl1 or arcControl2 would deselect the wall after drag ended
   - Now selection is preserved when arcControl is dragged
   - User can continue adjusting without reselecting

Files changed:
- wall/wall-panel.js: Added 180° flip logic in arc checkbox handler
- pointer/pointer-up.js: Preserve selectedObject when type is arcControl