### PR TITLE
style: 3D Göster butonunu FPS kamera boyutlarına küçült

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -612,9 +612,11 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
     top: 10px;
     right: 10px;
     z-index: 100;
-    padding: 8px 16px;
-    font-size: 14px;
+    padding: 5px 8px;
+    font-size: 11px;
     font-weight: 500;
+    min-width: auto;
+    white-space: nowrap;
     background: #3c4043;
     border: 1px solid #5f6368;
     color: #e8eaed;


### PR DESCRIPTION
3D Göster butonunun boyutları FPS Kamera butonu ile aynı hale getirildi:
- padding: 8px 16px -> 5px 8px
- font-size: 14px -> 11px
- min-width: auto ve white-space: nowrap eklendi

Buton artık daha compact ve modern görünüyor.