### PR TITLE
fix: Stop all panel clicks from bubbling to document

### DIFF
--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -284,22 +284,24 @@ function setupDetailPanelListeners() {
         hideDetailPanel();
     });
 
+    // Panel içindeki TÜM tıklamaları durdur (document'e bubble up etmesin)
+    detailPanel.addEventListener('click', (e) => {
+        e.stopPropagation();
+    });
+
     // Global listener'ları sadece bir kez ekle
     if (detailPanelListenersAdded) return;
     detailPanelListenersAdded = true;
 
-    // Panel dışına tıklandığında kapat (async ile timing düzelt)
+    // Panel dışına tıklandığında kapat
     document.addEventListener('click', (e) => {
-        // Mini panel'in expand butonuna tıklamayı bekle
-        setTimeout(() => {
-            if (detailPanel &&
-                detailPanel.style.display === 'block' &&
-                !detailPanel.contains(e.target) &&
-                !miniPanel.contains(e.target)) {
-                hideDetailPanel();
-            }
-        }, 0);
-    }, true); // Capture phase kullan
+        if (detailPanel &&
+            detailPanel.style.display === 'block' &&
+            !detailPanel.contains(e.target) &&
+            !miniPanel.contains(e.target)) {
+            hideDetailPanel();
+        }
+    });
 
     // ESC tuşuna basıldığında kapat
     document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
Root cause: All clicks inside panel were bubbling up to document click listener, which was closing the panel.

Solution: Added stopPropagation to panel itself
- detailPanel.addEventListener('click', stopPropagation)
- This blocks ALL internal clicks from reaching document
- Removed setTimeout and capture phase (not needed)

Now panel closes ONLY in 3 cases:
1. ESC key
2. × button
3. Click outside panel

Panel stays open for:
- Floor selection
- Floor creation (ÜSTE KAT EKLE / ALTA KAT EKLE)
- Delete button
- Visibility toggle
- Drag-drop
- All other internal interactions