### PR TITLE
refactor: Ayarlar paneli tasarım iyileştirmeleri

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -271,7 +271,7 @@ canvas {
 }
 
 .tab-btn-vertical {
-    padding: 6px 10px;
+    padding: 8px 10px; /* Arttırıldı: 6px -> 8px */
     cursor: pointer;
     border: none;
     background-color: transparent;
@@ -280,6 +280,9 @@ canvas {
     font-size: 11px;
     text-align: left;
     transition: all 0.2s;
+    display: flex;
+    align-items: flex-end; /* Alta dayandı */
+    font-weight: 500; /* Daha belirgin */
 }
 
 .tab-btn-vertical:hover {
@@ -290,6 +293,7 @@ canvas {
     color: #8ab4f8;
     border-left-color: #8ab4f8;
     background-color: rgba(138, 180, 248, 0.1);
+    font-weight: 600; /* Aktif tab daha belirgin */
 }
 
 .tab-content-vertical {
@@ -311,8 +315,8 @@ canvas {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 8px;
-    gap: 8px;
+    margin-bottom: 6px; /* Azaltıldı: 8px -> 6px */
+    gap: 4px; /* Azaltıldı: 8px -> 4px - etiket ve seçenekler yakınlaştı */
 }
 
 .setting-control label {

--- a/index.html
+++ b/index.html
@@ -74,7 +74,10 @@
 </div>
 
 <button id="settings-btn" class="btn">
- <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"></circle><path d="M12 1v6m0 6v6m0-6h6m-6 0H6m12.364-7.364l-4.243 4.243m0 6.243l4.243 4.243M7.879 7.879l4.243 4.243m-4.243 4.243l4.243-4.243" stroke-width="1.5"></path></svg>
+ <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="3"></circle>
+  <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"></path>
+ </svg>
  Ayarlar
 </button>
 


### PR DESCRIPTION
Ayarlar butonu ve paneli için tasarım güncellemeleri:

1. Ayarlar İkonu (index.html):
   - Önceki karmaşık ikonu basit settings ikonuna çevrildi
   - Daha standart ve anlaşılır görünüm

2. Tab İsimleri (style.css):
   - padding: 6px -> 8px (daha fazla alan)
   - display: flex ve align-items: flex-end eklendi (alta dayandı)
   - font-weight: 500 eklendi (daha belirgin)
   - Aktif tab font-weight: 600 (daha belirgin vurgu)

3. Ayar Kontrolleri (style.css):
   - margin-bottom: 8px -> 6px (daha compact)
   - gap: 8px -> 4px (etiket ve seçenekler birbirine yakın)

Ayarlar paneli artık daha düzenli ve kullanımı kolay.