### PR TITLE
debug: Add floor filtering debug logging to getObjectAtPoint

### DIFF
--- a/general-files/actions.js
+++ b/general-files/actions.js
@@ -22,6 +22,16 @@ export function getObjectAtPoint(pos) {
     const { zoom } = state;
     const currentFloorId = state.currentFloor?.id;
 
+    // DEBUG: Log floor filtering info
+    if (currentFloorId) {
+        console.log('🔍 getObjectAtPoint - Current Floor:', currentFloorId);
+        console.log('📊 Total walls:', state.walls?.length, 'Filtered walls:', (state.walls || []).filter(w => w.floorId === currentFloorId).length);
+        const wallsWithoutFloor = (state.walls || []).filter(w => !w.floorId);
+        if (wallsWithoutFloor.length > 0) {
+            console.warn('⚠️ Found', wallsWithoutFloor.length, 'walls WITHOUT floorId!', wallsWithoutFloor);
+        }
+    }
+
     // Sadece aktif kata ait elemanları filtrele
     const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
     const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);


### PR DESCRIPTION
Added debug logging to identify cross-floor selection issues:
- Logs current floor ID
- Logs total walls vs filtered walls count
- Warns if walls exist without floorId property

This will help diagnose the reported issue where walls from other floors can be selected even when on a different floor.