### PR TITLE
fix: Add floor isolation to symmetry and fix floor panel indicators

### DIFF
--- a/draw/symmetry.js
+++ b/draw/symmetry.js
@@ -18,26 +18,43 @@ import { processWalls } from '../wall/wall-processor.js';
  */
 export function calculateCopyPreview(axisP1, axisP2) {
     if (!axisP1 || !axisP2) {
-        setState({ symmetryPreviewElements: { 
-            nodes: [], walls: [], doors: [], windows: [], vents: [], 
-            columns: [], beams: [], stairs: [], rooms: [] 
+        setState({ symmetryPreviewElements: {
+            nodes: [], walls: [], doors: [], windows: [], vents: [],
+            columns: [], beams: [], stairs: [], rooms: []
         }});
         return;
     }
 
+    // FLOOR ISOLATION: Sadece aktif kattaki elemanları kopyala
+    const currentFloorId = state.currentFloor?.id;
+    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);
+    const columns = (state.columns || []).filter(c => !currentFloorId || c.floorId === currentFloorId);
+    const beams = (state.beams || []).filter(b => !currentFloorId || b.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || s.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
+
+    // Aktif kattaki duvarlardan node'ları topla
+    const nodesSet = new Set();
+    walls.forEach(w => {
+        if (w.p1) nodesSet.add(w.p1);
+        if (w.p2) nodesSet.add(w.p2);
+    });
+    const nodes = Array.from(nodesSet);
+
     const preview = {
-        nodes: [], walls: [], doors: [], windows: [], vents: [], 
+        nodes: [], walls: [], doors: [], windows: [], vents: [],
         columns: [], beams: [], stairs: [], rooms: []
     };
-    
+
     // Çeviri vektörü
     const translationX = axisP2.x - axisP1.x;
     const translationY = axisP2.y - axisP1.y;
-    
+
     const nodeMap = new Map();
 
     // 1. Nodeları kopyala
-    state.nodes.forEach(node => {
+    nodes.forEach(node => {
         const copied = {
             x: node.x + translationX,
             y: node.y + translationY
@@ -47,7 +64,7 @@ export function calculateCopyPreview(axisP1, axisP2) {
     });
 
     // 2. Duvarları kopyala
-    state.walls.forEach(wall => {
+    walls.forEach(wall => {
         const copiedP1 = nodeMap.get(wall.p1);
         const copiedP2 = nodeMap.get(wall.p2);
         if (copiedP1 && copiedP2) {
@@ -76,7 +93,7 @@ export function calculateCopyPreview(axisP1, axisP2) {
     });
 
     // 3. Kapıları kopyala
-    state.doors.forEach(door => {
+    doors.forEach(door => {
         const wall = door.wall;
         const copiedP1 = nodeMap.get(wall.p1);
         const copiedP2 = nodeMap.get(wall.p2);
@@ -92,7 +109,7 @@ export function calculateCopyPreview(axisP1, axisP2) {
     });
 
     // 4. Pencereleri kopyala
-    state.walls.forEach(wall => {
+    walls.forEach(wall => {
         const copiedP1 = nodeMap.get(wall.p1);
         const copiedP2 = nodeMap.get(wall.p2);
         if (copiedP1 && copiedP2) {
@@ -120,7 +137,7 @@ export function calculateCopyPreview(axisP1, axisP2) {
     });
 
     // 5. Kolonları kopyala
-    state.columns.forEach(col => {
+    columns.forEach(col => {
         const copiedCenter = {
             x: col.center.x + translationX,
             y: col.center.y + translationY
@@ -133,7 +150,7 @@ export function calculateCopyPreview(axisP1, axisP2) {
     });
 
     // 6. Kirişleri kopyala
-    state.beams.forEach(beam => {
+    beams.forEach(beam => {
         const copiedCenter = {
             x: beam.center.x + translationX,
             y: beam.center.y + translationY
@@ -146,7 +163,7 @@ export function calculateCopyPreview(axisP1, axisP2) {
     });
 
     // 7. Merdivenleri kopyala
-    state.stairs.forEach(stair => {
+    stairs.forEach(stair => {
         const copiedCenter = {
             x: stair.center.x + translationX,
             y: stair.center.y + translationY
@@ -159,7 +176,7 @@ export function calculateCopyPreview(axisP1, axisP2) {
     });
 
     // 8. Odaları kopyala
-    state.rooms.forEach(room => {
+    rooms.forEach(room => {
         if (room.polygon?.geometry?.coordinates) {
             const coords = room.polygon.geometry.coordinates[0];
             const copiedCoords = coords.map(p => [p[0] + translationX, p[1] + translationY]);
@@ -207,13 +224,30 @@ export function calculateSymmetryPreview(axisP1, axisP2) {
         return;
     }
 
+    // FLOOR ISOLATION: Sadece aktif kattaki elemanları yansıt
+    const currentFloorId = state.currentFloor?.id;
+    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);
+    const columns = (state.columns || []).filter(c => !currentFloorId || c.floorId === currentFloorId);
+    const beams = (state.beams || []).filter(b => !currentFloorId || b.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || s.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
+
+    // Aktif kattaki duvarlardan node'ları topla
+    const nodesSet = new Set();
+    walls.forEach(w => {
+        if (w.p1) nodesSet.add(w.p1);
+        if (w.p2) nodesSet.add(w.p2);
+    });
+    const nodes = Array.from(nodesSet);
+
     const preview = {
         nodes: [], walls: [], doors: [], windows: [], vents: [], columns: [], beams: [], stairs: [], rooms: []
     };
     const nodeMap = new Map(); // Orijinal node -> Yansıyan node koordinatı eşlemesi
 
     // 1. Nodeları yansıt (sadece koordinatları)
-    state.nodes.forEach(node => {
+    nodes.forEach(node => {
         const reflected = reflectPoint(node, axisP1, axisP2);
         if (reflected) {
             nodeMap.set(node, reflected);
@@ -224,7 +258,7 @@ export function calculateSymmetryPreview(axisP1, axisP2) {
     const axisAngleRad = Math.atan2(axisP2.y - axisP1.y, axisP2.x - axisP1.x);
 
     // 2. Duvarları yansıt
-    state.walls.forEach(wall => {
+    walls.forEach(wall => {
         const reflectedP1 = nodeMap.get(wall.p1);
         const reflectedP2 = nodeMap.get(wall.p2);
         if (reflectedP1 && reflectedP2) {
@@ -251,7 +285,7 @@ export function calculateSymmetryPreview(axisP1, axisP2) {
     });
 
     // 3. Kapıları yansıt
-    state.doors.forEach(door => {
+    doors.forEach(door => {
         const wall = door.wall;
         const reflectedP1 = nodeMap.get(wall.p1);
         const reflectedP2 = nodeMap.get(wall.p2);
@@ -277,7 +311,7 @@ export function calculateSymmetryPreview(axisP1, axisP2) {
     });
 
     // 4. Pencereleri ve Menfezleri yansıt
-    state.walls.forEach(wall => {
+    walls.forEach(wall => {
         const reflectedP1 = nodeMap.get(wall.p1);
         const reflectedP2 = nodeMap.get(wall.p2);
         if (reflectedP1 && reflectedP2) {
@@ -304,7 +338,7 @@ export function calculateSymmetryPreview(axisP1, axisP2) {
     });
 
     // 5. Kolonları yansıt
-    state.columns.forEach(col => {
+    columns.forEach(col => {
         const reflectedCenter = reflectPoint(col.center, axisP1, axisP2);
         if (reflectedCenter) {
             const originalRotationRad = (col.rotation || 0) * Math.PI / 180;
@@ -316,7 +350,7 @@ export function calculateSymmetryPreview(axisP1, axisP2) {
     });
 
     // 6. Kirişleri yansıt
-    state.beams.forEach(beam => {
+    beams.forEach(beam => {
         const reflectedCenter = reflectPoint(beam.center, axisP1, axisP2);
         if (reflectedCenter) {
             const originalRotationRad = (beam.rotation || 0) * Math.PI / 180;
@@ -328,7 +362,7 @@ export function calculateSymmetryPreview(axisP1, axisP2) {
     });
 
     // 7. Merdivenleri yansıt
-    state.stairs.forEach(stair => {
+    stairs.forEach(stair => {
         const reflectedCenter = reflectPoint(stair.center, axisP1, axisP2);
         if (reflectedCenter) {
             const originalRotationRad = (stair.rotation || 0) * Math.PI / 180;
@@ -340,7 +374,7 @@ export function calculateSymmetryPreview(axisP1, axisP2) {
     });
 
     // 8. Odaları yansıt
-    state.rooms.forEach(room => {
+    rooms.forEach(room => {
         if (room.polygon?.geometry?.coordinates) {
             const coords = room.polygon.geometry.coordinates[0];
             const reflectedCoords = coords.map(p => {

--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -201,8 +201,14 @@ export function renderMiniPanel() {
         // Kat kısa adı
         const shortName = getShortFloorName(floor.name);
 
-        // Katta çizim var mı kontrol et
-        const hasContent = state.walls?.length > 0 || state.doors?.length > 0;
+        // Bu katta çizim var mı kontrol et (floor-specific)
+        const floorWalls = (state.walls || []).filter(w => w.floorId === floor.id);
+        const floorDoors = (state.doors || []).filter(d => d.floorId === floor.id);
+        const floorColumns = (state.columns || []).filter(c => c.floorId === floor.id);
+        const floorBeams = (state.beams || []).filter(b => b.floorId === floor.id);
+        const floorStairs = (state.stairs || []).filter(s => s.floorId === floor.id);
+        const hasContent = floorWalls.length > 0 || floorDoors.length > 0 ||
+                          floorColumns.length > 0 || floorBeams.length > 0 || floorStairs.length > 0;
 
         // Durum renkler
         let bgColor, textColor, dotColor;

--- a/general-files/actions.js
+++ b/general-files/actions.js
@@ -22,16 +22,6 @@ export function getObjectAtPoint(pos) {
     const { zoom } = state;
     const currentFloorId = state.currentFloor?.id;
 
-    // DEBUG: Log floor filtering info
-    if (currentFloorId) {
-        console.log('🔍 getObjectAtPoint - Current Floor:', currentFloorId);
-        console.log('📊 Total walls:', state.walls?.length, 'Filtered walls:', (state.walls || []).filter(w => w.floorId === currentFloorId).length);
-        const wallsWithoutFloor = (state.walls || []).filter(w => !w.floorId);
-        if (wallsWithoutFloor.length > 0) {
-            console.warn('⚠️ Found', wallsWithoutFloor.length, 'walls WITHOUT floorId!', wallsWithoutFloor);
-        }
-    }
-
     // Sadece aktif kata ait elemanları filtrele
     const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
     const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);


### PR DESCRIPTION
This commit addresses two important issues:

1. **Symmetry Operations Floor Isolation**
   - calculateCopyPreview(): Now filters all elements by currentFloorId
   - calculateSymmetryPreview(): Now filters all elements by currentFloorId
   - Both functions now extract nodes only from current floor walls
   - Symmetry/copy operations only affect objects on the active floor
   - Prevents cross-floor symmetry which was causing unexpected behavior

2. **Floor Panel Indicator Dots**
   - Fixed hasContent calculation to be floor-specific
   - Now filters walls, doors, columns, beams, stairs by floor.id
   - Indicator dot only shows when that specific floor has objects
   - Before: showed indicator on all floors if ANY floor had objects
   - After: each floor shows its own content status independently

**draw/symmetry.js:**
- Added currentFloorId filtering to both preview functions
- Extract nodes from filtered walls instead of state.nodes
- Use filtered arrays (walls, doors, columns, beams, stairs, rooms)
- All state.X.forEach changed to filtered X.forEach (12+ places)

**floor/floor-panel.js (line 204-211):**
- Changed from global state check to floor-specific filtering
- Added filtering for walls, doors, columns, beams, stairs
- hasContent now accurately reflects each floor's content

**general-files/actions.js:**
- Removed debug logging (cleanup)

**Impact:**
- ✅ Symmetry operations fully floor-isolated
- ✅ Copy operations fully floor-isolated
- ✅ Floor indicators show accurate per-floor content status
- ✅ No cross-floor interference in any operations