### PR TITLE
refactor: FPS butonu ve koordinatları yeniden konumlandır

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -533,52 +533,24 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
     color: #8ab4f8;
 }
 
-/* 3D Overlay: FPS ve Kamera Koordinatları - Sol Üst */
-#stats-overlay {
-    position: absolute;
-    top: 10px;
-    left: 10px;
-    z-index: 100;
-    display: flex;
-    gap: 12px;
-    align-items: center;
-    background: rgba(30, 31, 32, 0.85);
+/* 3D Overlay: Kamera Koordinatları - split-ratio-buttons içinde */
+#split-ratio-buttons #camera-coords {
+    background: rgba(30, 31, 32, 0.9);
     padding: 6px 10px;
-    border-radius: 6px;
+    border-radius: 4px;
     border: 1px solid rgba(100, 149, 237, 0.3);
-    font-family: 'Consolas', 'Monaco', monospace;
-    font-size: 11px;
-    color: #e8eaed;
-    pointer-events: none;
-    backdrop-filter: blur(4px);
-}
-
-#stats-overlay span {
-    white-space: nowrap;
-}
-
-/* Stats overlay içindeki butonlar tıklanabilir olmalı */
-#stats-overlay .btn,
-#stats-overlay button {
-    pointer-events: auto;
-}
-
-/* Stats overlay içindeki FPS Kamera butonu özel stili */
-#stats-overlay #bFirstPerson {
-    padding: 5px 8px;
-    font-size: 11px;
-    min-width: auto;
-    white-space: nowrap;
-}
-
-#fps-display {
-    color: #87CEEB;
-    font-weight: 600;
-}
-
-#camera-coords {
     color: #a8dadc;
     font-size: 11px;
+    font-family: 'Consolas', 'Monaco', monospace;
+    white-space: nowrap;
+    margin-right: 4px;
+}
+
+/* FPS Kamera butonu aktif olduğunda özel stil */
+#bFirstPerson.active {
+    background: rgba(100, 149, 237, 0.3);
+    border-color: #87CEEB;
+    box-shadow: 0 0 8px rgba(135, 206, 235, 0.4);
 }
 
 /* 3D Overlay: Ekran Bölme Oranı Butonları - Daha Compact */

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -160,19 +160,15 @@ export function toggle3DView() {
     if (dom.mainContainer.classList.contains('show-3d')) {
         setMode("select"); // 3D açılırken modu "select" yap
 
-        // Overlay'leri göster (FPS Kamera butonu stats-overlay içinde olduğu için otomatik görünür)
-        const statsOverlay = document.getElementById('stats-overlay');
+        // Split ratio butonlarını göster
         const splitButtons = document.getElementById('split-ratio-buttons');
-        if (statsOverlay) statsOverlay.style.display = 'flex';
         if (splitButtons) splitButtons.style.display = 'flex';
 
         // Varsayılan split ratio'yu ayarla (25%)
         setSplitRatio(25);
     } else {
-        // Overlay'leri gizle
-        const statsOverlay = document.getElementById('stats-overlay');
+        // Split ratio butonlarını gizle
         const splitButtons = document.getElementById('split-ratio-buttons');
-        if (statsOverlay) statsOverlay.style.display = 'none';
         if (splitButtons) splitButtons.style.display = 'none';
     }
 
@@ -226,14 +222,12 @@ export function setSplitRatio(ratio) {
 
     // 3D açık değilse, önce aç sonra ratio'yu tekrar ayarla
     if (!dom.mainContainer.classList.contains('show-3d')) {
-        // Overlay'leri ve 3D'yi göster
+        // Split ratio butonlarını ve 3D'yi göster
         dom.mainContainer.classList.add('show-3d');
         dom.b3d.classList.add('active');
         setMode("select");
 
-        const statsOverlay = document.getElementById('stats-overlay');
         const splitButtons = document.getElementById('split-ratio-buttons');
-        if (statsOverlay) statsOverlay.style.display = 'flex';
         if (splitButtons) splitButtons.style.display = 'flex';
     }
 

--- a/index.html
+++ b/index.html
@@ -282,13 +282,18 @@
 <div id="splitter"></div>
 <div id="p3d" class="panel">
     <canvas id="c3d"></canvas>
-    <!-- 3D Overlay: FPS Kamera ve Koordinatlar (Sol Üst) -->
-    <div id="stats-overlay" style="display: none;">
-        <button id="bFirstPerson" class="btn">FPS Kamera</button>
-        <span id="camera-coords" style="display: none;">x: 0, y: 0, z: 0</span>
-    </div>
-    <!-- 3D Overlay: Ekran Bölme Oranı Butonları (Sağ Üst) -->
+    <!-- 3D Overlay: Ekran Bölme Oranı Butonları ve FPS Kamera (Sağ Üst) -->
     <div id="split-ratio-buttons" style="display: none;">
+        <!-- Koordinatlar (en solda) -->
+        <span id="camera-coords" style="display: none;">x: 0, y: 0, z: 0</span>
+        <!-- FPS Kamera butonu -->
+        <button id="bFirstPerson" class="split-btn" title="FPS Kamera">
+            <svg viewBox="0 0 24 24" width="24" height="24">
+                <circle cx="12" cy="12" r="3" fill="#8ab4f8" stroke="#666" stroke-width="1"/>
+                <path d="M12 5 L12 9 M12 15 L12 19 M5 12 L9 12 M15 12 L19 12" stroke="#8ab4f8" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+        </button>
+        <!-- Ekran bölme butonları -->
         <button id="split-100" class="split-btn" data-ratio="100" title="Tam Ekran 3D">
             <svg viewBox="0 0 24 24" width="24" height="24">
                 <rect x="2" y="2" width="20" height="20" fill="#87CEEB" stroke="#666" stroke-width="1"/>


### PR DESCRIPTION
- FPS Kamera butonu artık split-ratio-buttons içinde
- FPS butonu 3D Göster butonları ile aynı boyutta (28x28px)
- Koordinat verileri FPS butonunun solunda konumlandırıldı
- stats-overlay kaldırıldı, tüm kontroller tek bir panel altında
- FPS butonu artık %75-50 butonlarının solunda