### PR TITLE
feat: Her kata ayrı bağımsız çizim desteği eklendi

### DIFF
--- a/architectural-objects/beams.js
+++ b/architectural-objects/beams.js
@@ -17,7 +17,8 @@ export function createBeam(centerX, centerY, width, height, rotation) {
         hollowWidth: 0,
         hollowHeight: 0,
         hollowOffsetX: 0,
-        hollowOffsetY: 0
+        hollowOffsetY: 0,
+        floorId: state.currentFloor?.id
     };
 }
 

--- a/architectural-objects/columns.js
+++ b/architectural-objects/columns.js
@@ -19,7 +19,8 @@ export function createColumn(centerX, centerY, size = 40) {
         hollowWidth: 0,
         hollowHeight: 0,
         hollowOffsetX: 0,
-        hollowOffsetY: 0
+        hollowOffsetY: 0,
+        floorId: state.currentFloor?.id
     };
 }
 

--- a/architectural-objects/door-handler.js
+++ b/architectural-objects/door-handler.js
@@ -260,13 +260,13 @@ export function getDoorPlacement(wall, mousePos) {
         const minPos = segmentAtMouse.start + smallerWidth / 2;
         const maxPos = segmentAtMouse.end - smallerWidth / 2;
         const clampedPos = Math.max(minPos, Math.min(maxPos, posOnWall));
-        return { wall: wall, pos: clampedPos, width: smallerWidth, type: 'door', isWidthManuallySet: false }; // İşareti false başlat
+        return { wall: wall, pos: clampedPos, width: smallerWidth, type: 'door', isWidthManuallySet: false, floorId: wall.floorId }; // İşareti false başlat
     }
 
     const minPos = segmentAtMouse.start + doorWidth / 2;
     const maxPos = segmentAtMouse.end - doorWidth / 2;
     const clampedPos = Math.max(minPos, Math.min(maxPos, posOnWall));
