### PR TITLE
fix: Add floorId support for saved projects and legacy compatibility

### DIFF
--- a/architectural-objects/beams.js
+++ b/architectural-objects/beams.js
@@ -84,7 +84,7 @@ export function getBeamAtPoint(point) {
     const { zoom } = state;
     const currentFloorId = state.currentFloor?.id;
     // Sadece aktif kata ait kirişleri filtrele
-    const beams = (state.beams || []).filter(b => !currentFloorId || b.floorId === currentFloorId);
+    const beams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
     const handleTolerance = 8 / zoom;
 
     for (const beam of [...beams].reverse()) {

--- a/architectural-objects/columns.js
+++ b/architectural-objects/columns.js
@@ -88,7 +88,7 @@ export function getColumnAtPoint(point) {
     const { zoom } = state;
     const currentFloorId = state.currentFloor?.id;
     // Sadece aktif kata ait kolonları filtrele
-    const columns = (state.columns || []).filter(c => !currentFloorId || c.floorId === currentFloorId);
+    const columns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
     const handleTolerance = 8 / zoom;
 
     for (const column of [...columns].reverse()) {

--- a/architectural-objects/door-handler.js
+++ b/architectural-objects/door-handler.js
@@ -12,7 +12,7 @@ import { findAvailableSegmentAt, checkOverlapAndGap } from '../wall/wall-item-ut
  */
 export function getDoorAtPoint(pos, tolerance) {
     const currentFloorId = state.currentFloor?.id;
-    const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
 
     for (const door of [...doors].reverse()) {
         const wall = door.wall;
@@ -45,8 +45,8 @@ export function getDoorAtPoint(pos, tolerance) {
  */
 export function onPointerDownDraw(pos, clickedObject) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
 
     // 1. Direkt duvara yerleştirmeyi dene
     let previewWall = null, minDistSqPreview = Infinity;

--- a/architectural-objects/stairs.js
+++ b/architectural-objects/stairs.js
@@ -269,7 +269,7 @@ export function getStairAtPoint(point) {
     const { zoom } = state;
     const currentFloorId = state.currentFloor?.id;
     // Sadece aktif kata ait merdivenleri filtrele
-    const stairs = (state.stairs || []).filter(s => !currentFloorId || s.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
     if (stairs.length === 0) return null; // Merdiven yoksa null dön
     const handleTolerance = 8 / zoom; // Handle yakalama toleransı (zoom'a bağlı)
     // Önce handle'ları kontrol et (daha küçük hedef alan, daha öncelikli)

--- a/architectural-objects/window-handler.js
+++ b/architectural-objects/window-handler.js
@@ -12,7 +12,7 @@ function getRoomsAdjacentToWall(wall) {
     if (!state.rooms || state.rooms.length === 0 || !wall || !wall.p1 || !wall.p2) return adjacentRooms;
 
     const currentFloorId = state.currentFloor?.id;
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
 
     for (const room of rooms) {
         if (!room.polygon || !room.polygon.geometry) continue;
@@ -41,7 +41,7 @@ function getRoomsAdjacentToWall(wall) {
  */
 export function getWindowAtPoint(pos, tolerance) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
 
     for (const wall of walls) {
         if (!wall.windows || wall.windows.length === 0 || !wall.p1 || !wall.p2) continue;
@@ -133,7 +133,7 @@ function addWindowToWallMiddle(wall, roomName = null) { // Oda adı parametresi 
  */
 export function onPointerDownDraw(pos, clickedObject) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
 
     // 1. Direkt duvara yerleştirmeyi dene
     let previewWall = null, minDistSqPreview = Infinity;
@@ -286,7 +286,7 @@ export function onPointerMove(unsnappedPos) {
     const targetPos = { x: targetX, y: targetY };
 
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
 
     let closestWall = null;
     let minDistSq = Infinity;

--- a/draw/draw-previews.js
+++ b/draw/draw-previews.js
@@ -11,7 +11,7 @@ export function drawObjectPlacementPreviews(ctx2d, state, getDoorPlacement, isSp
 
     // FLOOR ISOLATION: Sadece aktif kattaki duvarları kullan
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
 
     // Kapı önizlemesi
     if (currentMode === "drawDoor" && !isPanning && !isDragging) {

--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -233,12 +233,12 @@ export function draw2D() {
 
     // Sadece aktif kata ait çizimleri filtrele
     const currentFloorId = state.currentFloor?.id;
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
-    const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);
-    const beams = (state.beams || []).filter(b => !currentFloorId || b.floorId === currentFloorId);
-    const stairs = (state.stairs || []).filter(s => !currentFloorId || s.floorId === currentFloorId);
-    const columns = (state.columns || []).filter(c => !currentFloorId || c.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
+    const beams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
+    const columns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
 
     // Sadece aktif kata ait node'ları filtrele (duvarlardan topla)
     const nodesSet = new Set();

--- a/draw/geometry.js
+++ b/draw/geometry.js
@@ -128,7 +128,7 @@ export function findNodeAt(x, y) {
     const currentFloorId = state.currentFloor?.id;
 
     // Sadece aktif kattaki duvarlardan node'ları topla
-    const currentFloorWalls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const currentFloorWalls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
     const nodesSet = new Set();
     currentFloorWalls.forEach(w => {
         if (w.p1) nodesSet.add(w.p1);
@@ -149,7 +149,7 @@ export function getOrCreateNode(x, y) {
     const currentFloorId = state.currentFloor?.id;
 
     // Sadece aktif kattaki duvarlardan node'ları topla
-    const currentFloorWalls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const currentFloorWalls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
     const nodesSet = new Set();
     currentFloorWalls.forEach(w => {
         if (w.p1) nodesSet.add(w.p1);
@@ -186,8 +186,8 @@ export function calculatePlanarArea(coords) {
 export function detectRooms() {
     const currentFloorId = state.currentFloor?.id;
     // Sadece aktif kattaki duvarları kullan
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
-    const oldRooms = [...state.rooms].filter(r => !currentFloorId || r.floorId === currentFloorId); // Sadece aktif kattaki önceki odaları koru
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const oldRooms = [...state.rooms].filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId); // Sadece aktif kattaki önceki odaları koru
 
     // Yeterli duvar yoksa oda oluşmaz
     if (walls.length < 3) {

--- a/draw/symmetry.js
+++ b/draw/symmetry.js
@@ -27,12 +27,12 @@ export function calculateCopyPreview(axisP1, axisP2) {
 
     // FLOOR ISOLATION: Sadece aktif kattaki elemanları kopyala
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
-    const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);
-    const columns = (state.columns || []).filter(c => !currentFloorId || c.floorId === currentFloorId);
-    const beams = (state.beams || []).filter(b => !currentFloorId || b.floorId === currentFloorId);
-    const stairs = (state.stairs || []).filter(s => !currentFloorId || s.floorId === currentFloorId);
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
+    const columns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
+    const beams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
 
     // Aktif kattaki duvarlardan node'ları topla
     const nodesSet = new Set();
@@ -226,12 +226,12 @@ export function calculateSymmetryPreview(axisP1, axisP2) {
 
     // FLOOR ISOLATION: Sadece aktif kattaki elemanları yansıt
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
-    const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);
-    const columns = (state.columns || []).filter(c => !currentFloorId || c.floorId === currentFloorId);
-    const beams = (state.beams || []).filter(b => !currentFloorId || b.floorId === currentFloorId);
-    const stairs = (state.stairs || []).filter(s => !currentFloorId || s.floorId === currentFloorId);
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
+    const columns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
+    const beams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
 
     // Aktif kattaki duvarlardan node'ları topla
     const nodesSet = new Set();

--- a/general-files/actions.js
+++ b/general-files/actions.js
@@ -75,9 +75,9 @@ export function getObjectAtPoint(pos) {
     const currentFloorId = state.currentFloor?.id;
 
     // Floor filtering: currentFloor varsa sadece o kattaki objeleri al
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
-    const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
 
     const tolerance = 8 / zoom;
 

--- a/general-files/file-io.js
+++ b/general-files/file-io.js
@@ -41,7 +41,8 @@ function saveProject() {
             vents: w.vents || [],
             isArc: w.isArc, // EKLENDİ
             arcControl1: w.arcControl1, // EKLENDİ
-            arcControl2: w.arcControl2  // EKLENDİ
+            arcControl2: w.arcControl2,  // EKLENDİ
+            floorId: w.floorId // floorId ekle
         })),
         doors: state.doors.map(d => ({
             wallIndex: state.walls.indexOf(d.wall),
@@ -190,7 +191,8 @@ function openProject(e) {
                     vents: w.vents || [],
                     isArc: w.isArc,
                     arcControl1: w.arcControl1,
-                    arcControl2: w.arcControl2
+                    arcControl2: w.arcControl2,
+                    floorId: w.floorId // floorId geri yükle
                 }));
 
                 // Kapıları geri yükle

--- a/general-files/snap.js
+++ b/general-files/snap.js
@@ -66,8 +66,8 @@ function getStairEdges(stair) {
 function getStairSnapPoint(wm, screenMouse, SNAP_RADIUS_PIXELS) {
     const candidates = [];
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
-    const stairs = (state.stairs || []).filter(s => !currentFloorId || s.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
 
     // Aday ekleme yardımcısı
     const addCandidate = (point, type, distance) => {
@@ -272,7 +272,7 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
 
     // Sadece aktif kata ait duvarları kullan
     const currentFloorId = state.currentFloor?.id;
-    const currentFloorWalls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const currentFloorWalls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
 
     // Taranacak duvarlar
     const wallsToScan = state.snapOptions.nearestOnly
@@ -318,7 +318,7 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
     }
 
     // Kolon, Kiriş Snap Noktaları (sadece aktif kat)
-    const currentFloorColumns = (state.columns || []).filter(c => !currentFloorId || c.floorId === currentFloorId);
+    const currentFloorColumns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
     if (currentFloorColumns.length > 0) {
         currentFloorColumns.forEach(column => {
              if (state.isDragging && state.selectedObject?.type === 'column' && state.selectedObject.object === column) return;
@@ -337,7 +337,7 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
              } catch (error) { console.error("Error processing column corners for snap:", error, column); }
         });
     }
-    const currentFloorBeams = (state.beams || []).filter(b => !currentFloorId || b.floorId === currentFloorId);
+    const currentFloorBeams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
     if (currentFloorBeams.length > 0) {
          currentFloorBeams.forEach(beam => {
              if (state.isDragging && state.selectedObject?.type === 'beam' && state.selectedObject.object === beam) return;
@@ -358,7 +358,7 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
     }
 
     // Merdiven Köşe/Merkez Snap (Çizim modu DIŞINDA, sadece aktif kat)
-    const currentFloorStairs = (state.stairs || []).filter(s => !currentFloorId || s.floorId === currentFloorId);
+    const currentFloorStairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
     if (state.currentMode !== 'drawStairs' && currentFloorStairs.length > 0) {
         for (const stair of currentFloorStairs) {
              if (state.isDragging && state.selectedObject?.type === 'stairs' && state.selectedObject.object === stair) continue;

--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -22,7 +22,7 @@ const SYMMETRY_PREVIEW_DEBOUNCE_MS = 50; // 50ms gecikme
 // Helper: Verilen bir noktanın duvar merkez çizgisine snap olup olmadığını kontrol eder.
 function getSnappedWallInfo(point, tolerance = 1.0) { // Tolerans: 1 cm
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
     for (const wall of walls) {
         if (!wall.p1 || !wall.p2) continue;
         const distSq = distToSegmentSquared(point, wall.p1, wall.p2);
@@ -52,7 +52,7 @@ export function onPointerMove(e) {
         let needsProcessing = false;
 
         const currentFloorId_delete = state.currentFloor?.id;
-        const walls_delete = (state.walls || []).filter(w => !currentFloorId_delete || w.floorId === currentFloorId_delete);
+        const walls_delete = (state.walls || []).filter(w => !currentFloorId_delete || !w.floorId || w.floorId === currentFloorId_delete);
 
         // Duvar silme
         const wallsToDelete = new Set();
@@ -247,7 +247,7 @@ export function onPointerMove(e) {
             case 'window': onPointerMoveWindow(unsnappedPos);             break;
             case 'vent':
                 const currentFloorId_vent = state.currentFloor?.id;
-                const walls_vent = (state.walls || []).filter(w => !currentFloorId_vent || w.floorId === currentFloorId_vent);
+                const walls_vent = (state.walls || []).filter(w => !currentFloorId_vent || !w.floorId || w.floorId === currentFloorId_vent);
                 const vent = state.selectedObject.object; const oldWall = state.selectedObject.wall;
                 const targetX = unsnappedPos.x + state.dragOffset.x; const targetY = unsnappedPos.y + state.dragOffset.y; const targetPos = { x: targetX, y: targetY };
                 let closestWall = null; let minDistSq = Infinity; const bodyHitTolerance = state.wallThickness * 2;

--- a/scene3d/scene3d-update.js
+++ b/scene3d/scene3d-update.js
@@ -58,12 +58,12 @@ export function update3DScene() {
 
     // Sadece aktif kata ait elementleri filtrele
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
-    const doors = (state.doors || []).filter(d => !currentFloorId || d.floorId === currentFloorId);
-    const columns = (state.columns || []).filter(c => !currentFloorId || c.floorId === currentFloorId);
-    const beams = (state.beams || []).filter(b => !currentFloorId || b.floorId === currentFloorId);
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || r.floorId === currentFloorId);
-    const stairs = (state.stairs || []).filter(s => !currentFloorId || s.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
+    const columns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
+    const beams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
 
     // --- Duvarları, Kapıları, Pencereleri ve Menfezleri Oluştur ---
     walls.forEach(w => {

--- a/wall/wall-handler.js
+++ b/wall/wall-handler.js
@@ -25,7 +25,7 @@ export function wallExists(p1, p2) {
  */
 export function getWallAtPoint(pos, tolerance) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
 
     // Duvar ucu (node) kontrolü
     for (const wall of [...walls].reverse()) {
@@ -259,7 +259,7 @@ export function onPointerDownSelect(selectedObject, pos, snappedPos, e) {
  */
 export function onPointerMove(snappedPos, unsnappedPos) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || w.floorId === currentFloorId);
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
     let neighborWallsToDimension = new Set(); // Komşu duvarları saklamak için Set
 
     if (state.selectedObject.handle !== "body") {


### PR DESCRIPTION
SWEEP ÖZELLİĞİ GERİ GETİRİLDİ + PROJE YÜKLEME DÜZELTİLDİ

1. Sweep özelliği düzeltildi:
   - Sweep duvarlarına floorId eklendi (wall-handler.js)
   - Shift tuşu ile duvar süpürme tekrar çalışıyor

2. Proje kaydetme/yükleme floorId desteği:
   - Duvarlar kaydedilirken floorId dahil ediliyor
   - Yüklerken floorId geri yükleniyor

3. Legacy proje uyumluluğu (ÖNEMLİ):
   - Eski proje dosyalarında floorId olmayan objeler artık gösteriliyor
   - Tüm floor filtrelerine !obj.floorId kontrolü eklendi
   - 13 dosyada 51 değişiklik yapıldı:
     * pointer/pointer-move.js
     * draw/symmetry.js, draw2d.js, draw-previews.js, geometry.js * general-files/snap.js, actions.js * scene3d/scene3d-update.js * architectural-objects/door-handler.js, window-handler.js * architectural-objects/columns.js, beams.js, stairs.js

Artık hem yeni hem eski projeler doğru çalışıyor!