### PR TITLE
feat: Add floor height and stairs settings to settings panel

### DIFF
--- a/architectural-objects/stairs.js
+++ b/architectural-objects/stairs.js
@@ -136,7 +136,7 @@ export function createStairs(centerX, centerY, width, height, rotation, isLandin
         topElevation: defaultTopElevation,     // Hesaplanan üst kot
         connectedStairId: connectedStairId,    // Bağlantı ID'si
         isLanding: isLanding, // Parametreden gelen değeri ata
-        showRailing: !isLanding // **** DEĞİŞİKLİK BURADA: Varsayılan olarak korkuluk yok ****
+        showRailing: isLanding ? false : state.stairSettings.showRailing // Sahanlıksa false, normal merdivense ayarlardan al
     };
 
     // Basamak sayısını hesapla (sahanlık değilse)
@@ -157,8 +157,9 @@ export function recalculateStepCount(stair) {
         return;
     }
     const totalRun = stair.width; // Merdiven uzunluğu
-    const minStepRun = 25; // Minimum basamak derinliği
-    const maxStepRun = 30; // Maksimum basamak derinliği
+
+    // Basamak derinliği aralığını ayarlardan al
+    const [minStepRun, maxStepRun] = state.stairSettings.stepDepthRange.split('-').map(val => parseInt(val, 10));
 
     // Geçersiz uzunluk veya yükseklik durumunda 1 basamak ata
     const totalRise = stair.topElevation - stair.bottomElevation;

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -299,6 +299,13 @@ export let state = {
     currentFloor: null, // Aktif kat
     defaultFloorHeight: 270, // Varsayılan kat yüksekliği (cm)
     // --- KAT YÖNETİMİ SONU ---
+
+    // --- MERDİVEN AYARLARI ---
+    stairSettings: {
+        showRailing: false, // Varsayılan korkuluk durumu
+        stepDepthRange: "25-35" // Varsayılan basamak derinliği aralığı
+    }
+    // --- MERDİVEN AYARLARI SONU ---
 };
 
 export function setState(newState) {
@@ -348,18 +355,21 @@ export const dom = {
         grid: document.getElementById("tab-btn-grid"),
         snap: document.getElementById("tab-btn-snap"),
         dimension: document.getElementById("tab-btn-dimension"),
+        stairs: document.getElementById("tab-btn-stairs"),
     },
     tabPanes: {
         general: document.getElementById("tab-pane-general"),
         grid: document.getElementById("tab-pane-grid"),
         snap: document.getElementById("tab-pane-snap"),
         dimension: document.getElementById("tab-pane-dimension"),
+        stairs: document.getElementById("tab-pane-stairs"),
     },
     borderPicker: document.getElementById("borderPicker"),
     roomPicker: document.getElementById("roomPicker"),
     lineThicknessInput: document.getElementById("line-thickness"),
     wallThicknessInput: document.getElementById("wall-thickness"), // YENİ EKLENDİ
     drawingAngleInput: document.getElementById("drawing-angle"), // YENİ EKLENDİ
+    defaultFloorHeightInput: document.getElementById("default-floor-height"), // YENİ EKLENDİ
     gridVisibleInput: document.getElementById("grid-visible"),
     gridColorInput: document.getElementById("grid-color"),
     gridWeightInput: document.getElementById("grid-weight"),
@@ -374,6 +384,8 @@ export const dom = {
     dimensionDefaultViewSelect: document.getElementById("dimension-default-view"),
     dimensionShowAreaSelect: document.getElementById("dimension-show-area"),
     dimensionShowOuterSelect: document.getElementById("dimension-show-outer"),
+    stairsShowRailingInput: document.getElementById("stairs-show-railing"), // YENİ EKLENDİ
+    stairsStepDepthSelect: document.getElementById("stairs-step-depth"), // YENİ EKLENDİ
     roomNamePopup: document.getElementById("room-name-popup"),
     roomNameSelect: document.getElementById("room-name-select"),
     roomNameInput: document.getElementById("room-name-input"),

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -20,6 +20,7 @@ export function initializeSettings() {
     dom.lineThicknessInput.value = state.lineThickness;
     dom.wallThicknessInput.value = state.wallThickness;
     dom.drawingAngleInput.value = state.drawingAngle;
+    dom.defaultFloorHeightInput.value = state.defaultFloorHeight; // YENİ EKLENDİ
     dom.gridVisibleInput.checked = state.gridOptions.visible;
     dom.gridColorInput.value = state.gridOptions.color;
     dom.gridWeightInput.value = state.gridOptions.weight;
@@ -34,6 +35,8 @@ export function initializeSettings() {
     dom.dimensionDefaultViewSelect.value = state.dimensionOptions.defaultView;
     dom.dimensionShowAreaSelect.value = state.dimensionOptions.showArea;
     dom.dimensionShowOuterSelect.value = state.dimensionOptions.showOuter;
+    dom.stairsShowRailingInput.checked = state.stairSettings.showRailing; // YENİ EKLENDİ
+    dom.stairsStepDepthSelect.value = state.stairSettings.stepDepthRange; // YENİ EKLENDİ
 }
 
 function openTab(tabName) {
@@ -553,6 +556,9 @@ export function setupUIListeners() {
     dom.dimensionDefaultViewSelect.addEventListener("change", (e) => { const value = parseInt(e.target.value, 10); if (!isNaN(value)) { state.dimensionOptions.defaultView = value; setState({ dimensionMode: value }); } });
     dom.dimensionShowAreaSelect.addEventListener("change", (e) => { const value = parseInt(e.target.value, 10); if (!isNaN(value)) state.dimensionOptions.showArea = value; });
     dom.dimensionShowOuterSelect.addEventListener("change", (e) => { const value = parseInt(e.target.value, 10); if (!isNaN(value)) state.dimensionOptions.showOuter = value; });
+    dom.defaultFloorHeightInput.addEventListener("input", (e) => { const value = parseInt(e.target.value, 10); if (!isNaN(value)) setState({ defaultFloorHeight: value }); }); // YENİ EKLENDİ
+    dom.stairsShowRailingInput.addEventListener("change", (e) => { state.stairSettings.showRailing = e.target.checked; }); // YENİ EKLENDİ
+    dom.stairsStepDepthSelect.addEventListener("change", (e) => { state.stairSettings.stepDepthRange = e.target.value; }); // YENİ EKLENDİ
     dom.roomNameSelect.addEventListener('click', confirmRoomNameChange);
     dom.roomNameSelect.addEventListener('dblclick', confirmRoomNameChange);
     dom.roomNameInput.addEventListener('input', filterRoomNameList);

--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
  <button class="tab-btn" id="tab-btn-grid">Grid</button>
  <button class="tab-btn" id="tab-btn-snap">Snap</button>
  <button class="tab-btn" id="tab-btn-dimension">Ölçülendirme</button>
+ <button class="tab-btn" id="tab-btn-stairs">Merdiven</button>
  </div>
  <div class="tab-content">
  <div class="tab-pane active" id="tab-pane-general">
@@ -111,6 +112,10 @@
   <div class="setting-control">
   <label for="drawing-angle">Çizim Açısı (°)</label>
   <input type="number" id="drawing-angle" min="0" max="180" step="1" />
+  </div>
+  <div class="setting-control">
+  <label for="default-floor-height">Kat Yüksekliği (cm)</label>
+  <input type="number" id="default-floor-height" min="100" max="500" step="10" />
   </div>
   </div>
  <div class="tab-pane" id="tab-pane-grid">
@@ -187,6 +192,24 @@
     <option value="2">Sadece Özet Görünümde</option>
     <option value="3">Sadece Detaylı Görünümde</option>
    </select>
+  </div>
+ </div>
+ <div class="tab-pane" id="tab-pane-stairs">
+  <div class="setting-control">
+  <label for="stairs-show-railing">Korkuluk Göster</label>
+  <input type="checkbox" id="stairs-show-railing" />
+  </div>
+  <div class="setting-control">
+  <label for="stairs-step-depth">Basamak Derinliği</label>
+  <select id="stairs-step-depth">
+   <option value="20-30">20-30 cm</option>
+   <option value="25-35">25-35 cm</option>
+   <option value="30-40">30-40 cm</option>
+   <option value="35-45">35-45 cm</option>
+   <option value="40-50">40-50 cm</option>
+   <option value="45-55">45-55 cm</option>
+   <option value="50-60">50-60 cm</option>
+  </select>
   </div>
  </div>
  </div>


### PR DESCRIPTION
- Added "Kat Yüksekliği" (Floor Height) input to GENEL tab
  - Default value: 270 cm
  - Range: 100-500 cm with 10 cm steps
  - Controls the default floor height for the project

- Added new MERDİVEN (Stairs) tab to settings panel with:
  - "Korkuluk Göster" checkbox for default railing visibility
  - "Basamak Derinliği" combobox for step depth range selection Options: 20-30, 25-35, 30-40, 35-45, 40-50, 45-55, 50-60 cm

- Updated state management to include stair settings
- Modified stair creation to use default settings from state
- Updated recalculateStepCount to dynamically use step depth range
- Added DOM references and event listeners for all new controls