### PR TITLE
refactor: 3D buton ve FPS kamera yerleşimi, bug düzeltmeleri

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -504,6 +504,12 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
     white-space: nowrap;
 }
 
+/* Stats overlay içindeki butonlar tıklanabilir olmalı */
+#stats-overlay .btn,
+#stats-overlay button {
+    pointer-events: auto;
+}
+
 #fps-display {
     color: #87CEEB;
     font-weight: 600;

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -198,9 +198,19 @@ export function setSplitRatio(ratio) {
 
     // Ratio 0 ise 3D panelini kapat
     if (ratio === 0) {
+        // Önce 2D panelini tam ekran yap
+        p2dPanel.style.flex = '1 1 100%';
+        p3dPanel.style.flex = '0 0 0';
+
+        // Sonra 3D'yi kapat
         if (dom.mainContainer.classList.contains('show-3d')) {
             toggle3DView(); // 3D'yi kapat
         }
+
+        // resize'ı çağır
+        setTimeout(() => {
+            resize();
+        }, 10);
         return;
     }
 

--- a/index.html
+++ b/index.html
@@ -69,20 +69,15 @@
  <svg viewBox="0 0 24 24"><path d="M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-7l-2-2H5a2 2 0 0 0-2 2z"></path></svg>
  Aç
  </button>
+ <button id="b3d" class="btn">
+ <svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
+ 3D Göster
+ </button>
  <button id="bAssignNames" class="btn">Mahal Tanımla</button>
 <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none"/>
 </div>
 
 <button id="settings-btn" class="btn">Ayarlar</button>
-
-<button id="b3d" class="btn">
- <svg viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>
- 3D Göster
-</button>
-
-<button id="bFirstPerson" class="btn" style="display: none;">
- FPS Kamera
-</button>
 
 <div id="settings-popup">
  <div class="settings-header">
@@ -277,7 +272,8 @@
     <canvas id="c3d"></canvas>
     <!-- 3D Overlay: FPS ve Kamera Konumu (Sol Üst) -->
     <div id="stats-overlay" style="display: none;">
-        <span id="fps-display">FPS: 60</span>
+        <button id="bFirstPerson" class="btn">FPS Kamera</button>
+        <span id="fps-display" style="display: none;">FPS: 60</span>
         <span id="camera-coords" style="display: none;">Kamera: x: 0 cm, y: 0 cm, z: 0 cm</span>
     </div>
     <!-- 3D Overlay: Ekran Bölme Oranı Butonları (Sağ Üst) -->


### PR DESCRIPTION
- 3D Göster butonu soldaki butonların altına taşındı (Mahal Tanımla'nın üstüne)
- FPS Kamera butonu 3D ekranın içine (stats-overlay) taşındı
- FPS değeri gizlendi (display: none)
- Bug fix: 3D %100'den %0'a geçişte 2D sahne görünmeme sorunu düzeltildi
- Bug fix: stats-overlay içindeki butonlar için pointer-events: auto eklendi