### PR TITLE
fix: Add sticky snap lock for wall BODY dragging

### DIFF
--- a/pointer/pointer-up.js
+++ b/pointer/pointer-up.js
@@ -200,6 +200,7 @@ export function onPointerUp(e) {
         sweepWalls: [],
         columnRotationOffset: null,
         tempNeighborWallsToDimension: null, // Komşu duvar Set'ini temizle
-        wallNodeSnapLock: null // Snap lock'u temizle
+        wallNodeSnapLock: null, // Snap lock'u temizle
+        wallBodySnapLock: null  // Wall body snap lock'u temizle
     });
 }


### PR DESCRIPTION
The previous snap lock only worked for wall NODE dragging (p1/p2). Wall BODY dragging was using unsnappedPos directly, causing jitter.

Changes:
- Add wallBodySnapLock for duvar body sürükleme
- Lock delta when snap detected
- Mouse can move ±40cm without affecting wall position
- Wall stays frozen at snap position
- Clear lock on drag end

Now both wall node AND wall body dragging have sticky snap!