-    return { wall: wall, pos: clampedPos, width: doorWidth, type: 'door', isWidthManuallySet: false }; // İşareti false başlat
+    return { wall: wall, pos: clampedPos, width: doorWidth, type: 'door', isWidthManuallySet: false, floorId: wall.floorId }; // İşareti false başlat
 }
 
 export function isSpaceForDoor(door) {

--- a/architectural-objects/stairs.js
+++ b/architectural-objects/stairs.js
@@ -136,7 +136,8 @@ export function createStairs(centerX, centerY, width, height, rotation, isLandin
         topElevation: defaultTopElevation,     // Hesaplanan üst kot
         connectedStairId: connectedStairId,    // Bağlantı ID'si
         isLanding: isLanding, // Parametreden gelen değeri ata
-        showRailing: isLanding ? false : state.stairSettings.showRailing // Sahanlıksa false, normal merdivense ayarlardan al
+        showRailing: isLanding ? false : state.stairSettings.showRailing, // Sahanlıksa false, normal merdivense ayarlardan al
+        floorId: state.currentFloor?.id
     };
 
     // Basamak sayısını hesapla (sahanlık değilse)

--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -226,10 +226,19 @@ function drawStairSequenceArrows(ctx2d, state) {
 export function draw2D() {
     const { ctx2d, c2d } = dom;
     const {
-        panOffset, zoom, rooms, walls, doors, beams, stairs, selectedObject, // <-- stairs EKLEYİN
+        panOffset, zoom, selectedObject, // <-- stairs EKLEYİN
         isDragging, dimensionMode, affectedWalls, startPoint, nodes,
         dimensionOptions, wallAdjacency,
     } = state;
+
+    // Sadece aktif kata ait çizimleri filtrele
+    const currentFloorId = state.currentFloor?.id;
+    const rooms = state.rooms.filter(r => !currentFloorId || r.floorId === currentFloorId);
+    const walls = state.walls.filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const doors = state.doors.filter(d => !currentFloorId || d.floorId === currentFloorId);
+    const beams = state.beams?.filter(b => !currentFloorId || b.floorId === currentFloorId) || [];
+    const stairs = state.stairs?.filter(s => !currentFloorId || s.floorId === currentFloorId) || [];
+    const columns = state.columns?.filter(c => !currentFloorId || c.floorId === currentFloorId) || [];
 
     ctx2d.fillStyle = BG;
     ctx2d.fillRect(0, 0, c2d.width, c2d.height);
@@ -299,7 +308,7 @@ export function draw2D() {
     });
 
     // 4. KOLONLAR (Duvarlardan sonra, kapı/pencereden önce)
-    state.columns.forEach(column => {
+    columns.forEach(column => {
         // Her kolon için isSelected durumunu kontrol et (tek seçim veya grup seçimi)
         const isSelected = (selectedObject?.type === "column" && selectedObject.object === column) ||
                           state.selectedGroup.some(item => item.type === "column" && item.object === column);
@@ -307,7 +316,7 @@ export function draw2D() {
     });
 
     // 4.5. KİRİŞLER
-    (state.beams || []).forEach(beam => {
+    beams.forEach(beam => {
         // Her kiriş için isSelected durumunu kontrol et (tek seçim veya grup seçimi)
         const isSelected = (selectedObject?.type === "beam" && selectedObject.object === beam) ||
                           state.selectedGroup.some(item => item.type === "beam" && item.object === beam);
@@ -315,7 +324,7 @@ export function draw2D() {
     });
 
     // 4.7. MERDİVENLER
-    (state.stairs || []).forEach(stair => {
+    stairs.forEach(stair => {
         // Her bir merdiven için seçili olup olmadığını kontrol et (tek seçim veya grup seçimi)
         const isSelected = !!(
             (selectedObject && selectedObject.type === "stairs" && selectedObject.object === stair) ||
@@ -471,7 +480,7 @@ export function draw2D() {
     drawDrawingPreviews(ctx2d, state, snapTo15DegreeAngle, drawDimension);
     drawSnapFeedback(ctx2d, state, isMouseOverWall);
     drawSymmetryPreview(ctx2d, state);
- if (state.isStairPopupVisible && state.stairs && state.stairs.length > 0) {
+ if (state.isStairPopupVisible && stairs && stairs.length > 0) {
         ctx2d.textAlign = "center";
         ctx2d.textBaseline = "middle";
         ctx2d.fillStyle = "#e57373"; // Kırmızı renk
@@ -480,7 +489,7 @@ export function draw2D() {
         const ZOOM_EXPONENT_STAIR_NAME = -0.5; // Zoom ile nasıl küçüleceği (room names ile benzer veya farklı olabilir)
         const minWorldFontSize = 8; // Minimum dünya boyutu
 
-        state.stairs.forEach(stair => {
+        stairs.forEach(stair => {
             if (stair.center && stair.name) {
                 let fontSize = baseFontSize * Math.pow(zoom, ZOOM_EXPONENT_STAIR_NAME);
                 ctx2d.font = `bold ${Math.max(minWorldFontSize, fontSize)}px "Segoe UI", "Roboto", "Helvetica Neue", sans-serif`; // Kalın font

--- a/draw/geometry.js
+++ b/draw/geometry.js
@@ -282,7 +282,21 @@ export function detectRooms() {
 
                     // Alan 40m²'den büyükse adı "DAİRE" yap (Özel kural)
                     let finalRoomName = existingRoomName;
-                    
+
+                    // Odanın hangi kata ait olduğunu bul (poligonu oluşturan duvarlardan birinin floorId'si)
+                    let roomFloorId = null;
+                    const coords = polygon.geometry.coordinates[0];
+                    for (let i = 0; i < coords.length - 1 && !roomFloorId; i++) {
+                        const p1Coord = coords[i];
+                        const p2Coord = coords[i + 1];
+                        const wall = validWalls.find(w => {
+                            if (!w || !w.p1 || !w.p2) return false;
+                            const d1 = Math.hypot(w.p1.x - p1Coord[0], w.p1.y - p1Coord[1]) + Math.hypot(w.p2.x - p2Coord[0], w.p2.y - p2Coord[1]);
+                            const d2 = Math.hypot(w.p1.x - p2Coord[0], w.p1.y - p2Coord[1]) + Math.hypot(w.p2.x - p1Coord[0], w.p2.y - p1Coord[1]);
+                            return Math.min(d1, d2) < 1;
+                        });
+                        if (wall && wall.floorId) roomFloorId = wall.floorId;
+                    }
 
                     // Yeni odayı listeye ekle
                     newRooms.push({
@@ -290,7 +304,8 @@ export function detectRooms() {
                         area: areaInM2, // Alan (m²)
                         center: [newCenterX, newCenterY], // Hesaplanan merkez [x, y]
                         name: finalRoomName, // İsim
-                        centerOffset: existingRoomCenterOffset // Orantısal merkez bilgisi
+                        centerOffset: existingRoomCenterOffset, // Orantısal merkez bilgisi
+                        floorId: roomFloorId // Odanın ait olduğu kat
                     });
                 } catch (e) {
                     console.error("Poligon işleme hatası:", e); // Hata olursa konsola yaz

--- a/draw/symmetry.js
+++ b/draw/symmetry.js
@@ -414,7 +414,8 @@ export function applyCopy(axisP1, axisP2) {
                 thickness: wall.thickness || state.wallThickness,
                 wallType: wall.wallType || 'normal',
                 isArc: wall.isArc,
-                windows: [], vents: []
+                windows: [], vents: [],
+                floorId: wall.floorId
             };
 
             // Yay duvarları için kontrol noktalarını kopyala
@@ -467,7 +468,8 @@ export function applyCopy(axisP1, axisP2) {
             size: Math.max(col.width || col.size, col.height || col.size),
             rotation: col.rotation || 0, // Rotasyon aynı kalır
             hollowWidth: col.hollowWidth, hollowHeight: col.hollowHeight,
-            hollowOffsetX: col.hollowOffsetX, hollowOffsetY: col.hollowOffsetY
+            hollowOffsetX: col.hollowOffsetX, hollowOffsetY: col.hollowOffsetY,
+            floorId: col.floorId
         });
         newColumns.push(newCol);
     });
@@ -481,7 +483,8 @@ export function applyCopy(axisP1, axisP2) {
         const newBeam = createBeam(copiedCenter.x, copiedCenter.y, beam.width, beam.height, beam.rotation || 0);
         Object.assign(newBeam, {
             depth: beam.depth, hollowWidth: beam.hollowWidth, hollowHeight: beam.hollowHeight,
-            hollowOffsetX: beam.hollowOffsetX, hollowOffsetY: beam.hollowOffsetY
+            hollowOffsetX: beam.hollowOffsetX, hollowOffsetY: beam.hollowOffsetY,
+            floorId: beam.floorId
         });
         newBeams.push(newBeam);
     });
@@ -500,6 +503,7 @@ export function applyCopy(axisP1, axisP2) {
             topElevation: stair.topElevation,
             showRailing: stair.showRailing,
             stepCount: stair.stepCount,
+            floorId: stair.floorId,
             // connectedStairId kopyalanmaz (null kalır) çünkü kopya bağımsız olmalı
         });
 
@@ -598,7 +602,8 @@ export function applySymmetry(axisP1, axisP2) {
                 thickness: wall.thickness || state.wallThickness,
                 wallType: wall.wallType || 'normal',
                 isArc: wall.isArc,
-                windows: [], vents: []
+                windows: [], vents: [],
+                floorId: wall.floorId
             };
 
             // Yay duvarları için kontrol noktalarını yansıt

--- a/wall/wall-handler.js
+++ b/wall/wall-handler.js
@@ -95,7 +95,7 @@ export function onPointerDownDraw(snappedPos) {
                  const didConnectToWallBody = !didSnapToExistingNode && isPointOnWallBody(endNode);
 
                  if (endNode !== state.startPoint && !wallExists(state.startPoint, endNode)) {
-                     state.walls.push({ type: "wall", p1: state.startPoint, p2: endNode, thickness: state.wallThickness, wallType: 'normal' });
+                     state.walls.push({ type: "wall", p1: state.startPoint, p2: endNode, thickness: state.wallThickness, wallType: 'normal', floorId: state.currentFloor?.id });
                      geometryChanged = true;
                  }
 
@@ -114,7 +114,7 @@ export function onPointerDownDraw(snappedPos) {
                          v4 = getOrCreateNode(v1.x, placementPos.y);
                    [{ p1: v1, p2: v2 }, { p1: v2, p2: v3 }, { p1: v3, p2: v4 }, { p1: v4, p2: v1 }].forEach(pw => {
                         if (!wallExists(pw.p1, pw.p2)) {
-                            state.walls.push({ type: "wall", ...pw, thickness: state.wallThickness, wallType: 'normal' });
+                            state.walls.push({ type: "wall", ...pw, thickness: state.wallThickness, wallType: 'normal', floorId: state.currentFloor?.id });
                         }
                    });
                    geometryChanged = true;

--- a/wall/wall-processor.js
+++ b/wall/wall-processor.js
@@ -100,8 +100,8 @@ function splitWallsAtCrossings() {
                     state.walls.splice(i, 1);
                     
                     // Orijinal duvar özelliklerini al
-                    const w1_props = { thickness: w1.thickness || state.wallThickness, wallType: w1.wallType || 'normal' };
-                    const w2_props = { thickness: w2.thickness || state.wallThickness, wallType: w2.wallType || 'normal' };
+                    const w1_props = { thickness: w1.thickness || state.wallThickness, wallType: w1.wallType || 'normal', floorId: w1.floorId };
+                    const w2_props = { thickness: w2.thickness || state.wallThickness, wallType: w2.wallType || 'normal', floorId: w2.floorId };
 
                     if (Math.hypot(w1.p1.x - n.x, w1.p1.y - n.y) > 1) state.walls.push({ type: "wall", p1: w1.p1, p2: n, ...w1_props });
                     if (Math.hypot(w1.p2.x - n.x, w1.p2.y - n.y) > 1) state.walls.push({ type: "wall", p1: n, p2: w1.p2, ...w1_props });
@@ -129,8 +129,8 @@ function splitWallsAtTjunctions() {
                     const nodeDist = Math.hypot(node.x - originalP1.x, node.y - originalP1.y);
                     
                     // Orijinal duvar özelliklerini al
-                    const wall_props = { thickness: wall.thickness || state.wallThickness, wallType: wall.wallType || 'normal' };
-                    
+                    const wall_props = { thickness: wall.thickness || state.wallThickness, wallType: wall.wallType || 'normal', floorId: wall.floorId };
+
                     const newWall1 = { type: "wall", p1: originalP1, p2: node, ...wall_props };
                     const newWall2 = { type: "wall", p1: node, p2: originalP2, ...wall_props };
                     state.doors.forEach((d) => {
@@ -186,7 +186,7 @@ function mergeCollinearChains() {
                 if (!still) { const i = state.nodes.indexOf(node); if (i >= 0) state.nodes.splice(i, 1); }
                 if (a.other !== b.other) {
                     // Özellikleri birleşen duvarlardan birinden devral (a.wall)
-                    const wall_props = { thickness: a.wall.thickness || state.wallThickness, wallType: a.wall.wallType || 'normal' };
+                    const wall_props = { thickness: a.wall.thickness || state.wallThickness, wallType: a.wall.wallType || 'normal', floorId: a.wall.floorId };
                     state.walls.push({ type: "wall", p1: a.other, p2: b.other, ...wall_props });
                 }                
                 changed = true;
@@ -411,8 +411,8 @@ export function splitWallAtMousePosition() {
     if (wallIndex > -1) walls.splice(wallIndex, 1);
 
     const distToSplitNode = Math.hypot(splitNode.x - p1.x, splitNode.y - p1.y);
-    const newWall1 = { type: "wall", p1: p1, p2: splitNode };
-    const newWall2 = { type: "wall", p1: splitNode, p2: p2 };
+    const newWall1 = { type: "wall", p1: p1, p2: splitNode, thickness: wallToSplit.thickness, wallType: wallToSplit.wallType, floorId: wallToSplit.floorId };
+    const newWall2 = { type: "wall", p1: splitNode, p2: p2, thickness: wallToSplit.thickness, wallType: wallToSplit.wallType, floorId: wallToSplit.floorId };
 
     state.doors.forEach((door) => {
         if (door.wall === wallToSplit) {


### PR DESCRIPTION
- Her çizim objesine (duvar, kapı, kolon, kiriş, merdiven, oda) floorId özelliği eklendi
- Çizim oluştururken aktif katın ID'si otomatik olarak atanıyor
- 2D render fonksiyonu sadece aktif kata ait çizimleri gösterecek şekilde filtrelendi
- Duvar işleme (bölme, birleştirme) sırasında floorId korunuyor
- Simetri kopyalama işlemlerinde floorId orijinal objeden alınıyor
- Odalar, kendilerini oluşturan duvarların floorId'sine göre etiketleniyor

Artık her kat bağımsız çizimler içeriyor ve kullanıcı katlar arasında geçiş yaptığında sadece o kata ait çizimler görüntüleniyor.