### PR TITLE
fix: Complete wall dragging floor isolation and UI fixes

### DIFF
--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -601,7 +601,7 @@ function renderDetailPanel() {
         if (index === upperPlaceholderIndex && upperPlaceholderIndex !== -1) {
             html += `
                 <tr style="height: 2px; background: #5f6368;">
-                    <td colspan="6" style="padding: 0; height: 2px; background: linear-gradient(to right, transparent, #8ab4f8, transparent);"></td>
+                    <td colspan="7" style="padding: 0; height: 2px; background: linear-gradient(to right, transparent, #8ab4f8, transparent);"></td>
                 </tr>
             `;
         }
@@ -1338,12 +1338,9 @@ function addFloorFromPlaceholder(placeholderId) {
     // Katları yüksekliğe göre sırala
     floors.sort((a, b) => a.bottomElevation - b.bottomElevation);
 
-    // Yeni eklenen katı bul ve aktif yap
-    const newFloor = floors.find(f => f.name === newFloorName);
-
+    // Yeni eklenen katı ekle ama aktif katı değiştirme
     setState({
-        floors,
-        currentFloor: newFloor
+        floors
     });
 
     renderDetailPanel();

--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -21,7 +21,9 @@ const SYMMETRY_PREVIEW_DEBOUNCE_MS = 50; // 50ms gecikme
 
 // Helper: Verilen bir noktanın duvar merkez çizgisine snap olup olmadığını kontrol eder.
 function getSnappedWallInfo(point, tolerance = 1.0) { // Tolerans: 1 cm
-    for (const wall of state.walls) {
+    const currentFloorId = state.currentFloor?.id;
+    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    for (const wall of walls) {
         if (!wall.p1 || !wall.p2) continue;
         const distSq = distToSegmentSquared(point, wall.p1, wall.p2);
         if (distSq < tolerance * tolerance) {
@@ -49,9 +51,12 @@ export function onPointerMove(e) {
         const mousePos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
         let needsProcessing = false;
 
+        const currentFloorId_delete = state.currentFloor?.id;
+        const walls_delete = (state.walls || []).filter(w => !currentFloorId_delete || w.floorId === currentFloorId_delete);
+
         // Duvar silme
         const wallsToDelete = new Set();
-        for (const wall of state.walls) {
+        for (const wall of walls_delete) {
              if (!wall.p1 || !wall.p2) continue;
              const wallPx = wall.thickness || state.wallThickness;
              const currentToleranceSq = (wallPx / 2 + 3 / state.zoom)**2;
@@ -241,10 +246,12 @@ export function onPointerMove(e) {
             case 'door':   onPointerMoveDoor(unsnappedPos);               break;
             case 'window': onPointerMoveWindow(unsnappedPos);             break;
             case 'vent':
+                const currentFloorId_vent = state.currentFloor?.id;
+                const walls_vent = (state.walls || []).filter(w => !currentFloorId_vent || w.floorId === currentFloorId_vent);
                 const vent = state.selectedObject.object; const oldWall = state.selectedObject.wall;
                 const targetX = unsnappedPos.x + state.dragOffset.x; const targetY = unsnappedPos.y + state.dragOffset.y; const targetPos = { x: targetX, y: targetY };
                 let closestWall = null; let minDistSq = Infinity; const bodyHitTolerance = state.wallThickness * 2;
-                for (const w of state.walls) {
+                for (const w of walls_vent) {
                     if (!w.p1 || !w.p2) continue;
                     const d = distToSegmentSquared(targetPos, w.p1, w.p2);
                     if (d < bodyHitTolerance ** 2 && d < minDistSq) { minDistSq = d; closestWall = w; }

--- a/wall/wall-handler.js
+++ b/wall/wall-handler.js
@@ -24,8 +24,11 @@ export function wallExists(p1, p2) {
  * @returns {object | null} - Bulunan duvar nesnesi (seçim için) veya null
  */
 export function getWallAtPoint(pos, tolerance) {
+    const currentFloorId = state.currentFloor?.id;
+    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+
     // Duvar ucu (node) kontrolü
-    for (const wall of [...state.walls].reverse()) {
+    for (const wall of [...walls].reverse()) {
         if (!wall.p1 || !wall.p2) continue;
         const d1 = Math.hypot(pos.x - wall.p1.x, pos.y - wall.p1.y);
         const d2 = Math.hypot(pos.x - wall.p2.x, pos.y - wall.p2.y);
@@ -255,7 +258,9 @@ export function onPointerDownSelect(selectedObject, pos, snappedPos, e) {
  * @param {object} unsnappedPos - Snap uygulanmamış fare pozisyonu
  */
 export function onPointerMove(snappedPos, unsnappedPos) {
-   let neighborWallsToDimension = new Set(); // Komşu duvarları saklamak için Set
+    const currentFloorId = state.currentFloor?.id;
+    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    let neighborWallsToDimension = new Set(); // Komşu duvarları saklamak için Set
 
     if (state.selectedObject.handle !== "body") {
         // Duvar Ucu (Node) Sürükleme
@@ -327,7 +332,7 @@ export function onPointerMove(snappedPos, unsnappedPos) {
             let bestSnapY = { diff: SNAP_DISTANCE, value: null };
 
             // Tüm duvar yüzeylerine snap kontrolü
-            state.walls.forEach(wall => {
+            walls.forEach(wall => {
                 // Sürüklenen node'un bağlı olduğu duvarları atla
                 if (state.affectedWalls.includes(wall)) return;
                 if (!wall.p1 || !wall.p2) return;
@@ -389,7 +394,7 @@ export function onPointerMove(snappedPos, unsnappedPos) {
         }
 
        // Sürüklenen node'a bağlı komşu duvarları bul (affectedWalls hariç)
-       state.walls.forEach(wall => {
+       walls.forEach(wall => {
            if (!state.affectedWalls.includes(wall) && (wall.p1 === nodeToMove || wall.p2 === nodeToMove)) {
                neighborWallsToDimension.add(wall);
            }
@@ -446,7 +451,7 @@ export function onPointerMove(snappedPos, unsnappedPos) {
              const len1 = Math.hypot(dx1, dy1); if (len1 < 0.1) return;
              const dir1 = { x: dx1 / len1, y: dy1 / len1 };
 
-             state.walls.forEach(staticWall => {
+             walls.forEach(staticWall => {
                  if (wallsToMove.includes(staticWall)) return;
                  const dx2 = staticWall.p2.x - staticWall.p1.x, dy2 = staticWall.p2.y - staticWall.p1.y;
                  const len2 = Math.hypot(dx2, dy2); if (len2 < 0.1) return;
@@ -514,7 +519,7 @@ export function onPointerMove(snappedPos, unsnappedPos) {
 
        // Sürüklenen nodelara bağlı komşu duvarları bul (wallsToMove hariç)
        nodesToMove.forEach(node => {
-           state.walls.forEach(wall => {
+           walls.forEach(wall => {
                // Duvarın geçerli olduğundan emin ol
                if (!wall || !wall.p1 || !wall.p2) return;
                // Sürüklenen duvarlardan değilse VE node'a bağlıysa ekle


### PR DESCRIPTION
This fixes critical cross-floor interference issues during wall dragging.

**wall-handler.js:**
- getWallAtPoint(): Filter walls by currentFloorId
- onPointerMove(): Filter walls by currentFloorId at function start
- All state.walls.forEach loops now use filtered walls
- Prevents wall nodes from snapping to other floor walls
- Prevents wall drag from affecting other floors

**pointer/pointer-move.js:**
- getSnappedWallInfo(): Filter walls by currentFloorId
- Delete mode (Alt key): Filter walls by currentFloorId
- Vent dragging: Filter walls by currentFloorId
- All wall queries now floor-isolated

**floor/floor-panel.js:**
- Fixed separator line colspan from 6 to 7 (was missing last column)
- addFloorFromPlaceholder(): Removed currentFloor change on new floor add
- Active floor now stays unchanged when adding new floors

**Impact:**
- Wall dragging no longer creates cross-floor node connections
- Walls no longer "break apart" when dragging near other floor walls
- Floor panel separator line now spans all columns correctly
- Adding new floors no longer changes active floor