### PR TITLE
fix: Add cross-floor selection blocking WITHOUT breaking sweep behavior

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -130,6 +130,31 @@ export function onPointerDown(e) {
             });
         }
 
+        // FLOOR VALIDATION: Farklı kattaki objeleri seçmeyi engelle
+        if (clickedObject && state.currentFloor?.id) {
+            const currentFloorId = state.currentFloor.id;
+            const obj = clickedObject.object;
+
+            // Wall, door, window, vent, column, beam, stairs için floor kontrolü
+            if (['wall', 'door', 'window', 'vent', 'column', 'beam', 'stairs'].includes(clickedObject.type)) {
+                // Wall için direkt object'ten kontrol
+                if (clickedObject.type === 'wall' && obj.floorId && obj.floorId !== currentFloorId) {
+                    console.log('🚫 Cross-floor wall selection blocked:', obj.floorId, '!==', currentFloorId);
+                    clickedObject = null;
+                }
+                // Door/window/vent için wall üzerinden kontrol
+                else if (['door', 'window', 'vent'].includes(clickedObject.type) && clickedObject.wall?.floorId && clickedObject.wall.floorId !== currentFloorId) {
+                    console.log('🚫 Cross-floor', clickedObject.type, 'selection blocked');
+                    clickedObject = null;
+                }
+                // Column, beam, stairs için direkt object'ten kontrol
+                else if (['column', 'beam', 'stairs'].includes(clickedObject.type) && obj.floorId && obj.floorId !== currentFloorId) {
+                    console.log('🚫 Cross-floor', clickedObject.type, 'selection blocked');
+                    clickedObject = null;
+                }
+            }
+        }
+
         // Tıklanan nesne varsa seçili yap ve sürüklemeyi başlat
         if (clickedObject) {
             if (clickedObject.type === 'room') {


### PR DESCRIPTION
CRITICAL: Previous approach broke sweep walls by modifying getWallAtPoint!

New approach:
- Do NOT modify getWallAtPoint or any wall detection logic
- Instead, validate clickedObject AFTER getObjectAtPoint returns
- If object is from different floor, set clickedObject = null
- This prevents selection but keeps all sweep/T-junction logic intact

Why this works:
- getWallAtPoint still uses state.walls (all floors) for body detection
- T-junction splitting in onPointerDownSelect uses state.walls (unchanged)
- Sweep wall generation in onPointerMove uses state.walls (unchanged)
- Only the FINAL selection is validated for floor match

Validates:
- Walls: obj.floorId !== currentFloorId
- Doors/windows/vents: wall.floorId !== currentFloorId
- Columns/beams/stairs: obj.floorId !== currentFloorId