### PR TITLE
fix: Sol menü ve kat paneli son iyileştirmeler

### DIFF
--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -277,29 +277,30 @@ function adjustFloorPanelPosition() {
     if (!uiMenu || !miniPanel) return;
 
     const uiRect = uiMenu.getBoundingClientRect();
-    const panelRect = miniPanel.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
 
     const minGap = 16; // Minimum boşluk
     const uiRight = uiRect.right; // Sol menünün sağ kenarı
-    const panelLeft = panelRect.left; // Kat panelinin sol kenarı
 
-    const currentGap = panelLeft - uiRight;
+    // Önce paneli merkeze al
+    miniPanel.style.left = '50%';
+    miniPanel.style.transform = 'translateX(-50%)';
 
-    if (currentGap < minGap) {
-        // Çakışma var, kat panelini sağa kaydır
-        const neededShift = minGap - currentGap;
-        const currentLeft = parseFloat(miniPanel.style.left) || 50; // %50
-        const panelWidth = panelRect.width;
-        const viewportWidth = window.innerWidth;
+    // Panelin güncel pozisyonunu kontrol et
+    const panelRect = miniPanel.getBoundingClientRect();
+    const panelLeft = panelRect.left;
+    const panelWidth = panelRect.width;
 
-        // Yeni left değerini hesapla (px cinsinden)
-        const newLeftPx = (viewportWidth / 2) + neededShift;
-        const newLeftPercent = (newLeftPx / viewportWidth) * 100;
+    // Panelin sol kenarının olması gereken minimum pozisyon
+    const minPanelLeft = uiRight + minGap;
+
+    if (panelLeft < minPanelLeft) {
+        // Çakışma var, paneli sağa kaydır
+        // Panelin merkezi sol kenardan panel_width/2 kadar sağda olmalı
+        const newCenterPx = minPanelLeft + (panelWidth / 2);
+        const newLeftPercent = (newCenterPx / viewportWidth) * 100;
 
         miniPanel.style.left = `${newLeftPercent}%`;
-    } else {
-        // Çakışma yok, merkeze döndür
-        miniPanel.style.left = '50%';
     }
 }
 

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -127,20 +127,20 @@ canvas {
 /* YENİ KURAL: UI içindeki butonları sadece ikon göster */
 #ui .btn {
     width: auto; /* Otomatik genişlik */
-    min-width: 36px; /* Minimum genişlik */
-    height: 36px; /* Sabit yükseklik */
+    min-width: 28px; /* Minimum genişlik - kat çubuğu ile uyumlu */
+    height: 28px; /* Sabit yükseklik - kat çubuğu ile uyumlu */
     box-sizing: border-box;
     justify-content: center; /* İkonu ortala */
     align-items: center; /* İkonu ortala */
-    padding: 8px; /* Eşit padding */
+    padding: 6px; /* Eşit padding */
     font-size: 0; /* Metni gizle */
     gap: 0; /* Gap gerekmez */
 }
 
 /* UI içindeki buton iconları */
 #ui .btn svg {
-    width: 20px; /* Biraz daha büyük */
-    height: 20px;
+    width: 16px; /* Kat çubuğu ile uyumlu boyut */
+    height: 16px;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -69,7 +69,17 @@
  <svg viewBox="0 0 24 24"><path d="M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-7l-2-2H5a2 2 0 0 0-2 2z"></path></svg>
  Aç
  </button>
- <button id="bAssignNames" class="btn" title="Mahal Tanımla">Mahal Tanımla</button>
+ <button id="bAssignNames" class="btn" title="Mahal Tanımla">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Ana puzzle parçası gövdesi -->
+    <path d="M5 9h14v10H5z"/>
+    <!-- Üst çıkıntı -->
+    <path d="M9 9V7c0-1.1.9-2 2-2h2c1.1 0 2 .9 2 2v2"/>
+    <!-- Sağ çıkıntı -->
+    <path d="M19 13h2c1.1 0 2 .9 2 2v0c0 1.1-.9 2-2 2h-2"/>
+  </svg>
+  Mahal Tanımla
+ </button>
 <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none"/>
 </div>
 


### PR DESCRIPTION
- Kat paneli pozisyon kontrolü iyileştirildi: Sol menünün sağından minimum 16px boşluk garantisi
- Panel çok genişlediğinde merkezi kaydırılarak çakışma önleniyor
- Sol menü buton boyutları kat çubuğu ile uyumlu hale getirildi (28px yükseklik)
- Buton iconları küçültüldü (20px -> 16px)
- Buton padding azaltıldı (8px -> 6px)
- Mahal Tanımla butonuna puzzle parçası SVG ikonu eklendi