### PR TITLE
Fix room keyboard filter by using correct state variable

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -295,9 +295,9 @@ function onKeyDown(e) {
     }
 
     // Mahal (room) seçiliyken harf girişi ile filtreleme
-    if (state.selectedObject && state.selectedObject.type === "room" && /^[a-zA-ZçğıöşüÇĞİÖŞÜ]$/.test(e.key)) {
+    if (state.selectedRoom && /^[a-zA-ZçğıöşüÇĞİÖŞÜ]$/.test(e.key)) {
         e.preventDefault();
-        const room = state.selectedObject.object;
+        const room = state.selectedRoom;
         // Get room center position and convert to screen coordinates
         const centerX = room.center ? room.center.x : 0;
         const centerY = room.center ? room.center.y : 0;


### PR DESCRIPTION
- Use state.selectedRoom instead of state.selectedObject.type === "room"
- When a room is clicked, selectedRoom is set but selectedObject is null
- This fix ensures keyboard shortcuts (M, W, R, etc) are blocked when room is selected
- Now typing a letter when room is selected will open the filter popup instead of changing mode