### PR TITLE
Add multi-select with CTRL and arrow key movement (1cm increments)

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -296,25 +296,26 @@ export function draw2D() {
 
     // 4. KOLONLAR (Duvarlardan sonra, kapı/pencereden önce)
     state.columns.forEach(column => {
-        // Her kolon için isSelected durumunu kontrol et
-        const isSelected = selectedObject?.type === "column" && selectedObject.object === column;
+        // Her kolon için isSelected durumunu kontrol et (tek seçim veya grup seçimi)
+        const isSelected = (selectedObject?.type === "column" && selectedObject.object === column) ||
+                          state.selectedGroup.some(item => item.type === "column" && item.object === column);
         drawColumn(column, isSelected);
     });
 
     // 4.5. KİRİŞLER
     (state.beams || []).forEach(beam => {
-        // Her kiriş için isSelected durumunu kontrol et
-        const isSelected = selectedObject?.type === "beam" && selectedObject.object === beam;
+        // Her kiriş için isSelected durumunu kontrol et (tek seçim veya grup seçimi)
+        const isSelected = (selectedObject?.type === "beam" && selectedObject.object === beam) ||
+                          state.selectedGroup.some(item => item.type === "beam" && item.object === beam);
         drawBeam(beam, isSelected);
     });
 
     // 4.7. MERDİVENLER
     (state.stairs || []).forEach(stair => {
-        // Her bir merdiven için seçili olup olmadığını kontrol et
+        // Her bir merdiven için seçili olup olmadığını kontrol et (tek seçim veya grup seçimi)
         const isSelected = !!(
-            selectedObject &&
-            selectedObject.type === "stairs" &&
-            selectedObject.object === stair
+            (selectedObject && selectedObject.type === "stairs" && selectedObject.object === stair) ||
+            state.selectedGroup.some(item => item.type === "stairs" && item.object === stair)
         );
         drawStairs(stair, isSelected);
     });

--- a/general-files/input.js
+++ b/general-files/input.js
@@ -359,14 +359,67 @@ function onKeyDown(e) {
             setState({ selectedObject: null, selectedGroup: [] });
             // --- GÜNCELLEME: processWalls() sadece rehber silindiyse çağrılmaz ---
             if (state.selectedObject?.type !== 'guide') {
-                processWalls(); 
+                processWalls();
             }
-            saveState(); 
+            saveState();
             // update3DScene() processWalls içinden çağrılır,
             // ama rehber silindiyse (ve 3D açıksa) update'e gerek yok.
             // (Rehberler 3D'de çizilmiyor)
             // update3DScene(); // processWalls() zaten çağırıyor
         }
+    }
+
+    // Ok tuşları ile seçili nesneleri hareket ettirme (1cm artışlarla)
+    if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+        // Tek nesne veya grup seçimi kontrolü
+        const hasSelection = state.selectedGroup.length > 0 ||
+                           (state.selectedObject && ['column', 'beam', 'stairs'].includes(state.selectedObject.type));
+
+        if (!hasSelection) return; // Hiç seçili nesne yoksa çık
+
+        e.preventDefault();
+
+        const MOVE_STEP = 1; // 1 cm hareket miktarı
+        let deltaX = 0, deltaY = 0;
+
+        // Hareket yönünü belirle
+        if (e.key === 'ArrowUp') deltaY = -MOVE_STEP;
+        else if (e.key === 'ArrowDown') deltaY = MOVE_STEP;
+        else if (e.key === 'ArrowLeft') deltaX = -MOVE_STEP;
+        else if (e.key === 'ArrowRight') deltaX = MOVE_STEP;
+
+        // Grup seçimi varsa, tüm grup nesnelerini hareket ettir
+        if (state.selectedGroup.length > 0) {
+            state.selectedGroup.forEach(selectedItem => {
+                const obj = selectedItem.object;
+
+                if (selectedItem.type === 'column' && obj.center) {
+                    obj.center.x += deltaX;
+                    obj.center.y += deltaY;
+                } else if (selectedItem.type === 'beam' && obj.center) {
+                    obj.center.x += deltaX;
+                    obj.center.y += deltaY;
+                } else if (selectedItem.type === 'stairs' && obj.center) {
+                    obj.center.x += deltaX;
+                    obj.center.y += deltaY;
+                }
+            });
+        }
+        // Tek nesne seçimi varsa, sadece onu hareket ettir
+        else if (state.selectedObject) {
+            const obj = state.selectedObject.object;
+            if (obj && obj.center && ['column', 'beam', 'stairs'].includes(state.selectedObject.type)) {
+                obj.center.x += deltaX;
+                obj.center.y += deltaY;
+            }
+        }
+
+        // Değişiklikleri kaydet ve 3D sahneyi güncelle
+        saveState();
+        if (dom.mainContainer.classList.contains('show-3d')) {
+            update3DScene();
+        }
+        return;
     }
 
     // Mod değiştirme kısayolları (FPS modundayken W/A/S/D engellenecek)

--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -53,6 +53,29 @@ export function onPointerDown(e) {
             return; // Başka işlem yapma
         }
 
+        // CTRL ile multi-select modu (sadece CTRL basılıyken, sürüklenebilir nesneler için)
+        if (e.ctrlKey && !e.altKey && !e.shiftKey && clickedObject &&
+            ['column', 'beam', 'stairs'].includes(clickedObject.type)) {
+            // Seçili grup içinde bu nesne var mı kontrol et
+            const existingIndex = state.selectedGroup.findIndex(item =>
+                item.type === clickedObject.type && item.object === clickedObject.object
+            );
+
+            if (existingIndex !== -1) {
+                // Zaten seçiliyse, seçimden çıkar (toggle off)
+                const newGroup = [...state.selectedGroup];
+                newGroup.splice(existingIndex, 1);
+                setState({ selectedGroup: newGroup, selectedObject: null });
+            } else {
+                // Seçili değilse, gruba ekle (toggle on)
+                setState({
+                    selectedGroup: [...state.selectedGroup, clickedObject],
+                    selectedObject: null
+                });
+            }
+            return; // Multi-select işlemi bitti, sürükleme başlatma
+        }
+
         // Önceki seçimi temizle (eğer yeni bir nesneye tıklanmadıysa veya boşluğa tıklandıysa)
         // Eğer tıklanan nesne varsa ve bu bir oda DEĞİLSE, seçimi daha sonra yapacağız.
         // Eğer tıklanan nesne yoksa veya oda ise, seçimi şimdi temizleyebiliriz.


### PR DESCRIPTION
- Implement CTRL+click multi-select for columns, beams, and stairs
- Add arrow key movement (1cm per press) for selected objects
- Update visual highlighting to show multi-selected objects
- Support both single object and multi-object movement