### PR TITLE
fix: Improve guide menu UX and snap behavior

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -568,19 +568,20 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
 .context-submenu {
     display: none;
     position: absolute;
-    left: 100%;
-    top: 0;
+    left: calc(100% - 4px);
+    top: -5px;
     background-color: #2a2b2c;
     border: 1px solid #5f6368;
     border-radius: 6px;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
     padding: 5px;
     min-width: 180px;
-    margin-left: 2px;
     z-index: 201;
+    pointer-events: auto;
 }
 
-.context-menu-item-with-submenu:hover .context-submenu {
+.context-menu-item-with-submenu:hover .context-submenu,
+.context-submenu:hover {
     display: block;
 }
 

--- a/index.html
+++ b/index.html
@@ -271,7 +271,6 @@
     </div>
 </div>
 <div id="guide-context-menu">
-    <div class="context-menu-title">Sağ Tık Menüsü</div>
     <div class="context-menu-item-with-submenu">
         <button class="context-menu-btn submenu-trigger">
             Referans Ekle ▶


### PR DESCRIPTION
- Remove 'Sağ Tık Menüsü' title from context menu for cleaner look
- Enable hover-based submenu navigation (no click required)
- Fix CTRL+drag copy to work while holding CTRL during drag
- Prioritize guide intersections when snapping (0.5x distance)