### PR TITLE
fix: Improve settings panel UI and add close functionality

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -321,6 +321,12 @@ function onKeyDown(e) {
     if (e.key === "Escape" || e.code === "Space") {
         if (e.code === "Space") e.preventDefault();
 
+        // Settings popup açıksa kapat
+        if (dom.settingsPopup.style.display === 'block') {
+            dom.settingsPopup.style.display = 'none';
+            return;
+        }
+
         // Mahal popup kontrolü ZATEN YUKARIDA yapıldığı için burada tekrar gerekmez.
 
         if (state.isEditingLength) cancelLengthEdit(); // Length input açıksa kapatır

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -219,22 +219,56 @@ canvas {
     padding: 15px;
     z-index: 100;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
-    width: 280px;
+    width: 380px;
+}
+
+.settings-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 15px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #5f6368;
+}
+
+.settings-title {
+    font-size: 18px;
+    font-weight: bold;
+    color: #e8eaed;
+}
+
+.settings-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.btn-small {
+    padding: 4px 8px;
+    font-size: 12px;
+}
+
+.btn-small svg {
+    width: 14px;
+    height: 14px;
 }
 
 .tab-bar {
     display: flex;
+    flex-wrap: wrap;
     border-bottom: 1px solid #5f6368;
     margin-bottom: 15px;
+    gap: 4px;
 }
 
 .tab-btn {
-    padding: 8px 16px;
+    padding: 8px 12px;
     cursor: pointer;
     border: none;
     background-color: transparent;
     color: #9aa0a6;
     border-bottom: 2px solid transparent;
+    font-size: 13px;
 }
 
 .tab-btn.active {

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -534,8 +534,20 @@ function confirmStairChange() {
 
 // --- GÜNCELLENMİŞ setupUIListeners (Sahanlık kotu mantığını düzelten) ---
 export function setupUIListeners() {
-    dom.settingsBtn.addEventListener("click", () => { dom.settingsPopup.style.display = 'block'; });
+    dom.settingsBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        dom.settingsPopup.style.display = 'block';
+    });
     dom.closeSettingsPopupBtn.addEventListener("click", () => { dom.settingsPopup.style.display = 'none'; });
+
+    // Ayarlar popup'ı dışında bir yere tıklanınca kapat
+    document.addEventListener("click", (e) => {
+        if (dom.settingsPopup.style.display === 'block' &&
+            !dom.settingsPopup.contains(e.target) &&
+            e.target !== dom.settingsBtn) {
+            dom.settingsPopup.style.display = 'none';
+        }
+    });
     Object.keys(dom.tabButtons).forEach(key => { dom.tabButtons[key].addEventListener('click', () => openTab(key)); });
     dom.borderPicker.addEventListener("input", (e) => setState({ wallBorderColor: e.target.value }));
     dom.roomPicker.addEventListener("input", (e) => setState({ roomFillColor: e.target.value }));

--- a/index.html
+++ b/index.html
@@ -69,14 +69,6 @@
  <svg viewBox="0 0 24 24"><path d="M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-7l-2-2H5a2 2 0 0 0-2 2z"></path></svg>
  Aç
  </button>
- <button id="b3d" class="btn">
-  <svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
-  3D Göster
- </button>
- <button id="bFirstPerson" class="btn" style="display: none;">
-  <!-- <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M12 1v6m0 6v6M5.6 5.6l4.2 4.2m4.2 4.2l4.2 4.2M1 12h6m6 0h6M5.6 18.4l4.2-4.2m4.2-4.2l4.2-4.2"></path></svg> -->
-  FPS Kamera
- </button>
  <button id="bAssignNames" class="btn">Mahal Tanımla</button>
 <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none"/>
 </div>
@@ -84,6 +76,18 @@
 <button id="settings-btn" class="btn">Ayarlar</button>
 
 <div id="settings-popup">
+ <div class="settings-header">
+  <span class="settings-title">Ayarlar</span>
+  <div class="settings-actions">
+   <button id="b3d" class="btn btn-small">
+    <svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+    3D Göster
+   </button>
+   <button id="bFirstPerson" class="btn btn-small" style="display: none;">
+    FPS Kamera
+   </button>
+  </div>
+ </div>
  <div class="tab-bar">
  <button class="tab-btn active" id="tab-btn-general">Genel</button>
  <button class="tab-btn" id="tab-btn-grid">Grid</button>


### PR DESCRIPTION
- Fix ladder (Merdiven) tab visibility by increasing popup width from 280px to 380px
- Move 3D Göster and FPS Göster buttons to settings panel header (right side)
- Add settings header with title and action buttons
- Enable tab wrapping to ensure all tabs are visible
- Add ESC key support to close settings panel
- Add click-outside functionality to close settings panel
- Improve tab button styling with smaller padding and font size