### PR TITLE
fix: Toplu silme sonrası katlar yeniden sıraya göre adlandırılıyor

### DIFF
--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -1386,6 +1386,10 @@ function bulkDeleteFloors() {
     if (!confirmed) return;
 
     const newFloors = floors.filter(f => !selectedFloors.has(f.id));
+
+    // Kalan katları yeniden numaralandır
+    renumberFloors(newFloors);
+
     setState({ floors: newFloors });
 
     // Aktif kat silinmişse, ilk görünür katı aktif yap


### PR DESCRIPTION
- bulkDeleteFloors() içinde renumberFloors() çağrısı eklendi
- Katlar silindikten sonra kalan katlar pozisyonlarına göre yeniden numaralandırılıyor
- Zemin üstü katlar: 1.KAT, 2.KAT, 3.KAT...
- Zemin altı katlar: 1.BODRUM, 2.BODRUM, 3.BODRUM...
- Kat sıralaması korunarak tutarlı isimlendirme sağlanıyor