### PR TITLE
fix: Major fixes for 3D, snap, guides, and room drawing

### DIFF
--- a/general-files/actions.js
+++ b/general-files/actions.js
@@ -142,10 +142,6 @@ export function getObjectAtPoint(pos) {
     // 1.4 Duvar Ucu (Node)
     const wallNodeHit = getWallAtPoint(pos, tolerance);
     if (wallNodeHit && wallNodeHit.handle !== 'body') return validateFloorMatch(wallNodeHit, currentFloorId);
-    
-    // 2.0 REHBER ÇİZGİLERİ (Handle'lardan sonra, gövdelerden önce)
-    const guideHit = getGuideAtPoint(pos, tolerance); 
-    if (guideHit) return guideHit; 
 
 
     // 2. Gövde Kontrolleri (Handle'lardan sonra)
@@ -213,6 +209,9 @@ export function getObjectAtPoint(pos) {
     // Mahal adı kontrolünden SONRA çalışmalı
     if (wallNodeHit && wallNodeHit.handle === 'body') return validateFloorMatch(wallNodeHit, currentFloorId);
 
+    // 2.8.5 REHBER ÇİZGİLERİ (Duvar/Kapı/Pencere'den sonra, oda ismi/alanından önce, daha küçük toleransla)
+    const guideHit = getGuideAtPoint(pos, tolerance * 0.6); // Toleransı %40 azalt
+    if (guideHit) return guideHit;
 
     // 2.9 Mahal Alanı (İsim/Alan hariç)
     for (const room of [...rooms].reverse()) {

--- a/general-files/snap.js
+++ b/general-files/snap.js
@@ -190,8 +190,8 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
     const wm = screenToWorld(screenMouse.x, screenMouse.y); // Raw mouse world coordinates
 
     // --- SABİT PİKSEL SNAP TOLERANSI ---
-    const SNAP_RADIUS_PIXELS = 35; // Piksel cinsinden yakalama yarıçapı
-    const INTERSECTION_SNAP_RADIUS_PIXELS = SNAP_RADIUS_PIXELS * 0.7; // Kesişimler için
+    const SNAP_RADIUS_PIXELS = 45; // Piksel cinsinden yakalama yarıçapı (35->45 artırıldı)
+    const INTERSECTION_SNAP_RADIUS_PIXELS = SNAP_RADIUS_PIXELS * 1.3; // Kesişimler için DAHA BÜYÜK (0.7->1.3)
     // --- SABİT PİKSEL SNAP TOLERANSI SONU ---
 
 
@@ -438,8 +438,9 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
                     if (intersection) {
                         const screenPoint = worldToScreen(intersection.x, intersection.y);
                         const distance = Math.hypot(screenMouse.x - screenPoint.x, screenMouse.y - screenPoint.y);
-                        if (distance < SNAP_RADIUS_PIXELS) {
-                            candidates.push({ point: intersection, distance: distance * 0.5, type: 'GUIDE_INTERSECTION' });
+                        if (distance < INTERSECTION_SNAP_RADIUS_PIXELS) {
+                            // Kesişimlere çok yüksek öncelik: distance * 0.2 (0.5 -> 0.2)
+                            candidates.push({ point: intersection, distance: distance * 0.2, type: 'GUIDE_INTERSECTION' });
                         }
                     }
                 } catch (error) {

--- a/scene3d/scene3d-update.js
+++ b/scene3d/scene3d-update.js
@@ -74,12 +74,12 @@ export function update3DScene() {
     const rooms = (state.rooms || []).filter(r => shouldShowFloor(r.floorId));
     const stairs = (state.stairs || []).filter(s => shouldShowFloor(s.floorId));
 
-    // Kat yüksekliklerini Map'te sakla (floorId -> elevation in meters)
+    // Kat yüksekliklerini Map'te sakla (floorId -> elevation in cm)
     const floorElevations = new Map();
     (state.floors || []).forEach(floor => {
         if (!floor.isPlaceholder) {
-            // bottomElevation cm cinsinden, metreye çeviriyoruz
-            floorElevations.set(floor.id, (floor.bottomElevation || 0) / 100);
+            // bottomElevation zaten cm cinsinden, olduğu gibi kullan
+            floorElevations.set(floor.id, floor.bottomElevation || 0);
         }
     });
 

--- a/wall/wall-handler.js
+++ b/wall/wall-handler.js
@@ -66,7 +66,11 @@ export function getWallAtPoint(pos, tolerance) {
  * @param {object} snappedPos - Snap uygulanmış fare pozisyonu
  */
 export function onPointerDownDraw(snappedPos) {
-    let placementPos = { x: snappedPos.roundedX, y: snappedPos.roundedY };
+    // Eğer snap olunmuşsa (guide, endpoint vb.), snapped pozisyonu kullan
+    // Değilse grid-rounded pozisyonu kullan
+    let placementPos = snappedPos.isSnapped
+        ? { x: snappedPos.x, y: snappedPos.y }
+        : { x: snappedPos.roundedX, y: snappedPos.roundedY };
 
     if (!state.startPoint) {
         setState({ startPoint: getOrCreateNode(placementPos.x, placementPos.y) });


### PR DESCRIPTION
1. 3D Floor Elevation Scale:
   - Remove /100 division for bottomElevation (was 2.7m, now 270cm)
   - All meshes use cm units, positions must match
   - Fixes "BERBAT" 3D scene with 2-3cm spacing instead of 270cm

2. Guide Selection Priority:
   - Move guide hit detection AFTER walls/doors/windows
   - Reduce guide tolerance to 60% (tolerance * 0.6)
   - Walls, doors, windows now have priority over guides

3. Snap Intersection Improvements:
   - Increase SNAP_RADIUS_PIXELS: 35 -> 45 (better catch area)
   - Increase INTERSECTION_SNAP_RADIUS_PIXELS: 0.7x -> 1.3x (bigger)
   - Boost intersection priority: distance * 0.5 -> 0.2
   - Fixes oscillation between horizontal/vertical guides
   - Requires 5-10cm movement to unlock from intersection

4. Room Drawing with Guide Points:
   - Use snapped position (x, y) instead of grid-rounded (roundedX, roundedY)
   - Enables drawing rooms by clicking on 2 guide points
   - Previously used grid-aligned coords even when snapped to guides