### PR TITLE
Fix selectedGroup being cleared on pointer-up

### DIFF
--- a/pointer/pointer-up.js
+++ b/pointer/pointer-up.js
@@ -189,7 +189,7 @@ export function onPointerUp(e) {
         aDragOccurred: false,
         stretchMode: null,
         initialDragPoint: null,
-        selectedGroup: [], // Sürükleme sonrası seçimi korumak için yorumlandı
+        // selectedGroup: [], // REMOVED - Bu satır CTRL multi-select'i bozuyordu
         affectedWalls: [],
         preDragWallStates: new Map(),
         preDragNodeStates: new Map(),


### PR DESCRIPTION
The root cause of CTRL multi-select not working was that selectedGroup was being reset to an empty array on every pointer-up event. This meant that even after successfully adding items to the selection group, they would be immediately cleared when the mouse button was released.

Changes:
- Remove selectedGroup: [] from pointer-up setState call
- This allows multi-select to persist between clicks
- Selection clearing is already properly handled in pointer-down.js

The comment even mentioned this was for "keeping selection after drag" but the line was never actually removed.