### PR TITLE
Fix popup focus issues and add keyboard filter for room selection

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -294,6 +294,20 @@ function onKeyDown(e) {
         return;
     }
 
+    // Mahal (room) seçiliyken harf girişi ile filtreleme
+    if (state.selectedObject && state.selectedObject.type === "room" && /^[a-zA-ZçğıöşüÇĞİÖŞÜ]$/.test(e.key)) {
+        e.preventDefault();
+        const room = state.selectedObject.object;
+        // Get room center position for popup
+        const centerX = room.center ? room.center.x : 0;
+        const centerY = room.center ? room.center.y : 0;
+        const screenPos = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+        // Create a synthetic event with screen position
+        const syntheticEvent = { clientX: screenPos.x, clientY: screenPos.y };
+        showRoomNamePopup(room, syntheticEvent, e.key);
+        return;
+    }
+
     // Kopyala / Yapıştır (Input dışındayken)
     if (e.ctrlKey && e.key.toLowerCase() === 'c') { handleCopy(e); return; }
     if (e.ctrlKey && e.key.toLowerCase() === 'v') { handlePaste(e); return; }

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -76,10 +76,10 @@ function filterRoomNameList() {
     populateRoomNameList(dom.roomNameInput.value);
 }
 
-export function showRoomNamePopup(room, e) {
+export function showRoomNamePopup(room, e, initialKey = '') {
     setState({ roomToEdit: room });
-    dom.roomNameInput.value = ''; // Input'u temizle
-    populateRoomNameList(); // Listeyi doldur
+    dom.roomNameInput.value = initialKey; // Initial key veya boş
+    populateRoomNameList(initialKey); // Listeyi doldur (varsa filtre ile)
 
     // Popup'ı konumlandır
     const popupWidth = dom.roomNamePopup.offsetWidth || 200; // Genişliği al veya varsay
@@ -100,7 +100,11 @@ export function showRoomNamePopup(room, e) {
     dom.roomNamePopup.style.left = `${left}px`;
     dom.roomNamePopup.style.top = `${top}px`;
     dom.roomNamePopup.style.display = 'block';
-    dom.roomNameInput.focus(); // Input alanına odaklan
+
+    // Use setTimeout to ensure focus works correctly
+    setTimeout(() => {
+        dom.roomNameInput.focus();
+    }, 0);
 
     // Dışarı tıklama dinleyicisini ayarla
     const clickListener = (event) => {
@@ -234,8 +238,13 @@ export function startLengthEdit(initialKey = '') {
     if (state.selectedObject.type === "wall") { const wall = selectedObject.object; const currentLength = Math.hypot(wall.p2.x - wall.p1.x, wall.p2.y - wall.p1.y); currentValue = currentLength.toFixed(0); }
     else { currentValue = state.selectedObject.object.width.toFixed(0); }
     dom.lengthInput.value = initialKey || currentValue;
-    dom.lengthInput.focus();
-    if (!initialKey) { setTimeout(() => dom.lengthInput.select(), 0); }
+    // Use setTimeout to ensure the input is fully rendered before focusing
+    setTimeout(() => {
+        dom.lengthInput.focus();
+        if (!initialKey) {
+            dom.lengthInput.select();
+        }
+    }, 0);
 }
 
 // Uzunluk düzenlemeyi onaylama


### PR DESCRIPTION
- Fix wall length input popup focus by using setTimeout to ensure proper rendering before focus
- Add keyboard-triggered room name filter: typing while a room is selected opens the filter popup
- Room filter supports Turkish characters (çğıöşüÇĞİÖŞÜ) and filters with contains search
- Top filtered result is automatically selected, confirmed with Enter key
- Keyboard shortcuts are disabled when room filter input is active