### PR TITLE
feat: Add floor management system

### DIFF
--- a/floor/floor-handler.js
+++ b/floor/floor-handler.js
@@ -1,0 +1,182 @@
+// floor-handler.js
+import { state, setState } from '../general-files/main.js';
+
+/**
+ * Default katları initialize eder
+ * İlk açılışta: alt kat (placeholder), zemin (aktif), üst kat (placeholder)
+ */
+export function initializeDefaultFloors() {
+    // Eğer zaten katlar varsa, tekrar initialize etme
+    if (state.floors && state.floors.length > 0) {
+        return;
+    }
+
+    const defaultHeight = state.defaultFloorHeight;
+
+    // Alt kat (placeholder)
+    const lowerFloor = {
+        id: 'floor-lower-placeholder',
+        name: 'BODRUM (Hazır)',
+        bottomElevation: -defaultHeight,
+        topElevation: 0,
+        visible: false,
+        isPlaceholder: true
+    };
+
+    // Zemin kat (aktif)
+    const groundFloor = {
+        id: 'floor-ground',
+        name: 'ZEMİN',
+        bottomElevation: 0,
+        topElevation: defaultHeight,
+        visible: true,
+        isPlaceholder: false
+    };
+
+    // Üst kat (placeholder)
+    const upperFloor = {
+        id: 'floor-upper-placeholder',
+        name: '1.KAT (Hazır)',
+        bottomElevation: defaultHeight,
+        topElevation: defaultHeight * 2,
+        visible: false,
+        isPlaceholder: true
+    };
+
+    setState({
+        floors: [lowerFloor, groundFloor, upperFloor],
+        currentFloor: groundFloor
+    });
+}
+
+/**
+ * Belirli bir kata geçiş yapar
+ * @param {string} floorId - Kat ID'si
+ */
+export function switchToFloor(floorId) {
+    const floor = state.floors.find(f => f.id === floorId);
+
+    if (floor && !floor.isPlaceholder) {
+        setState({ currentFloor: floor });
+    }
+}
+
+/**
+ * Yeni bir kat ekler
+ * @param {number} bottomElevation - Alt kot (cm)
+ * @param {number} topElevation - Üst kot (cm)
+ * @param {string} name - Kat adı
+ * @returns {object} Yeni kat objesi
+ */
+export function addFloor(bottomElevation, topElevation, name) {
+    const newFloor = {
+        id: `floor-${Date.now()}`,
+        name: name || `Kat ${state.floors.length + 1}`,
+        bottomElevation,
+        topElevation,
+        visible: true,
+        isPlaceholder: false
+    };
+
+    const floors = [...state.floors, newFloor];
+
+    // Katları yüksekliğe göre sırala (alçaktan yükseğe)
+    floors.sort((a, b) => a.bottomElevation - b.bottomElevation);
+
+    setState({ floors });
+
+    return newFloor;
+}
+
+/**
+ * Bir katı siler
+ * @param {string} floorId - Silinecek katın ID'si
+ */
+export function deleteFloor(floorId) {
+    const floors = state.floors.filter(f => f.id !== floorId);
+
+    // Eğer aktif kat silindiyse, başka bir kata geç
+    if (state.currentFloor?.id === floorId) {
+        const newCurrentFloor = floors.find(f => !f.isPlaceholder) || null;
+        setState({ currentFloor: newCurrentFloor });
+    }
+
+    setState({ floors });
+}
+
+/**
+ * Bir katın adını günceller
+ * @param {string} floorId - Kat ID'si
+ * @param {string} newName - Yeni isim
+ */
+export function renameFloor(floorId, newName) {
+    const floors = state.floors.map(f => {
+        if (f.id === floorId) {
+            return { ...f, name: newName };
+        }
+        return f;
+    });
+
+    setState({ floors });
+}
+
+/**
+ * Bir katın yüksekliğini günceller
+ * @param {string} floorId - Kat ID'si
+ * @param {number} bottomElevation - Yeni alt kot
+ * @param {number} topElevation - Yeni üst kot
+ */
+export function updateFloorElevation(floorId, bottomElevation, topElevation) {
+    const floors = state.floors.map(f => {
+        if (f.id === floorId) {
+            return {
+                ...f,
+                bottomElevation,
+                topElevation
+            };
+        }
+        return f;
+    });
+
+    // Katları yüksekliğe göre yeniden sırala
+    floors.sort((a, b) => a.bottomElevation - b.bottomElevation);
+
+    setState({ floors });
+}
+
+/**
+ * Aktif katın yükseklik aralığını döndürür
+ * @returns {object} { bottom: number, top: number } veya null
+ */
+export function getCurrentFloorElevation() {
+    if (!state.currentFloor) {
+        return null;
+    }
+
+    return {
+        bottom: state.currentFloor.bottomElevation,
+        top: state.currentFloor.topElevation,
+        height: state.currentFloor.topElevation - state.currentFloor.bottomElevation
+    };
+}
+
+/**
+ * Tüm görünür katları döndürür
+ * @returns {Array} Görünür katlar
+ */
+export function getVisibleFloors() {
+    return state.floors.filter(f => f.visible && !f.isPlaceholder);
+}
+
+/**
+ * Belirli bir yükseklikte hangi kat olduğunu bulur
+ * @param {number} elevation - Yükseklik (cm)
+ * @returns {object|null} Kat objesi veya null
+ */
+export function getFloorAtElevation(elevation) {
+    return state.floors.find(f =>
+        !f.isPlaceholder &&
+        elevation >= f.bottomElevation &&
+        elevation < f.topElevation
+    ) || null;
+}

