### PR TITLE
fix: Prevent stuck mouse state after ALT+TAB window switching

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -758,6 +758,46 @@ export function setupInputListeners() {
              saveState();
         }
     });
+
+    // ALT+TAB stuck state fix: Window focus kaybolduğunda state'i temizle
+    window.addEventListener("blur", () => {
+        console.log('🔄 Window blur - Cleaning up stuck states');
+
+        // Tüm modifier key'leri resetle
+        currentModifierKeys.ctrl = false;
+        currentModifierKeys.alt = false;
+        currentModifierKeys.shift = false;
+
+        // Dragging state'i temizle
+        if (state.isDragging) {
+            setState({
+                isDragging: false,
+                isStretchDragging: false,
+                affectedWalls: [],
+                preDragWallStates: new Map(),
+                preDragNodeStates: new Map()
+            });
+            if (state.history[state.historyIndex]) restoreState(state.history[state.historyIndex]);
+        }
+
+        // Panning state'i temizle
+        if (state.isPanning) {
+            setState({ isPanning: false });
+            dom.p2d.classList.remove('panning');
+        }
+
+        // Delete mode'u temizle
+        if (state.isCtrlDeleting) {
+            setState({ isCtrlDeleting: false });
+            dom.p2d.style.cursor = '';
+        }
+
+        // Cursor'u resetle
+        if (dom.p2d) {
+            dom.p2d.style.cursor = '';
+        }
+    });
+
     window.addEventListener("copy", handleCopy);
     window.addEventListener("paste", handlePaste);
     window.addEventListener("keydown", onKeyDown);


### PR DESCRIPTION
This fixes the critical bug where mouse clicks stop working after switching windows with ALT+TAB during drawing operations.

**Problem:**
When user switches away (ALT+TAB) during a mouse operation:
1. mousedown event fires normally
2. User switches to another window
3. mouseup event is lost (fires in other window)
4. App returns with stuck state: isDragging, isPanning, etc.
5. Mouse clicks no longer work until page refresh

**Solution - general-files/input.js (line 762-799):**

Added window.addEventListener("blur") to cleanup all states:

```javascript
window.addEventListener("blur", () => {
    // Reset all modifier keys
    currentModifierKeys.ctrl = false;
    currentModifierKeys.alt = false;
    currentModifierKeys.shift = false;

    // Clean dragging state
    if (state.isDragging) {
        setState({...});
        restoreState(state.history[state.historyIndex]);
    }

    // Clean panning state
    if (state.isPanning) {
        setState({ isPanning: false });
        dom.p2d.classList.remove('panning');
    }

    // Clean delete mode
    if (state.isCtrlDeleting) {
        setState({ isCtrlDeleting: false });
    }

    // Reset cursor
    dom.p2d.style.cursor = '';
});
```

**Impact:**
- ✅ Window blur (ALT+TAB, minimize, etc.) resets all states
- ✅ Mouse clicks work correctly after returning to app
- ✅ No more stuck dragging/panning/delete modes
- ✅ Modifier keys properly reset
- ✅ Cursor properly reset

**User reported test case:**
- Drawing walls -> ALT+TAB away -> return -> mouse works!