### PR TITLE
feat: Add sticky snap lock for wall node dragging

### DIFF
--- a/pointer/pointer-up.js
+++ b/pointer/pointer-up.js
@@ -199,6 +199,7 @@ export function onPointerUp(e) {
         isSweeping: false,
         sweepWalls: [],
         columnRotationOffset: null,
-        tempNeighborWallsToDimension: null // Komşu duvar Set'ini temizle
+        tempNeighborWallsToDimension: null, // Komşu duvar Set'ini temizle
+        wallNodeSnapLock: null // Snap lock'u temizle
     });
 }


### PR DESCRIPTION
Implement "sticky" snap behavior to prevent snap from releasing on small mouse movements:

- Snap locks when within 25cm of wall surface
- Snap releases only when mouse moves 40cm+ away
- State-based snap locking (wallNodeSnapLock)
- Prevents jittery behavior during dragging
- Snap stays locked even with small mouse wobbles

How it works:
1. Detect snap within 25cm → lock to that position
2. Mouse can move ±40cm while staying locked
3. Only releases if mouse moves beyond 40cm
4. Provides stable, predictable snap behavior

This fixes the issue where snap would constantly engage/disengage with minor mouse movements.