### PR TITLE
refactor: Reorganize 3D view controls layout

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -643,6 +643,50 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
     height: 100%;
 }
 
+/* Katı/Binayı Göster Butonu (dikdörtgen) */
+.floor-view-btn {
+    padding: 6px 12px;
+    background: rgba(60, 64, 67, 0.8);
+    border: 1px solid #5f6368;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    color: #e8eaed;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+}
+
+.floor-view-btn:hover {
+    background: rgba(80, 84, 87, 1);
+    border-color: #87CEEB;
+    transform: scale(1.05);
+}
+
+.floor-view-btn.active {
+    background: rgba(100, 149, 237, 0.3);
+    border-color: #87CEEB;
+    box-shadow: 0 0 8px rgba(135, 206, 235, 0.4);
+    color: #a8dadc;
+}
+
+/* FPS Kamera Kontrolleri (Sağ Alt) */
+#fps-camera-controls {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    z-index: 100;
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    background: rgba(30, 31, 32, 0.85);
+    padding: 4px;
+    border-radius: 6px;
+    border: 1px solid rgba(100, 149, 237, 0.3);
+    backdrop-filter: blur(4px);
+}
+
 /* 3D Göster Butonu - 2D Ekranın Sağ Üst Köşesi */
 .btn-show-3d {
     position: absolute;

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -164,12 +164,20 @@ export function toggle3DView() {
         const splitButtons = document.getElementById('split-ratio-buttons');
         if (splitButtons) splitButtons.style.display = 'flex';
 
+        // FPS kamera kontrollerini göster
+        const fpsControls = document.getElementById('fps-camera-controls');
+        if (fpsControls) fpsControls.style.display = 'flex';
+
         // Varsayılan split ratio'yu ayarla (25%)
         setSplitRatio(25);
     } else {
         // Split ratio butonlarını gizle
         const splitButtons = document.getElementById('split-ratio-buttons');
         if (splitButtons) splitButtons.style.display = 'none';
+
+        // FPS kamera kontrollerini gizle
+        const fpsControls = document.getElementById('fps-camera-controls');
+        if (fpsControls) fpsControls.style.display = 'none';
     }
 
     setTimeout(() => {
@@ -808,18 +816,14 @@ export function setupUIListeners() {
     if (dom.bFloorView) {
         dom.bFloorView.addEventListener('click', () => {
             const currentMode = dom.bFloorView.getAttribute('data-view-mode');
-            const floorIcon = document.getElementById('floor-icon');
-            const buildingIcon = document.getElementById('building-icon');
-            const label = document.getElementById('bFloorViewLabel');
 
             if (currentMode === 'floor') {
                 // Binayı göster moduna geç
                 dom.bFloorView.setAttribute('data-view-mode', 'building');
-                if (floorIcon) floorIcon.style.display = 'none';
-                if (buildingIcon) buildingIcon.style.display = 'block';
-                if (label) label.textContent = 'Binayı Göster';
+                dom.bFloorView.textContent = 'BİNA';
+                dom.bFloorView.title = 'Binayı Göster (Tüm Katlar)';
 
-                // Tüm katları görünür yap (TODO: 3D sahneyi güncelle)
+                // Tüm katları görünür yap
                 const floors = state.floors || [];
                 floors.forEach(f => {
                     if (!f.isPlaceholder) {
@@ -830,9 +834,8 @@ export function setupUIListeners() {
             } else {
                 // Katı göster moduna geç
                 dom.bFloorView.setAttribute('data-view-mode', 'floor');
-                if (floorIcon) floorIcon.style.display = 'block';
-                if (buildingIcon) buildingIcon.style.display = 'none';
-                if (label) label.textContent = 'Katı Göster';
+                dom.bFloorView.textContent = 'KAT';
+                dom.bFloorView.title = 'Katı Göster (Sadece Aktif Kat)';
 
                 // Sadece aktif katı görünür yap
                 const floors = state.floors || [];

--- a/index.html
+++ b/index.html
@@ -292,29 +292,14 @@
 <div id="splitter"></div>
 <div id="p3d" class="panel">
     <canvas id="c3d"></canvas>
-    <!-- 3D Overlay: Ekran Bölme Oranı Butonları ve FPS Kamera (Sağ Üst) -->
+    <!-- 3D Overlay: Ekran Bölme Oranı Butonları (Sağ Üst) -->
     <div id="split-ratio-buttons" style="display: none;">
-        <!-- Koordinatlar (en solda) -->
-        <span id="camera-coords" style="display: none;">x: 0, y: 0, z: 0</span>
-        <!-- Katı Göster / Binayı Göster toggle butonu -->
-        <button id="bFloorView" class="fps-btn" title="Katı Göster / Binayı Göster" data-view-mode="floor">
-            <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.5">
-                <!-- Kat görünümü ikonu (tek kat) -->
-                <rect id="floor-icon" x="4" y="10" width="16" height="8" stroke="currentColor" fill="none" stroke-width="1.5"></rect>
-                <line x1="4" y1="14" x2="20" y2="14" stroke="currentColor" stroke-width="1"></line>
-                <!-- Bina görünümü ikonu (çok katlı) - başlangıçta gizli -->
-                <g id="building-icon" style="display: none;">
-                    <rect x="4" y="6" width="16" height="12" stroke="currentColor" fill="none" stroke-width="1.5"></rect>
-                    <line x1="4" y1="10" x2="20" y2="10" stroke="currentColor" stroke-width="1"></line>
-                    <line x1="4" y1="14" x2="20" y2="14" stroke="currentColor" stroke-width="1"></line>
-                </g>
-            </svg>
-            <span id="bFloorViewLabel">Katı Göster</span>
+        <!-- Katı Göster / Binayı Göster toggle butonu (dikdörtgen, sadece metin) -->
+        <button id="bFloorView" class="floor-view-btn" title="Katı Göster / Binayı Göster" data-view-mode="floor">
+            KAT
         </button>
-        <!-- FPS Kamera butonu -->
-        <button id="bFirstPerson" class="fps-btn" title="FPS Kamera">FPS Kamera</button>
         <!-- Ayırıcı -->
-        <div style="width: 1px; height: 24px; background: #5f6368; margin: 0 4px;"></div>
+        <div style="width: 1px; height: 24px; background: #5f6368; margin: 0 6px;"></div>
         <!-- Ekran bölme butonları -->
         <button id="split-100" class="split-btn" data-ratio="100" title="Tam Ekran 3D">
             <svg viewBox="0 0 24 24" width="24" height="24">
@@ -347,6 +332,11 @@
                 <line x1="16" y1="8" x2="8" y2="16" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
             </svg>
         </button>
+    </div>
+    <!-- FPS Kamera ve Koordinatlar (Sağ Alt) -->
+    <div id="fps-camera-controls" style="display: none;">
+        <span id="camera-coords" style="display: none;">x: 0, y: 0, z: 0</span>
+        <button id="bFirstPerson" class="fps-btn" title="FPS Kamera">FPS Kamera</button>
     </div>
 </div>
 </div>


### PR DESCRIPTION
### Layout Changes
- Move FPS camera button and coordinates to bottom-right corner
- Relocate floor/building view toggle to left of split ratio buttons
- Separate FPS controls into dedicated container for better organization

### Floor/Building View Button
- Simplified to rectangular button with "KAT" or "BİNA" text only
- Removed icon graphics for cleaner look
- Positioned before split ratio buttons with separator
- Better visual hierarchy: view mode → split ratios

### FPS Camera Controls
- New bottom-right positioned container (#fps-camera-controls)
- Contains FPS camera button and coordinate display
- Keeps viewport controls separate from layout controls
- Improved accessibility and less clutter in top-right area

All changes maintain existing functionality while improving UI organization.