### PR TITLE
Fix: Clear selectedGroup when clicking without CTRL

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -135,8 +135,8 @@ export function onPointerDown(e) {
                  dom.p2d.classList.add('dragging'); // Sürükleme cursor'ı ekle (grabbing)
             } else {
                  // Diğer nesneler (duvar, kapı, kolon vb.) için:
-                 // Seçimi yap
-                 setState({ selectedObject: clickedObject, selectedRoom: null }); // Oda seçimini temizle
+                 // Seçimi yap ve grup seçimini temizle
+                 setState({ selectedObject: clickedObject, selectedRoom: null, selectedGroup: [] });
 
                  // Sürükleme için başlangıç bilgilerini nesne tipine göre al
                  let dragInfo = { startPointForDragging: pos, dragOffset: { x: 0, y: 0 }, additionalState: {} };


### PR DESCRIPTION
When selecting an object without holding CTRL, the multi-selection (selectedGroup) was not being cleared. This caused the group selection to persist even when making a normal (non-CTRL) click.

Fixed by adding selectedGroup: [] to the setState call when a regular object is clicked without CTRL (pointer-down.js:139).