### PR TITLE
fix: Complete floor isolation - prevent cross-floor interactions

### DIFF
--- a/draw/geometry.js
+++ b/draw/geometry.js
@@ -149,7 +149,7 @@ export function getOrCreateNode(x, y) {
     const currentFloorId = state.currentFloor?.id;
 
     // Sadece aktif kattaki duvarlardan node'ları topla
-    const currentFloorWalls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const currentFloorWalls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
     const nodesSet = new Set();
     currentFloorWalls.forEach(w => {
         if (w.p1) nodesSet.add(w.p1);

--- a/general-files/actions.js
+++ b/general-files/actions.js
@@ -75,9 +75,9 @@ export function getObjectAtPoint(pos) {
     const currentFloorId = state.currentFloor?.id;
 
     // Floor filtering: currentFloor varsa sadece o kattaki objeleri al
-    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
-    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
+    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
+    const doors = currentFloorId ? (state.doors || []).filter(d => d.floorId === currentFloorId) : [];
+    const rooms = currentFloorId ? (state.rooms || []).filter(r => r.floorId === currentFloorId) : [];
 
     const tolerance = 8 / zoom;
 

--- a/general-files/snap.js
+++ b/general-files/snap.js
@@ -66,8 +66,8 @@ function getStairEdges(stair) {
 function getStairSnapPoint(wm, screenMouse, SNAP_RADIUS_PIXELS) {
     const candidates = [];
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
-    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
+    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
+    const stairs = currentFloorId ? (state.stairs || []).filter(s => s.floorId === currentFloorId) : [];
 
     // Aday ekleme yardımcısı
     const addCandidate = (point, type, distance) => {
@@ -272,7 +272,7 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
 
     // Sadece aktif kata ait duvarları kullan
     const currentFloorId = state.currentFloor?.id;
-    const currentFloorWalls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const currentFloorWalls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
 
     // Taranacak duvarlar
     const wallsToScan = state.snapOptions.nearestOnly
@@ -318,7 +318,7 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
     }
 
     // Kolon, Kiriş Snap Noktaları (sadece aktif kat)
-    const currentFloorColumns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
+    const currentFloorColumns = currentFloorId ? (state.columns || []).filter(c => c.floorId === currentFloorId) : [];
     if (currentFloorColumns.length > 0) {
         currentFloorColumns.forEach(column => {
              if (state.isDragging && state.selectedObject?.type === 'column' && state.selectedObject.object === column) return;
@@ -337,7 +337,7 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
              } catch (error) { console.error("Error processing column corners for snap:", error, column); }
         });
     }
-    const currentFloorBeams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
+    const currentFloorBeams = currentFloorId ? (state.beams || []).filter(b => b.floorId === currentFloorId) : [];
     if (currentFloorBeams.length > 0) {
          currentFloorBeams.forEach(beam => {
              if (state.isDragging && state.selectedObject?.type === 'beam' && state.selectedObject.object === beam) return;
@@ -358,7 +358,7 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
     }
 
     // Merdiven Köşe/Merkez Snap (Çizim modu DIŞINDA, sadece aktif kat)
-    const currentFloorStairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
+    const currentFloorStairs = currentFloorId ? (state.stairs || []).filter(s => s.floorId === currentFloorId) : [];
     if (state.currentMode !== 'drawStairs' && currentFloorStairs.length > 0) {
         for (const stair of currentFloorStairs) {
              if (state.isDragging && state.selectedObject?.type === 'stairs' && state.selectedObject.object === stair) continue;

--- a/wall/wall-handler.js
+++ b/wall/wall-handler.js
@@ -155,7 +155,12 @@ export function onPointerDownSelect(selectedObject, pos, snappedPos, e) {
         const nodeToDrag = selectedObject.object[selectedObject.handle];
         startPointForDragging = { x: nodeToDrag.x, y: nodeToDrag.y };
 
-        const affectedWalls = state.walls.filter((w) => w.p1 === nodeToDrag || w.p2 === nodeToDrag);
+        // Sadece aktif kattaki duvarları etkile (diğer katlardaki node'ları etkilemeden)
+        const currentFloorId = state.currentFloor?.id;
+        const affectedWalls = state.walls.filter((w) =>
+            (w.p1 === nodeToDrag || w.p2 === nodeToDrag) &&
+            (!currentFloorId || w.floorId === currentFloorId)
+        );
         additionalState.affectedWalls = affectedWalls;
         additionalState.dragAxis = null;
 
@@ -585,11 +590,14 @@ export function onPointerMove(snappedPos, unsnappedPos) {
 export function findCollinearChain(startWall) {
     const chain = [startWall];
     const visited = new Set([startWall]);
+    // Sadece aynı kattaki duvarları tara
+    const currentFloorId = state.currentFloor?.id;
+    const wallsOnSameFloor = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
 
     const exploreFrom = (wall) => {
         if (!wall || !wall.p1 || !wall.p2) return;
         [wall.p1, wall.p2].forEach(node => {
-            state.walls.forEach(w => {
+            wallsOnSameFloor.forEach(w => {
                 if (visited.has(w)) return;
                 if (!w || w.p1 !== node && w.p2 !== node) return;
                 if (!w.p1 || !w.p2) return;


### PR DESCRIPTION
CRITICAL FIX: Katlar arası etkileşim sorunları tamamen çözüldü.

ROOT CAUSE: getOrCreateNode ve birçok yerde !w.floorId mantık hatası vardı. Bu yüzden farklı katlardaki node'lar paylaşılıyor, bir kattaki duvar diğer katları etkiliyordu.

Fixes applied to ALL files with floor filtering:

1. draw/geometry.js - getOrCreateNode():
   - OLD: filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId)
   - NEW: filter(w => w.floorId === currentFloorId)
   - Ensures nodes are NEVER shared between floors

2. general-files/actions.js - getObjectAtPoint():
   - Same filter fix for walls, doors, rooms
   - Prevents selecting objects from other floors

3. general-files/snap.js - Multiple functions:
   - getSmartSnapPoint: walls, columns, beams, stairs
   - getStairSnapPoint: walls, stairs
   - All now properly floor-filtered
   - Prevents snapping to other floor's objects

4. wall/wall-handler.js - Two critical fixes: a) onPointerDownSelect - Node dragging:
      - affectedWalls now filtered by currentFloorId - Prevents dragging a node from affecting other floors

   b) findCollinearChain - Wall chain selection:
      - Now only searches wallsOnSameFloor
      - Prevents Ctrl+Shift multi-select across floors

RESULT:
- Drawing on floor 2 won't snap to floor 3 walls
- Dragging wall on floor 1 won't affect floor 2
- Sweeping on floor 3 won't interact with floor 1 guides
- Each floor is now completely isolated