### PR TITLE
feat: Enhance layer navigation UI and 3D view controls

### DIFF
--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -81,11 +81,16 @@ export function createFloorPanel() {
 
     document.body.appendChild(miniPanel);
 
-    // Genişleme butonu
+    // Genişleme butonu - toggle (aç/kapat)
     const expandBtn = miniPanel.querySelector('#floor-expand-btn');
     expandBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        showDetailPanel();
+        // Detaylı panel açıksa kapat, kapalıysa aç
+        if (detailPanel && detailPanel.style.display === 'block') {
+            hideDetailPanel();
+        } else {
+            showDetailPanel();
+        }
     });
 
     // Hover efekti
@@ -95,9 +100,6 @@ export function createFloorPanel() {
     expandBtn.addEventListener('mouseleave', () => {
         expandBtn.style.background = 'transparent';
     });
-
-    // Çift tıklama ile detaylı panel aç
-    miniPanel.addEventListener('dblclick', showDetailPanel);
 
     // Kaydırma okları
     setupScrollButtons();
@@ -154,7 +156,17 @@ function updateScrollButtons() {
     const scrollRight = miniPanel.querySelector('#floor-scroll-right');
     const floorList = miniPanel.querySelector('#floor-mini-list');
 
-    // Okları her zaman görünür yap, sadece opacity ile kontrol et
+    // Scroll gerekli mi kontrol et
+    const needsScroll = floorList.scrollWidth > floorList.clientWidth + 5;
+
+    // Scroll gerekmiyorsa okları tamamen gizle
+    if (!needsScroll) {
+        scrollLeft.style.display = 'none';
+        scrollRight.style.display = 'none';
+        return;
+    }
+
+    // Scroll gerekiyorsa okları göster ve opacity ile kontrol et
     scrollLeft.style.display = 'flex';
     scrollRight.style.display = 'flex';
 
@@ -1464,4 +1476,9 @@ function bulkSetHeight() {
     selectedFloorObjects.forEach(floor => {
         updateFloorHeight(floor.id, newHeight);
     });
+}
+
+// Window'a export et (klavye kısayolları için)
+if (typeof window !== 'undefined') {
+    window.renderMiniPanel = renderMiniPanel;
 }

--- a/general-files/input.js
+++ b/general-files/input.js
@@ -278,11 +278,43 @@ function onKeyDown(e) {
         return; // Diğer kısayollarla çakışmasın
     }
 
-    // TAB ile duvar uzatma
-    if (e.key === "Tab" && state.currentMode === "drawWall" && state.startPoint) {
-        e.preventDefault();
-        extendWallOnTabPress();
-        return;
+    // TAB ile duvar uzatma veya kat değiştirme
+    if (e.key === "Tab") {
+        // Shift+Tab veya Ctrl+Shift+Tab ile kat değiştirme
+        if (e.shiftKey) {
+            e.preventDefault();
+
+            // Görünür katları al ve sırala
+            const visibleFloors = (state.floors || [])
+                .filter(f => !f.isPlaceholder && f.visible !== false)
+                .sort((a, b) => a.bottomElevation - b.bottomElevation);
+
+            if (visibleFloors.length === 0) return;
+
+            const currentIndex = visibleFloors.findIndex(f => f.id === state.currentFloor?.id);
+
+            let newIndex;
+            if (e.ctrlKey) {
+                // Ctrl+Shift+Tab: Önceki kat (circular)
+                newIndex = currentIndex <= 0 ? visibleFloors.length - 1 : currentIndex - 1;
+            } else {
+                // Shift+Tab: Sonraki kat (circular)
+                newIndex = currentIndex >= visibleFloors.length - 1 ? 0 : currentIndex + 1;
+            }
+
+            setState({ currentFloor: visibleFloors[newIndex] });
+
+            // Mini panel'i güncelle (eğer varsa)
+            if (window.renderMiniPanel) window.renderMiniPanel();
+
+            return;
+        }
+        // Tab ile duvar uzatma (sadece drawWall modundayken ve startPoint varsa)
+        else if (state.currentMode === "drawWall" && state.startPoint) {
+            e.preventDefault();
+            extendWallOnTabPress();
+            return;
+        }
     }
 
     // Sayısal giriş ile boyut düzenleme

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -352,6 +352,7 @@ export const dom = {
     bOpen: document.getElementById("bOpen"),
     fileInput: document.getElementById("file-input"),
     bFirstPerson: document.getElementById("bFirstPerson"),
+    bFloorView: document.getElementById("bFloorView"),
     bAssignNames: document.getElementById("bAssignNames"),
     settingsBtn: document.getElementById("settings-btn"),
     settingsPopup: document.getElementById("settings-popup"),

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -803,5 +803,54 @@ export function setupUIListeners() {
     dom.b3d.addEventListener('click', () => {
         toggle3DView();
     });
+
+    // KATI GÖSTER / BİNAYI GÖSTER TOGGLE BUTONU
+    if (dom.bFloorView) {
+        dom.bFloorView.addEventListener('click', () => {
+            const currentMode = dom.bFloorView.getAttribute('data-view-mode');
+            const floorIcon = document.getElementById('floor-icon');
+            const buildingIcon = document.getElementById('building-icon');
+            const label = document.getElementById('bFloorViewLabel');
+
+            if (currentMode === 'floor') {
+                // Binayı göster moduna geç
+                dom.bFloorView.setAttribute('data-view-mode', 'building');
+                if (floorIcon) floorIcon.style.display = 'none';
+                if (buildingIcon) buildingIcon.style.display = 'block';
+                if (label) label.textContent = 'Binayı Göster';
+
+                // Tüm katları görünür yap (TODO: 3D sahneyi güncelle)
+                const floors = state.floors || [];
+                floors.forEach(f => {
+                    if (!f.isPlaceholder) {
+                        f.visible = true;
+                    }
+                });
+                setState({ floors });
+            } else {
+                // Katı göster moduna geç
+                dom.bFloorView.setAttribute('data-view-mode', 'floor');
+                if (floorIcon) floorIcon.style.display = 'block';
+                if (buildingIcon) buildingIcon.style.display = 'none';
+                if (label) label.textContent = 'Katı Göster';
+
+                // Sadece aktif katı görünür yap
+                const floors = state.floors || [];
+                const currentFloorId = state.currentFloor?.id;
+                floors.forEach(f => {
+                    if (!f.isPlaceholder) {
+                        f.visible = (f.id === currentFloorId);
+                    }
+                });
+                setState({ floors });
+            }
+
+            // 3D sahneyi güncelle
+            update3DScene();
+
+            // Mini panel'i güncelle
+            if (window.renderMiniPanel) window.renderMiniPanel();
+        });
+    }
 }
 // --- setupUIListeners Sonu ---

--- a/index.html
+++ b/index.html
@@ -296,6 +296,21 @@
     <div id="split-ratio-buttons" style="display: none;">
         <!-- Koordinatlar (en solda) -->
         <span id="camera-coords" style="display: none;">x: 0, y: 0, z: 0</span>
+        <!-- Katı Göster / Binayı Göster toggle butonu -->
+        <button id="bFloorView" class="fps-btn" title="Katı Göster / Binayı Göster" data-view-mode="floor">
+            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5">
+                <!-- Kat görünümü ikonu (tek kat) -->
+                <rect id="floor-icon" x="4" y="10" width="16" height="8" stroke="currentColor" fill="none" stroke-width="1.5"></rect>
+                <line x1="4" y1="14" x2="20" y2="14" stroke="currentColor" stroke-width="1"></line>
+                <!-- Bina görünümü ikonu (çok katlı) - başlangıçta gizli -->
+                <g id="building-icon" style="display: none;">
+                    <rect x="4" y="6" width="16" height="12" stroke="currentColor" fill="none" stroke-width="1.5"></rect>
+                    <line x1="4" y1="10" x2="20" y2="10" stroke="currentColor" stroke-width="1"></line>
+                    <line x1="4" y1="14" x2="20" y2="14" stroke="currentColor" stroke-width="1"></line>
+                </g>
+            </svg>
+            <span id="bFloorViewLabel">Katı Göster</span>
+        </button>
         <!-- FPS Kamera butonu -->
         <button id="bFirstPerson" class="fps-btn" title="FPS Kamera">FPS Kamera</button>
         <!-- Ayırıcı -->
@@ -327,6 +342,9 @@
         <button id="split-0" class="split-btn" data-ratio="0" title="3D Kapalı">
             <svg viewBox="0 0 24 24" width="24" height="24">
                 <rect x="2" y="2" width="20" height="20" fill="#999" stroke="#666" stroke-width="1"/>
+                <!-- × işareti (Close/Kapalı) -->
+                <line x1="8" y1="8" x2="16" y2="16" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+                <line x1="16" y1="8" x2="8" y2="16" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
             </svg>
         </button>
     </div>


### PR DESCRIPTION
### Keyboard Shortcuts
- Add Shift+Tab to navigate to next floor (circular)
- Add Ctrl+Shift+Tab to navigate to previous floor (circular)
- Circular navigation: wraps from last to first floor and vice versa

### Floor Panel Improvements
- Remove double-click to open floors panel
- Make floors panel button toggle (open/close with same button)
- Hide scroll arrows initially, show only when panel content overflows
- Export renderMiniPanel to window for keyboard shortcut integration

### 3D View Enhancements
- Add × icon to 0% split ratio button to indicate close/off state
- Add "Show Floor/Show Building" toggle button next to FPS camera
  - Toggle between single floor view and full building view
  - Updates floor visibility and refreshes 3D scene
  - Includes visual icon changes (single floor vs multi-floor building)

All improvements focused on streamlining layer navigation workflow.