### PR TITLE
Add doors and windows to multi-select and arrow key movement

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -343,14 +343,16 @@ export function draw2D() {
 
     // 8. Kapılar, Pencereler, Menfezler
     doors.forEach((door) => {
-        const isSelected = selectedObject?.type === "door" && selectedObject.object === door;
+        const isSelected = (selectedObject?.type === "door" && selectedObject.object === door) ||
+                          state.selectedGroup.some(item => item.type === "door" && item.object === door);
         drawDoorSymbol(door, false, isSelected);
     });
 
     walls.forEach(wall => {
         if (wall.windows && wall.windows.length > 0) {
             wall.windows.forEach(window => {
-                const isSelected = selectedObject?.type === "window" && selectedObject.object === window;
+                const isSelected = (selectedObject?.type === "window" && selectedObject.object === window) ||
+                                  state.selectedGroup.some(item => item.type === "window" && item.object === window);
                 drawWindowSymbol(wall, window, false, isSelected);
             });
         }

--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -55,7 +55,7 @@ export function onPointerDown(e) {
 
         // CTRL ile multi-select modu (sadece CTRL basılıyken, sürüklenebilir nesneler için)
         if (e.ctrlKey && !e.altKey && !e.shiftKey && clickedObject &&
-            ['column', 'beam', 'stairs'].includes(clickedObject.type)) {
+            ['column', 'beam', 'stairs', 'door', 'window'].includes(clickedObject.type)) {
             // Seçili grup içinde bu nesne var mı kontrol et
             const existingIndex = state.selectedGroup.findIndex(item =>
                 item.type === clickedObject.type && item.object === clickedObject.object


### PR DESCRIPTION
- Fix CTRL+click multi-select to work with all object types (stairs, columns, beams, doors, windows)
- Add door and window support for arrow key movement (1cm increments)
- Update visual highlighting to show selected doors and windows in multi-select
- Doors and windows move along their wall when using arrow keys