### PR TITLE
fix: Add floor filtering to door and window previews

### DIFF
--- a/draw/draw-previews.js
+++ b/draw/draw-previews.js
@@ -7,7 +7,11 @@ import { getWindowPlacement, isSpaceForWindow } from '../architectural-objects/w
 import { state, dom } from '../general-files/main.js';
 
 export function drawObjectPlacementPreviews(ctx2d, state, getDoorPlacement, isSpaceForDoor, getWindowPlacement, isSpaceForWindow, drawDoorSymbol, drawWindowSymbol) {
-    const { currentMode, isPanning, isDragging, walls, mousePos } = state;
+    const { currentMode, isPanning, isDragging, mousePos } = state;
+
+    // FLOOR ISOLATION: Sadece aktif kattaki duvarları kullan
+    const currentFloorId = state.currentFloor?.id;
+    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
 
     // Kapı önizlemesi
     if (currentMode === "drawDoor" && !isPanning && !isDragging) {


### PR DESCRIPTION
This fixes the bug where door/window placement previews were showing for walls on other floors, even when those walls were not visible.

**draw/draw-previews.js:**

**drawObjectPlacementPreviews() function:**
- Added floor filtering at function start (lines 12-14)
- Extract currentFloorId from state.currentFloor
- Filter state.walls by currentFloorId
- Use filtered walls for both door and window preview detection

**Impact:**
- ✅ Door preview only shows on current floor walls
- ✅ Window preview only shows on current floor walls
- ✅ No more "ghost wall" previews from other floors
- ✅ Preview system fully floor-isolated

**User Experience:**
Before: Moving mouse in "door mode" showed previews everywhere,
        even when no walls were visible (walls were on other floors)
After:  Previews only show when hovering over visible walls on
        the current floor