### PR TITLE
Add 3D View button to screen corner

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -401,6 +401,7 @@ export const dom = {
     stairShowRailingCheckbox: document.getElementById("stair-show-railing"), // <-- YENİ SATIR BURAYA EKLENECEK
     confirmStairPopupButton: document.getElementById("confirm-stair-popup"),
     cancelStairPopupButton: document.getElementById("cancel-stair-popup"),
+    b3d: document.getElementById("b3d"), // 3D Göster butonu
 };
 
 // GÜNCELLENMİŞ setMode fonksiyonu

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -605,3 +605,39 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
     width: 100%;
     height: 100%;
 }
+
+/* 3D Göster Butonu - 2D Ekranın Sağ Üst Köşesi */
+.btn-show-3d {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 100;
+    padding: 8px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    background: #3c4043;
+    border: 1px solid #5f6368;
+    color: #e8eaed;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.btn-show-3d:hover {
+    background: #5f6368;
+    border-color: #87CEEB;
+    box-shadow: 0 2px 8px rgba(135, 206, 235, 0.3);
+}
+
+.btn-show-3d.active {
+    background: #8ab4f8;
+    color: #202124;
+    border-color: #8ab4f8;
+    font-weight: 600;
+}
+
+/* 3D açıkken butonu gizle */
+.main.show-3d .btn-show-3d {
+    display: none;
+}

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -804,5 +804,10 @@ export function setupUIListeners() {
         // NOT: Pointer lock kullanmıyoruz - klavye kontrolleri yeterli
         // Mouse serbest kalıyor, kullanıcı FPS modunda bile mouse ile UI'ya erişebilir
     });
+
+    // 3D GÖSTER BUTONU LISTENER'I
+    dom.b3d.addEventListener('click', () => {
+        toggle3DView();
+    });
 }
 // --- setupUIListeners Sonu ---

--- a/index.html
+++ b/index.html
@@ -267,6 +267,7 @@
 </div>
 <canvas id="c2d"></canvas>
 <input type="text" id="length-input" />
+<button id="b3d" class="btn btn-show-3d">3D Göster</button>
 </div>
 <div id="splitter"></div>
 <div id="p3d" class="panel">


### PR DESCRIPTION
2D ekranın sağ üst köşesine kullanıcıların 3D görünümü açabilmesi için "3D Göster" butonu eklendi. Buton 3D açıkken otomatik olarak gizleniyor.

Değişiklikler:
- index.html: 2D paneline b3d butonu eklendi
- style.css: Butonun sağ üst köşe stilleri ve gizleme kuralı
- main.js: dom nesnesine b3d referansı eklendi
- ui.js: Butona event listener eklendi (toggle3DView çağrısı)