### PR TITLE
fix: Kat bazlı ölçü ve snap filtrasyonu eklendi

### DIFF
--- a/draw/dimensions.js
+++ b/draw/dimensions.js
@@ -80,9 +80,11 @@ export function drawDimension(p1, p2, isPreview = false, mode = 'single') {
 }
 
 
-export function drawTotalDimensions() {
+export function drawTotalDimensions(filteredWalls = null, filteredRooms = null) {
     const { ctx2d } = dom;
-    const { zoom, rooms, walls, gridOptions, dimensionOptions } = state;
+    const { zoom, gridOptions, dimensionOptions } = state;
+    const rooms = filteredRooms || state.rooms;
+    const walls = filteredWalls || state.walls;
 
     if (rooms.length === 0) return;
 
@@ -201,9 +203,10 @@ export function drawTotalDimensions() {
 }
 
 
-export function drawOuterDimensions() {
+export function drawOuterDimensions(filteredWalls = null) {
     const { ctx2d } = dom;
-    const { zoom, walls, gridOptions, dimensionOptions, dimensionMode } = state;
+    const { zoom, gridOptions, dimensionOptions, dimensionMode } = state;
+    const walls = filteredWalls || state.walls;
 
     const showOuterOption = dimensionOptions.showOuter;
     const showOuter = (showOuterOption === 1 && (dimensionMode === 1 || dimensionMode === 2)) ||

--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -240,6 +240,14 @@ export function draw2D() {
     const stairs = state.stairs?.filter(s => !currentFloorId || s.floorId === currentFloorId) || [];
     const columns = state.columns?.filter(c => !currentFloorId || c.floorId === currentFloorId) || [];
 
+    // Sadece aktif kata ait node'ları filtrele (duvarlardan topla)
+    const nodesSet = new Set();
+    walls.forEach(wall => {
+        if (wall.p1) nodesSet.add(wall.p1);
+        if (wall.p2) nodesSet.add(wall.p2);
+    });
+    const nodes = Array.from(nodesSet);
+
     ctx2d.fillStyle = BG;
     ctx2d.fillRect(0, 0, c2d.width, c2d.height);
     ctx2d.save();
@@ -390,14 +398,14 @@ export function draw2D() {
 
     // 10. Ölçülendirmeler
     if (dimensionMode === 1) {
-        drawTotalDimensions();
+        drawTotalDimensions(walls, rooms);
     } else if (dimensionMode === 2) {
         walls.forEach((w) => {
             if (w.p1 && w.p2) drawDimension(w.p1, w.p2, false, 'single'); // Check added
         });
     }
 
-    drawOuterDimensions(); // Dış ölçüler
+    drawOuterDimensions(walls); // Dış ölçüler
 
     // Seçili nesne veya sürüklenen duvarlar için geçici ölçüler
     if (isDragging && affectedWalls.length > 0 && (dimensionMode === 0 || dimensionMode === 1) && selectedObject?.type === 'wall') {


### PR DESCRIPTION
- drawOuterDimensions() filtrelenmiş duvarları kabul ediyor
- drawTotalDimensions() filtrelenmiş duvar ve odaları kabul ediyor
- draw2d.js içinde sadece aktif kata ait node'lar kullanılıyor
- Artık diğer katların snap noktaları ve ölçüleri görünmüyor