### PR TITLE
Fix room popup position by using correct array format for center coor…

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -298,9 +298,9 @@ function onKeyDown(e) {
     if (state.selectedRoom && /^[a-zA-ZçğıöşüÇĞİÖŞÜ]$/.test(e.key)) {
         e.preventDefault();
         const room = state.selectedRoom;
-        // Get room center position and convert to screen coordinates
-        const centerX = room.center ? room.center.x : 0;
-        const centerY = room.center ? room.center.y : 0;
+        // Get room center position (stored as array [x, y]) and convert to screen coordinates
+        const centerX = room.center ? room.center[0] : 0;
+        const centerY = room.center ? room.center[1] : 0;
         const screenPos = worldToScreen(centerX, centerY);
         // Create a synthetic event with screen position
         const syntheticEvent = { clientX: screenPos.x, clientY: screenPos.y };


### PR DESCRIPTION
…dinates

- room.center is stored as array [x, y], not object {x, y}
- Change room.center.x to room.center[0] and room.center.y to room.center[1]
- This fixes the popup opening at top-left corner (0,0) instead of room center
- Now popup opens near the selected room as expected