### PR TITLE
fix: Restore original filter logic to preserve wall dragging behavior

### DIFF
--- a/general-files/actions.js
+++ b/general-files/actions.js
@@ -74,19 +74,10 @@ export function getObjectAtPoint(pos) {
     const { zoom } = state;
     const currentFloorId = state.currentFloor?.id;
 
-    // STRICT FLOOR FILTERING: Eğer currentFloor varsa, SADECE o kattaki objeleri al
-    const walls = (state.walls || []).filter(w => {
-        if (currentFloorId) return w.floorId === currentFloorId;
-        return !w.floorId; // currentFloor yoksa, sadece floorId olmayan duvarları al
-    });
-    const doors = (state.doors || []).filter(d => {
-        if (currentFloorId) return d.floorId === currentFloorId;
-        return !d.floorId;
-    });
-    const rooms = (state.rooms || []).filter(r => {
-        if (currentFloorId) return r.floorId === currentFloorId;
-        return !r.floorId;
-    });
+    // Floor filtering: currentFloor varsa sadece o kattaki objeleri al
+    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
 
     const tolerance = 8 / zoom;
 

--- a/wall/wall-handler.js
+++ b/wall/wall-handler.js
@@ -25,11 +25,7 @@ export function wallExists(p1, p2) {
  */
 export function getWallAtPoint(pos, tolerance) {
     const currentFloorId = state.currentFloor?.id;
-    // STRICT FLOOR FILTERING: Only check walls from current floor
-    const walls = (state.walls || []).filter(w => {
-        if (currentFloorId) return w.floorId === currentFloorId;
-        return !w.floorId;
-    });
+    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
 
     // Duvar ucu (node) kontrolü
     for (const wall of [...walls].reverse()) {
@@ -263,11 +259,7 @@ export function onPointerDownSelect(selectedObject, pos, snappedPos, e) {
  */
 export function onPointerMove(snappedPos, unsnappedPos) {
     const currentFloorId = state.currentFloor?.id;
-    // STRICT FLOOR FILTERING: Only work with walls from current floor
-    const walls = (state.walls || []).filter(w => {
-        if (currentFloorId) return w.floorId === currentFloorId;
-        return !w.floorId;
-    });
+    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
     let neighborWallsToDimension = new Set(); // Komşu duvarları saklamak için Set
 
     if (state.selectedObject.handle !== "body") {


### PR DESCRIPTION
CRITICAL: Previous strict filter was WRONG and broke wall dragging!

Old logic (CORRECT):
  !currentFloorId || w.floorId === currentFloorId
  → If no currentFloor: include ALL walls
  → If currentFloor exists: include only matching floor

My wrong logic (BROKE EVERYTHING):
  if (currentFloorId) return w.floorId === currentFloorId; return !w.floorId;
  → If no currentFloor: include ONLY walls WITHOUT floorId
  → This broke sweep, neighbor detection, and all wall interactions!

Changes:
- Reverted filter logic in wall-handler.js (getWallAtPoint, onPointerMove)
- Reverted filter logic in actions.js (getObjectAtPoint)
- KEPT the critical fix: line 40 uses 'walls' not 'state.walls' for body check

This preserves all existing wall dragging behavior while fixing cross-floor selection.