--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -1,0 +1,351 @@
+// floor-panel.js
+import { state, setState } from '../general-files/main.js';
+
+let floorPanel = null;
+
+/**
+ * Kat panelini oluşturur (sadece bir kez)
+ */
+export function createFloorPanel() {
+    if (floorPanel) return;
+
+    floorPanel = document.createElement('div');
+    floorPanel.id = 'floor-panel';
+    floorPanel.style.cssText = `
+        position: fixed;
+        background: #2a2b2c;
+        border: 1px solid #8ab4f8;
+        border-radius: 8px;
+        padding: 16px;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+        z-index: 10000;
+        display: none;
+        min-width: 500px;
+        max-width: 600px;
+    `;
+
+    floorPanel.innerHTML = `
+        <div style="margin-bottom: 16px; font-size: 14px; font-weight: 500;
+                    color: #8ab4f8; border-bottom: 1px solid #3a3b3c; padding-bottom: 8px;
+                    display: flex; justify-content: space-between; align-items: center;">
+            <span>KAT YÖNETİMİ</span>
+            <button id="close-floor-panel" style="background: transparent; border: none;
+                    color: #e7e6d0; cursor: pointer; font-size: 18px; padding: 0; width: 24px; height: 24px;">
+                ✕
+            </button>
+        </div>
+        <div id="floor-table-container" style="overflow-y: auto; max-height: 400px;">
+            <!-- Tablo buraya dinamik olarak eklenecek -->
+        </div>
+    `;
+
+    document.body.appendChild(floorPanel);
+    setupFloorPanelListeners();
+}
+
+/**
+ * Panel event listener'larını kurar
+ */
+function setupFloorPanelListeners() {
+    const closeBtn = floorPanel.querySelector('#close-floor-panel');
+    closeBtn.addEventListener('click', hideFloorPanel);
+
+    // Panel dışına tıklandığında kapat
+    document.addEventListener('click', (e) => {
+        if (floorPanel.style.display === 'block' &&
+            !floorPanel.contains(e.target) &&
+            e.target.id !== 'bFloors') {
+            hideFloorPanel();
+        }
+    });
+}
+
+/**
+ * Kat tablosunu render eder
+ */
+export function renderFloorTable() {
+    if (!floorPanel) return;
+
+    const tableContainer = floorPanel.querySelector('#floor-table-container');
+    const floors = state.floors || [];
+
+    let html = `
+        <table style="width: 100%; border-collapse: collapse;">
+            <thead>
+                <tr style="border-bottom: 1px solid #3a3b3c;">
+                    <th style="padding: 8px; text-align: left; color: #8ab4f8; font-size: 12px; width: 60px;">Göster</th>
+                    <th style="padding: 8px; text-align: left; color: #8ab4f8; font-size: 12px; width: 120px;">Kat Adı</th>
+                    <th style="padding: 8px; text-align: left; color: #8ab4f8; font-size: 12px;">Ön İzleme</th>
+                </tr>
+            </thead>
+            <tbody>
+    `;
+
+    // Katları ters sırada göster (en üstteki kat en üstte)
+    const sortedFloors = [...floors].reverse();
+
+    sortedFloors.forEach((floor, index) => {
+        const isActive = state.currentFloor?.id === floor.id;
+        const rowStyle = isActive ?
+            'background: rgba(138, 180, 248, 0.1); border-left: 3px solid #8ab4f8;' :
+            '';
+
+        html += `
+            <tr data-floor-id="${floor.id}"
+                style="${rowStyle} border-bottom: 1px solid #3a3b3c; cursor: pointer;"
+                class="floor-row">
+                <td style="padding: 8px;">
+                    ${floor.isPlaceholder ?
+                        '' :
+                        `<input type="checkbox"
+                                class="floor-visibility-toggle"
+                                data-floor-id="${floor.id}"
+                                ${floor.visible ? 'checked' : ''}
+                                style="cursor: pointer;"/>`
+                    }
+                </td>
+                <td style="padding: 8px; color: ${isActive ? '#8ab4f8' : '#e7e6d0'}; font-size: 13px;">
+                    ${floor.name}
+                    ${isActive ? '<span style="color: #24ffda; font-size: 11px;"> (AKTİF)</span>' : ''}
+                </td>
+                <td style="padding: 8px;">
+                    ${floor.isPlaceholder ?
+                        renderPlaceholderPreview(floor) :
+                        renderFloorPreview(floor)
+                    }
+                </td>
+            </tr>
+        `;
+    });
+
+    html += `
+            </tbody>
+        </table>
+    `;
+
+    tableContainer.innerHTML = html;
+
+    // Event listener'ları ekle
+    setupTableEventListeners();
+}
+
+/**
+ * Placeholder kat önizlemesi (kesikli çizgiler + buton)
+ */
+function renderPlaceholderPreview(floor) {
+    return `
+        <div style="position: relative; width: 150px; height: 60px;">
+            <svg width="150" height="60" style="display: block;">
+                <rect x="10" y="10" width="130" height="40"
+                      fill="none"
+                      stroke="#5f6368"
+                      stroke-width="1"
+                      stroke-dasharray="4,4"/>
+                <line x1="10" y1="10" x2="140" y2="50"
+                      stroke="#5f6368"
+                      stroke-width="1"
+                      stroke-dasharray="4,4"/>
+                <line x1="140" y1="10" x2="10" y2="50"
+                      stroke="#5f6368"
+                      stroke-width="1"
+                      stroke-dasharray="4,4"/>
+            </svg>
+            <button class="add-floor-btn"
+                    data-floor-id="${floor.id}"
+                    style="position: absolute;
+                           top: 50%;
+                           left: 50%;
+                           transform: translate(-50%, -50%);
+                           background: #3a3b3c;
+                           color: #8ab4f8;
+                           border: 1px solid #8ab4f8;
+                           border-radius: 50%;
+                           width: 30px;
+                           height: 30px;
+                           font-size: 18px;
+                           cursor: pointer;
+                           display: flex;
+                           align-items: center;
+                           justify-content: center;
+                           transition: all 0.2s;">
+                +
+            </button>
+        </div>
+    `;
+}
+
+/**
+ * Normal kat önizlemesi (düz çizgiler)
+ */
+function renderFloorPreview(floor) {
+    return `
+        <svg width="150" height="60" style="display: block;">
+            <rect x="10" y="10" width="130" height="40"
+                  fill="none"
+                  stroke="#e7e6d0"
+                  stroke-width="1.5"/>
+            <line x1="10" y1="10" x2="140" y2="50"
+                  stroke="#e7e6d0"
+                  stroke-width="1"/>
+            <line x1="140" y1="10" x2="10" y2="50"
+                  stroke="#e7e6d0"
+                  stroke-width="1"/>
+        </svg>
+    `;
+}
+
+/**
+ * Tablo event listener'larını kurar
+ */
+function setupTableEventListeners() {
+    // Satıra tıklama - katı aktif yap
+    const rows = floorPanel.querySelectorAll('.floor-row');
+    rows.forEach(row => {
+        row.addEventListener('click', (e) => {
+            // Checkbox veya button tıklamasıysa ignore et
+            if (e.target.classList.contains('floor-visibility-toggle') ||
+                e.target.classList.contains('add-floor-btn')) {
+                return;
+            }
+
+            const floorId = row.dataset.floorId;
+            const floor = state.floors.find(f => f.id === floorId);
+
+            if (floor && !floor.isPlaceholder) {
+                setState({ currentFloor: floor });
+                renderFloorTable();
+            }
+        });
+    });
+
+    // Görünürlük toggle'ları
+    const visibilityToggles = floorPanel.querySelectorAll('.floor-visibility-toggle');
+    visibilityToggles.forEach(toggle => {
+        toggle.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const floorId = toggle.dataset.floorId;
+            toggleFloorVisibility(floorId);
+        });
+    });
+
+    // Kat ekleme butonları
+    const addButtons = floorPanel.querySelectorAll('.add-floor-btn');
+    addButtons.forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const floorId = btn.dataset.floorId;
+            addFloorFromPlaceholder(floorId);
+        });
+
+        // Hover efekti
+        btn.addEventListener('mouseenter', () => {
+            btn.style.background = '#8ab4f8';
+            btn.style.color = '#1e1f20';
+        });
+        btn.addEventListener('mouseleave', () => {
+            btn.style.background = '#3a3b3c';
+            btn.style.color = '#8ab4f8';
+        });
+    });
+}
+
+/**
+ * Kat görünürlüğünü toggle eder
+ */
+function toggleFloorVisibility(floorId) {
+    const floors = state.floors.map(f => {
+        if (f.id === floorId) {
+            return { ...f, visible: !f.visible };
+        }
+        return f;
+    });
+
+    setState({ floors });
+    renderFloorTable();
+}
+
+/**
+ * Placeholder'dan yeni kat ekler
+ */
+function addFloorFromPlaceholder(placeholderId) {
+    const floors = [...state.floors];
+    const placeholderIndex = floors.findIndex(f => f.id === placeholderId);
+
+    if (placeholderIndex === -1) return;
+
+    const placeholder = floors[placeholderIndex];
+
+    // Yeni kat adını belirle
+    const existingFloorNumbers = floors
+        .filter(f => !f.isPlaceholder && f.name.includes('.KAT'))
+        .map(f => parseInt(f.name.split('.')[0]))
+        .filter(n => !isNaN(n));
+
+    const maxFloorNumber = existingFloorNumbers.length > 0 ? Math.max(...existingFloorNumbers) : 0;
+    const newFloorNumber = maxFloorNumber + 1;
+    const newFloorName = `${newFloorNumber}.KAT`;
+
+    // Placeholder'ı gerçek kata dönüştür
+    floors[placeholderIndex] = {
+        ...placeholder,
+        name: newFloorName,
+        isPlaceholder: false,
+        visible: true
+    };
+
+    // Yeni placeholder ekle (üste)
+    const newBottomElevation = floors[placeholderIndex].topElevation;
+    const newTopElevation = newBottomElevation + state.defaultFloorHeight;
+
+    floors.splice(placeholderIndex, 0, {
+        id: `floor-${Date.now()}`,
+        name: `${newFloorNumber + 1}.KAT (Hazır)`,
+        bottomElevation: newBottomElevation,
+        topElevation: newTopElevation,
+        visible: false,
+        isPlaceholder: true
+    });
+
+    // Yeni katı aktif yap
+    const newFloor = floors[placeholderIndex + 1];
+
+    setState({
+        floors,
+        currentFloor: newFloor
+    });
+
+    renderFloorTable();
+}
+
+/**
+ * Kat panelini gösterir
+ */
+export function showFloorPanel() {
+    if (!floorPanel) {
+        createFloorPanel();
+    }
+
+    // Panel'i ekranın ortasına yerleştir
+    floorPanel.style.display = 'block';
+    floorPanel.style.left = '50%';
+    floorPanel.style.top = '50%';
+    floorPanel.style.transform = 'translate(-50%, -50%)';
+
+    renderFloorTable();
+}
+
+/**
+ * Kat panelini gizler
+ */
+export function hideFloorPanel() {
+    if (floorPanel) {
+        floorPanel.style.display = 'none';
+    }
+}
+
+/**
+ * Kat panelinin görünür olup olmadığını döndürür
+ */
+export function isFloorPanelVisible() {
+    return floorPanel && floorPanel.style.display === 'block';
+}

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -4,7 +4,7 @@ import { setupFileIOListeners } from './file-io.js';
 import { setupInputListeners } from './input.js';
 import { setupUIListeners, initializeSettings, toggle3DView } from './ui.js';
 import { draw2D } from '../draw/draw2d.js';
