### PR TITLE
fix: Prevent unwanted detail panel closing

### DIFF
--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -271,25 +271,40 @@ function createDetailPanel() {
     setupDetailPanelListeners();
 }
 
+// Global listener'lar için flag
+let detailPanelListenersAdded = false;
+
 /**
  * Detaylı panel event listener'ları
  */
 function setupDetailPanelListeners() {
     const closeBtn = detailPanel.querySelector('#close-detail-panel');
-    closeBtn.addEventListener('click', hideDetailPanel);
-
-    // Panel dışına tıklandığında kapat
-    document.addEventListener('click', (e) => {
-        if (detailPanel.style.display === 'block' &&
-            !detailPanel.contains(e.target) &&
-            !miniPanel.contains(e.target)) {
-            hideDetailPanel();
-        }
+    closeBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        hideDetailPanel();
     });
+
+    // Global listener'ları sadece bir kez ekle
+    if (detailPanelListenersAdded) return;
+    detailPanelListenersAdded = true;
+
+    // Panel dışına tıklandığında kapat (async ile timing düzelt)
+    document.addEventListener('click', (e) => {
+        // Mini panel'in expand butonuna tıklamayı bekle
+        setTimeout(() => {
+            if (detailPanel &&
+                detailPanel.style.display === 'block' &&
+                !detailPanel.contains(e.target) &&
+                !miniPanel.contains(e.target)) {
+                hideDetailPanel();
+            }
+        }, 0);
+    }, true); // Capture phase kullan
 
     // ESC tuşuna basıldığında kapat
     document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && detailPanel.style.display === 'block') {
+        if (e.key === 'Escape' && detailPanel && detailPanel.style.display === 'block') {
+            e.preventDefault();
             hideDetailPanel();
         }
     });


### PR DESCRIPTION
Issue: Panel was closing during internal interactions
Solution: Strict 3-way close control

Changes:
- Added flag to prevent multiple global listener additions
- Close button now uses stopPropagation
- Document click uses setTimeout for timing fix
- Document click uses capture phase (true)
- ESC key handler includes preventDefault
- Global listeners only added once

Panel closes ONLY in 3 cases:
1. ESC key press
2. × close button click
3. Click outside panel (on drawing area)

All other interactions keep panel open:
- Floor selection
- Floor creation
- Visibility toggle
- Delete operations
- Drag-drop reordering