### PR TITLE
Convert selectedObject to selectedGroup on first CTRL+click

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -76,22 +76,30 @@ export function onPointerDown(e) {
             clickedObject.handle === 'body') {
             console.log('✅ CTRL Multi-Select Mode Active');
 
+            // Eğer selectedGroup boş ama selectedObject varsa, önce onu gruba ekle
+            let currentGroup = [...state.selectedGroup];
+            if (currentGroup.length === 0 && state.selectedObject &&
+                ['column', 'beam', 'stairs', 'door', 'window'].includes(state.selectedObject.type)) {
+                console.log('🔄 Converting selectedObject to selectedGroup');
+                currentGroup.push(state.selectedObject);
+            }
+
             // Seçili grup içinde bu nesne var mı kontrol et
-            const existingIndex = state.selectedGroup.findIndex(item =>
+            const existingIndex = currentGroup.findIndex(item =>
                 item.type === clickedObject.type && item.object === clickedObject.object
             );
 
             if (existingIndex !== -1) {
                 // Zaten seçiliyse, seçimden çıkar (toggle off)
                 console.log('➖ Removing from selection');
-                const newGroup = [...state.selectedGroup];
-                newGroup.splice(existingIndex, 1);
-                setState({ selectedGroup: newGroup, selectedObject: null });
+                currentGroup.splice(existingIndex, 1);
+                setState({ selectedGroup: currentGroup, selectedObject: null });
             } else {
                 // Seçili değilse, gruba ekle (toggle on)
                 console.log('➕ Adding to selection');
+                currentGroup.push(clickedObject);
                 setState({
-                    selectedGroup: [...state.selectedGroup, clickedObject],
+                    selectedGroup: currentGroup,
                     selectedObject: null
                 });
             }


### PR DESCRIPTION
Improved multi-select behavior to match expected UX:
- When user selects one object normally (selectedObject)
- Then CTRL+clicks another object
- The first selectedObject is now automatically added to selectedGroup
- Then the newly clicked object is also added

Before: User had to CTRL+click the first object again to add it
After: First normal selection is automatically included in multi-select

Changes:
- Check if selectedGroup is empty and selectedObject exists
- Automatically convert selectedObject to first item in selectedGroup
- Log conversion with 🔄 emoji for debugging