### PR TITLE
fix: Correct floor/building view toggle behavior

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -213,6 +213,7 @@ export let state = {
     roomDragStartPos: null,
     roomOriginalCenter: null,
     dimensionMode: 1,
+    viewMode3D: 'floor', // 3D görünüm modu: 'floor' (sadece aktif kat) veya 'building' (tüm bina)
     zoom: 0.75,
     panOffset: { x: 0, y: 0 },
     isPanning: false,

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -557,8 +557,8 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
     color: #8ab4f8;
 }
 
-/* 3D Overlay: Kamera Koordinatları - split-ratio-buttons içinde */
-#split-ratio-buttons #camera-coords {
+/* 3D Overlay: Kamera Koordinatları */
+#camera-coords {
     background: rgba(30, 31, 32, 0.9);
     padding: 6px 10px;
     border-radius: 4px;

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -818,41 +818,21 @@ export function setupUIListeners() {
             const currentMode = dom.bFloorView.getAttribute('data-view-mode');
 
             if (currentMode === 'floor') {
-                // Binayı göster moduna geç
+                // Binayı göster moduna geç (3D'de tüm katları göster)
                 dom.bFloorView.setAttribute('data-view-mode', 'building');
                 dom.bFloorView.textContent = 'BİNA';
-                dom.bFloorView.title = 'Binayı Göster (Tüm Katlar)';
-
-                // Tüm katları görünür yap
-                const floors = state.floors || [];
-                floors.forEach(f => {
-                    if (!f.isPlaceholder) {
-                        f.visible = true;
-                    }
-                });
-                setState({ floors });
+                dom.bFloorView.title = 'Binayı Göster (3D\'de Tüm Katlar)';
+                setState({ viewMode3D: 'building' });
             } else {
-                // Katı göster moduna geç
+                // Katı göster moduna geç (3D'de sadece aktif katı göster)
                 dom.bFloorView.setAttribute('data-view-mode', 'floor');
                 dom.bFloorView.textContent = 'KAT';
-                dom.bFloorView.title = 'Katı Göster (Sadece Aktif Kat)';
-
-                // Sadece aktif katı görünür yap
-                const floors = state.floors || [];
-                const currentFloorId = state.currentFloor?.id;
-                floors.forEach(f => {
-                    if (!f.isPlaceholder) {
-                        f.visible = (f.id === currentFloorId);
-                    }
-                });
-                setState({ floors });
+                dom.bFloorView.title = 'Katı Göster (3D\'de Sadece Aktif Kat)';
+                setState({ viewMode3D: 'floor' });
             }
 
             // 3D sahneyi güncelle
             update3DScene();
-
-            // Mini panel'i güncelle
-            if (window.renderMiniPanel) window.renderMiniPanel();
         });
     }
 }

--- a/scene3d/scene3d-update.js
+++ b/scene3d/scene3d-update.js
@@ -56,14 +56,22 @@ export function update3DScene() {
         pictureFrameMaterial.transparent = true; pictureFrameMaterial.opacity = solidOpacity; pictureFrameMaterial.needsUpdate = true;
     }
 
-    // Sadece aktif kata ait elementleri filtrele
+    // 3D görünüm moduna göre filtreleme
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
-    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
-    const columns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
-    const beams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
-    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
+    const viewMode = state.viewMode3D || 'floor';
+
+    // 'floor' modunda sadece aktif kat, 'building' modunda tüm katlar görünür
+    const shouldShowFloor = (floorId) => {
+        if (viewMode === 'building') return true; // Tüm katlar
+        return !currentFloorId || !floorId || floorId === currentFloorId; // Sadece aktif kat
+    };
+
+    const walls = (state.walls || []).filter(w => shouldShowFloor(w.floorId));
+    const doors = (state.doors || []).filter(d => shouldShowFloor(d.floorId));
+    const columns = (state.columns || []).filter(c => shouldShowFloor(c.floorId));
+    const beams = (state.beams || []).filter(b => shouldShowFloor(b.floorId));
+    const rooms = (state.rooms || []).filter(r => shouldShowFloor(r.floorId));
+    const stairs = (state.stairs || []).filter(s => shouldShowFloor(s.floorId));
 
     // --- Duvarları, Kapıları, Pencereleri ve Menfezleri Oluştur ---
     walls.forEach(w => {


### PR DESCRIPTION
### 3D View Mode Logic
- Add `viewMode3D` state ('floor' or 'building') to control 3D rendering
- 'floor' mode: Shows only active floor in 3D view
- 'building' mode: Shows all floors together in 3D view
- 2D floor panel visibility remains unchanged - only affects 3D rendering

### Scene Rendering
- Update scene3d-update.js to filter elements based on viewMode3D
- Implement shouldShowFloor() helper for clean filtering logic
- Remove incorrect floor.visible manipulation from UI code

### Coordinate Display Font
- Fix camera coordinates font styling
- Restore monospace font (Consolas, Monaco) for better readability
- Apply styling to all #camera-coords instances (not just in specific container)

The floor/building toggle now correctly controls only 3D scene rendering without affecting the 2D floor navigation panel.