### PR TITLE
fix: Exclude selectedGroup walls from node dragging snap

### DIFF
--- a/wall/wall-handler.js
+++ b/wall/wall-handler.js
@@ -326,10 +326,15 @@ export function onPointerMove(snappedPos, unsnappedPos) {
             let bestSnapX = { diff: SNAP_DISTANCE, value: null };
             let bestSnapY = { diff: SNAP_DISTANCE, value: null };
 
+            // Taşınan duvarları tespit et (grup veya tek duvar)
+            const wallsToMove = state.selectedGroup.length > 0 ? state.selectedGroup : [state.selectedObject.object];
+
             // Tüm duvar yüzeylerine snap kontrolü
             state.walls.forEach(wall => {
                 // Sürüklenen node'un bağlı olduğu duvarları atla
                 if (state.affectedWalls.includes(wall)) return;
+                // Taşınan duvarları atla (grup seçimi durumunda)
+                if (wallsToMove.includes(wall)) return;
                 if (!wall.p1 || !wall.p2) return;
 
                 const wallThickness = wall.thickness || state.wallThickness;


### PR DESCRIPTION
Wall node dragging also needs to exclude walls from selectedGroup, not just affectedWalls. When dragging a wall node with multiple walls selected, the snap system was still detecting other walls in the group as snap candidates.

Changes:
- Build wallsToMove array from selectedGroup or selectedObject
- Exclude wallsToMove from distant snap detection in node dragging

This complements the previous snap.js fix to fully prevent self-snapping in all drag scenarios.

Fixes wall-handler.js:330,337