### PR TITLE
Fix CTRL multi-select to only work on body clicks

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -53,9 +53,11 @@ export function onPointerDown(e) {
             return; // Başka işlem yapma
         }
 
-        // CTRL ile multi-select modu (sadece CTRL basılıyken, sürüklenebilir nesneler için)
+        // CTRL ile multi-select modu (sadece CTRL basılıyken, body'ye tıklandığında)
+        // Handle'lara (köşe, kenar) tıklandığında normal işlemler devam eder
         if (e.ctrlKey && !e.altKey && !e.shiftKey && clickedObject &&
-            ['column', 'beam', 'stairs', 'door', 'window'].includes(clickedObject.type)) {
+            ['column', 'beam', 'stairs', 'door', 'window'].includes(clickedObject.type) &&
+            clickedObject.handle === 'body') {
             // Seçili grup içinde bu nesne var mı kontrol et
             const existingIndex = state.selectedGroup.findIndex(item =>
                 item.type === clickedObject.type && item.object === clickedObject.object


### PR DESCRIPTION
- Add handle === 'body' check to multi-select logic
- Prevents conflict with resize/rotate operations on handles
- CTRL+click on body → add to selection
- CTRL+click on handle → normal resize/rotate operation