### PR TITLE
fix: Disable grid snap during dragging for smooth movement

### DIFF
--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -183,8 +183,8 @@ export function onPointerMove(e) {
     }
 
     // Fare pozisyonunu güncelle (snap ile)
-    // Sürükleme sırasında da snap aktif olsun
-    let snappedPos = getSmartSnapPoint(e, true); // Her zaman grid snap kullan
+    // Sürükleme sırasında grid snap'i KAPAT (smooth hareket için)
+    let snappedPos = getSmartSnapPoint(e, !state.isDragging); // Sürüklerken grid snap yok
     setState({ mousePos: snappedPos });
 
     // Snaplenmemiş pozisyonu al


### PR DESCRIPTION
Grid snap was causing jumpy/stuttering movement during dragging. Mouse was snapping to 5cm grid points, making movement feel laggy.

Changes:
- Disable grid snap during isDragging
- Use raw mouse position for smooth movement
- Object/wall snap still works (snap lock system)
- Grid snap re-enables after drag ends

Result: Buttery smooth dragging motion!