### PR TITLE
fix: Correct floor filtering in 2D and 3D scenes

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -233,12 +233,13 @@ export function draw2D() {
 
     // Sadece aktif kata ait çizimleri filtrele
     const currentFloorId = state.currentFloor?.id;
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
-    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
-    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
-    const beams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
-    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
-    const columns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
+    // Sadece currentFloorId ile eşleşen öğeleri göster (floorId olmayan öğeleri gösterme!)
+    const rooms = currentFloorId ? (state.rooms || []).filter(r => r.floorId === currentFloorId) : [];
+    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
+    const doors = currentFloorId ? (state.doors || []).filter(d => d.floorId === currentFloorId) : [];
+    const beams = currentFloorId ? (state.beams || []).filter(b => b.floorId === currentFloorId) : [];
+    const stairs = currentFloorId ? (state.stairs || []).filter(s => s.floorId === currentFloorId) : [];
+    const columns = currentFloorId ? (state.columns || []).filter(c => c.floorId === currentFloorId) : [];
 
     // Sadece aktif kata ait node'ları filtrele (duvarlardan topla)
     const nodesSet = new Set();


### PR DESCRIPTION
- Fix 2D scene: Only show objects matching currentFloorId
- Fix 3D scene: Properly filter objects by floorId in both modes
- Fix picture frames: Use filtered rooms/walls instead of global state
- Remove incorrect !floorId logic that showed all unassigned objects

This fixes issues where objects from different floors were visible when they shouldn't be (e.g., doors showing other floor walls).