### PR TITLE
fix: Room names and floor preview now show per-floor content

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -360,7 +360,7 @@ export function draw2D() {
 
 
     // 7. Mahal Etiketleri
-    drawRoomNames(ctx2d, state, getObjectAtPoint);
+    drawRoomNames(ctx2d, { ...state, rooms }, getObjectAtPoint);
 
     // 8. Kapılar, Pencereler, Menfezler
     doors.forEach((door) => {

--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -696,10 +696,10 @@ function renderFloorPreview(floor) {
     const svgWidth = 80;
     const svgHeight = 40;
 
-    // Sadece duvarları göster
-    const walls = state.walls || [];
+    // Sadece bu kata ait duvarları göster
+    const walls = (state.walls || []).filter(w => !floor || w.floorId === floor.id);
 
-    // Tüm duvarların bounds'ını hesapla
+    // Bu katın duvarlarının bounds'ını hesapla
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
 
     walls.forEach(wall => {


### PR DESCRIPTION
Fixed two remaining cross-floor display issues:

1. Room names (draw2d.js:363)
   - Was passing unfiltered state to drawRoomNames
   - Now passes filtered rooms like drawRoomPolygons does
   - Room names now only appear on their respective floors

2. Floor panel preview (floor-panel.js:700)
   - Was showing ALL walls in every floor preview
   - Now filters walls by floorId for each floor
   - Each floor preview shows only its own content

Result:
- Room names only visible on correct floor
- Floor panel previews show accurate per-floor content
- Complete visual isolation between floors