### PR TITLE
feat: Sol menü yatay düzenlendi ve kat paneli iyileştirmeleri

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -98,15 +98,13 @@ canvas {
     left: 10px;
     z-index: 10;
     display: flex;
-    /* flex-wrap: wrap; */ /* DEĞİŞTİ */
-    flex-direction: column; /* EKLENDİ */
-    width: 125px; /* DARALTILDI: 140px -> 125px */
-    gap: 10px; /* Artırıldı: 6px -> 10px */
-    /* align-items: center; */ /* SİLİNDİ */
+    flex-direction: row; /* Yatay düzen */
+    width: auto; /* Otomatik genişlik */
+    gap: 8px; /* Butonlar arası boşluk */
     background: rgba(42, 43, 44, 0.9);
     border: 1px solid #5f6368;
     border-radius: 8px;
-    padding: 8px;
+    padding: 6px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     backdrop-filter: blur(4px);
     box-sizing: border-box;
@@ -125,20 +123,23 @@ canvas {
     gap: 8px;
 }
 
-/* YENİ KURAL: Sadece UI içindeki butonları 100% genişlik yap */
+/* YENİ KURAL: UI içindeki butonları sadece ikon göster */
 #ui .btn {
-    width: 100%; /* EKLENDİ */
-    box-sizing: border-box; /* EKLENDİ */
-    justify-content: flex-start; /* EKLENDİ */
-    padding: 6px 8px; /* Daraltıldı: 7px 10px -> 6px 8px */
-    font-size: 14px; /* %25 büyütüldü: 11px -> 14px */
-    gap: 6px; /* Daraltıldı: 8px -> 6px */
+    width: auto; /* Otomatik genişlik */
+    min-width: 36px; /* Minimum genişlik */
+    height: 36px; /* Sabit yükseklik */
+    box-sizing: border-box;
+    justify-content: center; /* İkonu ortala */
+    align-items: center; /* İkonu ortala */
+    padding: 8px; /* Eşit padding */
+    font-size: 0; /* Metni gizle */
+    gap: 0; /* Gap gerekmez */
 }
 
 /* UI içindeki buton iconları */
 #ui .btn svg {
-    width: 18px; /* %25 büyütüldü: 14px -> 18px */
-    height: 18px; /* %25 büyütüldü: 14px -> 18px */
+    width: 20px; /* Biraz daha büyük */
+    height: 20px;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -11,27 +11,27 @@
 <div class="main" id="main-container">
 <div id="p2d" class="panel">
 <div id="ui">
-<button id="bSel" class="btn">
+<button id="bSel" class="btn" title="Seç">
  <svg viewBox="0 0 24 24"><path d="M3 3l7.07 16.97 2.51-7.39 7.39-2.51L3 3z" stroke-width="1.5"></path></svg>
  Seç
  </button>
- <button id="bWall" class="btn">
+ <button id="bWall" class="btn" title="Duvar">
   <svg viewBox="0 0 24 24"><line x1="3" y1="12" x2="21" y2="12" stroke-width="4" stroke-linecap="round"></line></svg>
   Duvar
  </button>
- <button id="bRoom" class="btn">
+ <button id="bRoom" class="btn" title="Oda">
   <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect></svg>
   Oda
  </button>
- <button id="bDoor" class="btn">
+ <button id="bDoor" class="btn" title="Kapı">
   <svg viewBox="0 0 24 24"><path d="M18 20V6a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v14"></path><line x1="10" y1="12" x2="10" y2="12" stroke-width="3" stroke-linecap="round"></line></svg>
   Kapı
  </button>
- <button id="bWindow" class="btn">
+ <button id="bWindow" class="btn" title="Pencere">
   <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="1" ry="1" stroke-width="1.5"></rect><line x1="12" y1="3" x2="12" y2="21" stroke-width="1.5"></line><line x1="3" y1="12" x2="21" y2="12" stroke-width="1.5"></line></svg>
   Pencere
  </button>
- <button id="bColumn" class="btn">
+ <button id="bColumn" class="btn" title="Kolon">
   <svg viewBox="0 0 24 24">
     <rect x="8" y="4" width="8" height="2" stroke-width="1.5" fill="currentColor"/>
     <line x1="10" y1="6" x2="10" y2="18" stroke-width="1.5"/>
@@ -40,13 +40,13 @@
   </svg>
   Kolon
 </button>
-<button id="bBeam" class="btn">
+<button id="bBeam" class="btn" title="Kiriş">
   <svg viewBox="0 0 24 24" stroke="currentColor" fill="none">
     <rect x="3" y="10" width="18" height="4" stroke-width="1.5"/>
   </svg>
   Kiriş
 </button>
-<button id="bStairs" class="btn">
+<button id="bStairs" class="btn" title="Merdiven">
   <svg viewBox="0 0 24 24" stroke="currentColor" fill="none">
     <line x1="6" y1="19" x2="6" y2="5" stroke-width="1.5"/>
     <line x1="18" y1="19" x2="18" y2="5" stroke-width="1.5"/>
@@ -56,20 +56,20 @@
   </svg>
   Merdiven
 </button>
-<button id="bSymmetry" class="btn"> <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+<button id="bSymmetry" class="btn" title="Simetri"> <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
         <path d="M12 3v18"/> <path d="M8 7l-5 5 5 5"/> <path d="M16 7l5 5-5 5"/> <path d="M3 12h5"/> <path d="M16 12h5"/> </svg>
     Simetri
  </button>
 
-<button id="bSave" class="btn">
+<button id="bSave" class="btn" title="Kaydet">
  <svg viewBox="0 0 24 24"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path><polyline points="17 21 17 13 7 13 7 21"></polyline><polyline points="7 3 7 8 15 8"></polyline></svg>
  Kaydet
  </button>
- <button id="bOpen" class="btn">
+ <button id="bOpen" class="btn" title="Aç">
  <svg viewBox="0 0 24 24"><path d="M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-7l-2-2H5a2 2 0 0 0-2 2z"></path></svg>
  Aç
  </button>
- <button id="bAssignNames" class="btn">Mahal Tanımla</button>
+ <button id="bAssignNames" class="btn" title="Mahal Tanımla">Mahal Tanımla</button>
 <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none"/>
 </div>
 


### PR DESCRIPTION
- Sol menü (#ui) yatay düzene geçirildi (flex-direction: row)
- Butonlardan metinler kaldırıldı, sadece ikonlar gösteriliyor
- Metinler title attribute ile tooltip olarak korundu
- Buton boyutları 36x36px olarak ayarlandı
- Kat panelinde kaydırma okları (<>) her zaman görünür
- Mouse wheel ile yatay kaydırma desteği eklendi
- Sol menü ile kat paneli arasında minimum 16px boşluk kontrolü
- Çakışma durumunda kat paneli otomatik sağa kayıyor
- Window resize'da pozisyon kontrolü yapılıyor