-import { initGuideContextMenu } from '../draw/guide-menu.js'; 
+import { initGuideContextMenu } from '../draw/guide-menu.js';
 import { fitDrawingToScreen } from '../draw/zoom.js';
 // --- DEĞİŞİKLİK BURADA ---
 import { updateFirstPersonCamera, setupFirstPersonMouseControls } from '../scene3d/scene3d-camera.js';
@@ -12,6 +12,8 @@ import { update3DScene } from '../scene3d/scene3d-update.js';
 import { init3D, renderer as renderer3d, camera as camera3d, controls as controls3d, scene as scene3d } from '../scene3d/scene3d-core.js';
 // --- DEĞİŞİKLİK SONU ---
 import { createWallPanel } from '../wall/wall-panel.js';
+import { createFloorPanel, showFloorPanel } from '../floor/floor-panel.js';
+import { initializeDefaultFloors } from '../floor/floor-handler.js';
 /*
 // --- RESİM ÇERÇEVESİ KODU ---
 // config.js'den (eğer varsa) API anahtarını güvenli bir şekilde okur
@@ -201,7 +203,7 @@ export let state = {
     rooms: [],
     columns: [],
     beams: [],
-    stairs: [], 
+    stairs: [],
     clipboard: null, // <-- YENİ SATIR EKLE
     wallAdjacency: new Map(),
     selectedObject: null,
@@ -282,15 +284,21 @@ export let state = {
         columns: [], beams: [], stairs: [], rooms: []
     },
     symmetryPreviewTimer: null, // <-- DÜZELTME: Kilitlenme sorununu çözmek için eklendi
-    guides: [], 
+    guides: [],
     // --- YENİ: RESİM ÇERÇEVESİ İÇİN STATE ---
     pictureFrameCache: [], // Unsplash URL'lerini tutar
     pictureFrameMaterials: {}, // 3D Malzemeleri (URL'ye göre) cache'ler
     // --- YENİ STATE SONU ---
-    
+
     // --- YENİ: 3D FARE DURUMU ---
-    is3DMouseDown: false // 3D canvas'ta fare basılı mı?
+    is3DMouseDown: false, // 3D canvas'ta fare basılı mı?
     // --- YENİ STATE SONU ---
+
+    // --- YENİ: KAT YÖNETİMİ ---
+    floors: [], // Katlar dizisi
+    currentFloor: null, // Aktif kat
+    defaultFloorHeight: 270, // Varsayılan kat yüksekliği (cm)
+    // --- KAT YÖNETİMİ SONU ---
 };
 
 export function setState(newState) {
@@ -322,6 +330,7 @@ export const dom = {
     b3d: document.getElementById("b3d"),
     bFirstPerson: document.getElementById("bFirstPerson"),
     bAssignNames: document.getElementById("bAssignNames"),
+    bFloors: document.getElementById("bFloors"),
     settingsBtn: document.getElementById("settings-btn"),
     settingsPopup: document.getElementById("settings-popup"),
     closeSettingsPopupBtn: document.getElementById("close-settings-popup"),
@@ -728,7 +737,9 @@ function initialize() {
     setupInputListeners();
     setupFileIOListeners();
     createWallPanel();
-    initGuideContextMenu();  
+    createFloorPanel();
+    initializeDefaultFloors();
+    initGuideContextMenu();
 
     //loadPictureFrameImages(); // <-- YENİ: Resimleri yüklemeyi burada başlatın
 
@@ -741,9 +752,10 @@ function initialize() {
     dom.bBeam.addEventListener("click", () => setMode("drawBeam", true));
     dom.bStairs.addEventListener("click", () => setMode("drawStairs", true)); // forceSet ekleyin
     dom.bSymmetry.addEventListener("click", () => setMode("drawSymmetry", true)); // forceSet ekleyin
-    
+
     dom.b3d.addEventListener("click", toggle3DView);
     dom.bAssignNames.addEventListener("click", assignRoomNames); // Artık güncellenmiş fonksiyonu çağıracak
+    dom.bFloors.addEventListener("click", showFloorPanel);
 
     window.addEventListener("resize", resize);
 

--- a/index.html
+++ b/index.html
@@ -78,6 +78,14 @@
   FPS Kamera
  </button>
  <button id="bAssignNames" class="btn">Mahal Tanımla</button>
+ <button id="bFloors" class="btn">
+  <svg viewBox="0 0 24 24" stroke="currentColor" fill="none">
+    <rect x="4" y="3" width="16" height="5" stroke-width="1.5" fill="none"/>
+    <rect x="4" y="9.5" width="16" height="5" stroke-width="1.5" fill="currentColor" opacity="0.3"/>
+    <rect x="4" y="16" width="16" height="5" stroke-width="1.5" fill="none"/>
+  </svg>
+  KATLAR
+ </button>
 <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none"/>
 </div>
 


### PR DESCRIPTION
- Add floor state management (floors array, currentFloor, defaultFloorHeight)
- Create KATLAR button in main UI
- Implement floor panel with table layout showing:
  * Visibility toggle column
  * Floor name column
  * Preview column with diagonal rectangle visualization
- Initialize 3 default floors: lower placeholder (BODRUM), ground floor (ZEMİN - active), upper placeholder (1.KAT)
- Placeholder floors shown with dashed lines and + button
- Clicking + button converts placeholder to real floor and adds new placeholder above
- Floor heights: ZEMİN (0-270cm), 1.KAT (270-540cm) when added
- Each floor tracks: id, name, bottomElevation, topElevation, visible, isPlaceholder