### PR TITLE
fix: Ensure selectedGroup uses consistent wrapper format

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -174,8 +174,13 @@ function handlePaste(e) {
                 geometryChanged = true;
             }
         });
-         if (newWalls.length > 0) setState({ selectedObject: null, selectedGroup: newWalls });
-         else setState({ selectedObject: null, selectedGroup: [] });
+         if (newWalls.length > 0) {
+             // newWalls'ı wrapper formatına çevir
+             const wrappedWalls = newWalls.map(wall => ({ type: 'wall', object: wall, handle: 'body' }));
+             setState({ selectedObject: null, selectedGroup: wrappedWalls });
+         } else {
+             setState({ selectedObject: null, selectedGroup: [] });
+         }
     }
     if(geometryChanged){ processWalls(); saveState(); update3DScene(); }
 }

--- a/general-files/snap.js
+++ b/general-files/snap.js
@@ -287,7 +287,10 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
     let nodesBeingMoved = new Set();
     if (state.isDragging && state.selectedObject?.type === 'wall') {
         // Grup seçimi varsa grubu, yoksa tek duvarı al
-        wallsBeingMoved = state.selectedGroup.length > 0 ? state.selectedGroup : [state.selectedObject.object];
+        // selectedGroup elemanları {type, object, handle} formatında!
+        wallsBeingMoved = state.selectedGroup.length > 0
+            ? state.selectedGroup.map(item => item.object)
+            : [state.selectedObject.object];
         // Tüm taşınan duvarların nodlarını topla
         wallsBeingMoved.forEach(w => {
             if (w.p1) nodesBeingMoved.add(w.p1);

--- a/wall/wall-handler.js
+++ b/wall/wall-handler.js
@@ -183,9 +183,14 @@ export function onPointerDownSelect(selectedObject, pos, snappedPos, e) {
         } else {
              if (e.ctrlKey && e.shiftKey) {
                  const chain = findCollinearChain(selectedObject.object);
-                 setState({ selectedGroup: chain });
+                 // findCollinearChain wall objelerini döndürüyor, wrapper formatına çevir
+                 const wrappedChain = chain.map(wall => ({ type: 'wall', object: wall, handle: 'body' }));
+                 setState({ selectedGroup: wrappedChain });
              }
-             wallsBeingMoved = state.selectedGroup.length > 0 ? state.selectedGroup : [selectedObject.object];
+             // selectedGroup elemanları {type, object, handle} formatında!
+             wallsBeingMoved = state.selectedGroup.length > 0
+                 ? state.selectedGroup.map(item => item.object)
+                 : [selectedObject.object];
         }
 
         const nodesBeingMoved = new Set();
@@ -327,7 +332,10 @@ export function onPointerMove(snappedPos, unsnappedPos) {
             let bestSnapY = { diff: SNAP_DISTANCE, value: null };
 
             // Taşınan duvarları tespit et (grup veya tek duvar)
-            const wallsToMove = state.selectedGroup.length > 0 ? state.selectedGroup : [state.selectedObject.object];
+            // selectedGroup elemanları {type, object, handle} formatında!
+            const wallsToMove = state.selectedGroup.length > 0
+                ? state.selectedGroup.map(item => item.object)
+                : [state.selectedObject.object];
 
             // Tüm duvar yüzeylerine snap kontrolü
             state.walls.forEach(wall => {
@@ -432,7 +440,10 @@ export function onPointerMove(snappedPos, unsnappedPos) {
         // Duvar Gövdesi Sürükleme
         console.log('🏗️ Wall BODY dragging');
 
-        const wallsToMove = state.selectedGroup.length > 0 ? state.selectedGroup : [state.selectedObject.object];
+        // selectedGroup elemanları {type, object, handle} formatında!
+        const wallsToMove = state.selectedGroup.length > 0
+            ? state.selectedGroup.map(item => item.object)
+            : [state.selectedObject.object];
         const nodesToMove = new Set();
         wallsToMove.forEach((w) => { nodesToMove.add(w.p1); nodesToMove.add(w.p2); });
 


### PR DESCRIPTION
The root cause of self-snapping was selectedGroup format inconsistency:
- pointer-down.js used {type, object, handle} wrapper format
- findCollinearChain returned raw wall objects
- paste operation also used raw wall objects

This caused wallsBeingMoved.includes(wall) checks to fail since selectedGroup contained wrappers but we were comparing raw objects.

Changes:
1. snap.js: Extract .object from selectedGroup items (lines 291-293)
2. wall-handler.js node dragging: Extract .object (lines 331-333)
3. wall-handler.js body dragging: Extract .object (lines 439-441)
4. wall-handler.js collinear chain: Wrap returned walls (lines 187-188)
5. wall-handler.js pointer-down: Extract .object (lines 191-193)
6. input.js paste: Wrap pasted walls (lines 179-180)

Now selectedGroup always contains {type, object, handle} format, and all snap exclusion logic properly extracts .object for comparison.

This fully fixes the self-snapping issue where walls were catching themselves during drag operations.