### PR TITLE
fix: Real-time content indicators and right-aligned dots

### DIFF
--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -169,13 +169,14 @@ export function renderMiniPanel() {
             dotColor = '#808080'; // Gri nokta
         }
 
-        // Nokta HTML (sadece içerik varsa)
-        const dotHtml = hasContent ? `<span style="display: inline-block; width: 4px; height: 4px; border-radius: 50%; background: ${dotColor}; margin-left: 4px; vertical-align: middle;"></span>` : '';
+        // Nokta HTML (sadece içerik varsa, sağ üst köşede)
+        const dotHtml = hasContent ? `<span style="position: absolute; top: 4px; right: 4px; width: 4px; height: 4px; border-radius: 50%; background: ${dotColor};"></span>` : '';
 
         html += `
             <div class="floor-mini-item clickable"
                  data-floor-id="${floor.id}"
-                 style="background: ${bgColor};
+                 style="position: relative;
+                        background: ${bgColor};
                         color: ${textColor};
                         padding: 6px 8px;
                         border-radius: 4px;

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -12,7 +12,7 @@ import { update3DScene } from '../scene3d/scene3d-update.js';
 import { init3D, renderer as renderer3d, camera as camera3d, controls as controls3d, scene as scene3d } from '../scene3d/scene3d-core.js';
 // --- DEĞİŞİKLİK SONU ---
 import { createWallPanel } from '../wall/wall-panel.js';
-import { createFloorPanel, showFloorPanel } from '../floor/floor-panel.js';
+import { createFloorPanel, showFloorPanel, renderMiniPanel } from '../floor/floor-panel.js';
 import { initializeDefaultFloors } from '../floor/floor-handler.js';
 /*
 // --- RESİM ÇERÇEVESİ KODU ---
@@ -305,7 +305,17 @@ export function setState(newState) {
     if (newState.isDragging === false) {
         newState.draggedRoomInfo = [];
     }
+
+    // Walls veya doors değiştiğinde mini paneli güncelle
+    const wallsChanged = newState.walls !== undefined && newState.walls !== state.walls;
+    const doorsChanged = newState.doors !== undefined && newState.doors !== state.doors;
+
     state = { ...state, ...newState };
+
+    // Kat içerik durumu değiştiyse mini panel'i güncelle
+    if (wallsChanged || doorsChanged) {
+        renderMiniPanel();
+    }
 }
 
 export const dom = {


### PR DESCRIPTION
1. Auto-update mini panel when drawing:
   - setState now detects walls/doors changes
   - Automatically calls renderMiniPanel() on content change
   - Content dots appear immediately when drawing

2. Right-aligned status dots:
   - Dots now positioned at top-right corner (absolute)
   - All dots align vertically in column
   - Position: top: 4px, right: 4px
   - Container changed to position: relative
   - Active: dark blue dot, Passive: gray dot