### PR TITLE
fix: Kat paneli ve sol menü iyileştirmeleri

### DIFF
--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -232,7 +232,7 @@ export function renderMiniPanel() {
                         font-size: 11px;
                         font-weight: bold;
                         text-align: center;
-                        min-width: 36px;
+                        min-width: 40px;
                         cursor: pointer;
                         transition: all 0.2s;">
                 ${shortName}${dotHtml}
@@ -252,12 +252,6 @@ export function renderMiniPanel() {
                 setState({ currentFloor: floor });
                 renderMiniPanel();
             }
-        });
-
-        // Çift tıklama - detaylı panel aç
-        item.addEventListener('dblclick', (e) => {
-            e.stopPropagation();
-            showDetailPanel();
         });
 
         // Hover efekti

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -94,8 +94,8 @@ canvas {
 
 #ui {
     position: absolute;
-    top: 10px;
-    left: 10px;
+    top: 0;
+    left: 0;
     z-index: 10;
     display: flex;
     flex-direction: row; /* Yatay düzen */
@@ -103,7 +103,8 @@ canvas {
     gap: 8px; /* Butonlar arası boşluk */
     background: rgba(42, 43, 44, 0.9);
     border: 1px solid #5f6368;
-    border-radius: 8px;
+    border-top: none; /* Tavanda border yok */
+    border-radius: 0 0 8px 8px; /* Sadece alt köşeler yuvarlanmış */
     padding: 6px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     backdrop-filter: blur(4px);


### PR DESCRIPTION
- Kat isimlerinin min-width değeri 36px'den 40px'e artırıldı (10+ katlar için)
- Kat isimlerine çift tıklayarak panel açma özelliği kaldırıldı
- Sol menü (#ui) tavana dayalı yerleştirildi (top: 0, left: 0)
- Sol menü border-radius sadece alt köşelerde (0 0 8px 8px)
- Sol menü border-top kaldırıldı