### PR TITLE
fix: Restore snap functionality during dragging and legacy support

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -233,13 +233,13 @@ export function draw2D() {
 
     // Sadece aktif kata ait çizimleri filtrele
     const currentFloorId = state.currentFloor?.id;
-    // Sadece currentFloorId ile eşleşen öğeleri göster (floorId olmayan öğeleri gösterme!)
-    const rooms = currentFloorId ? (state.rooms || []).filter(r => r.floorId === currentFloorId) : [];
-    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
-    const doors = currentFloorId ? (state.doors || []).filter(d => d.floorId === currentFloorId) : [];
-    const beams = currentFloorId ? (state.beams || []).filter(b => b.floorId === currentFloorId) : [];
-    const stairs = currentFloorId ? (state.stairs || []).filter(s => s.floorId === currentFloorId) : [];
-    const columns = currentFloorId ? (state.columns || []).filter(c => c.floorId === currentFloorId) : [];
+    // Eğer currentFloorId yoksa (eski projeler), tüm öğeleri göster
+    const rooms = currentFloorId ? (state.rooms || []).filter(r => r.floorId === currentFloorId) : (state.rooms || []);
+    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : (state.walls || []);
+    const doors = currentFloorId ? (state.doors || []).filter(d => d.floorId === currentFloorId) : (state.doors || []);
+    const beams = currentFloorId ? (state.beams || []).filter(b => b.floorId === currentFloorId) : (state.beams || []);
+    const stairs = currentFloorId ? (state.stairs || []).filter(s => s.floorId === currentFloorId) : (state.stairs || []);
+    const columns = currentFloorId ? (state.columns || []).filter(c => c.floorId === currentFloorId) : (state.columns || []);
 
     // Sadece aktif kata ait node'ları filtrele (duvarlardan topla)
     const nodesSet = new Set();

--- a/draw/geometry.js
+++ b/draw/geometry.js
@@ -149,7 +149,10 @@ export function getOrCreateNode(x, y) {
     const currentFloorId = state.currentFloor?.id;
 
     // Sadece aktif kattaki duvarlardan node'ları topla
-    const currentFloorWalls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
+    // Eğer currentFloorId yoksa (eski projeler), tüm duvarları kullan
+    const currentFloorWalls = currentFloorId
+        ? (state.walls || []).filter(w => w.floorId === currentFloorId)
+        : (state.walls || []);
     const nodesSet = new Set();
     currentFloorWalls.forEach(w => {
         if (w.p1) nodesSet.add(w.p1);

--- a/general-files/actions.js
+++ b/general-files/actions.js
@@ -75,9 +75,16 @@ export function getObjectAtPoint(pos) {
     const currentFloorId = state.currentFloor?.id;
 
     // Floor filtering: currentFloor varsa sadece o kattaki objeleri al
-    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
-    const doors = currentFloorId ? (state.doors || []).filter(d => d.floorId === currentFloorId) : [];
-    const rooms = currentFloorId ? (state.rooms || []).filter(r => r.floorId === currentFloorId) : [];
+    // Eğer currentFloorId yoksa (eski projeler), tüm objeleri kullan
+    const walls = currentFloorId
+        ? (state.walls || []).filter(w => w.floorId === currentFloorId)
+        : (state.walls || []);
+    const doors = currentFloorId
+        ? (state.doors || []).filter(d => d.floorId === currentFloorId)
+        : (state.doors || []);
+    const rooms = currentFloorId
+        ? (state.rooms || []).filter(r => r.floorId === currentFloorId)
+        : (state.rooms || []);
 
     const tolerance = 8 / zoom;
 

--- a/general-files/snap.js
+++ b/general-files/snap.js
@@ -66,8 +66,13 @@ function getStairEdges(stair) {
 function getStairSnapPoint(wm, screenMouse, SNAP_RADIUS_PIXELS) {
     const candidates = [];
     const currentFloorId = state.currentFloor?.id;
-    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
-    const stairs = currentFloorId ? (state.stairs || []).filter(s => s.floorId === currentFloorId) : [];
+    // Eğer currentFloorId yoksa (eski projeler), tüm objeleri kullan
+    const walls = currentFloorId
+        ? (state.walls || []).filter(w => w.floorId === currentFloorId)
+        : (state.walls || []);
+    const stairs = currentFloorId
+        ? (state.stairs || []).filter(s => s.floorId === currentFloorId)
+        : (state.stairs || []);
 
     // Aday ekleme yardımcısı
     const addCandidate = (point, type, distance) => {
@@ -272,7 +277,10 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
 
     // Sadece aktif kata ait duvarları kullan
     const currentFloorId = state.currentFloor?.id;
-    const currentFloorWalls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : [];
+    // Eğer currentFloorId yoksa (eski projeler için), tüm duvarları kullan
+    const currentFloorWalls = currentFloorId
+        ? (state.walls || []).filter(w => w.floorId === currentFloorId)
+        : (state.walls || []);
 
     // Taranacak duvarlar
     const wallsToScan = state.snapOptions.nearestOnly
@@ -318,7 +326,9 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
     }
 
     // Kolon, Kiriş Snap Noktaları (sadece aktif kat)
-    const currentFloorColumns = currentFloorId ? (state.columns || []).filter(c => c.floorId === currentFloorId) : [];
+    const currentFloorColumns = currentFloorId
+        ? (state.columns || []).filter(c => c.floorId === currentFloorId)
+        : (state.columns || []);
     if (currentFloorColumns.length > 0) {
         currentFloorColumns.forEach(column => {
              if (state.isDragging && state.selectedObject?.type === 'column' && state.selectedObject.object === column) return;
@@ -337,7 +347,9 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
              } catch (error) { console.error("Error processing column corners for snap:", error, column); }
         });
     }
-    const currentFloorBeams = currentFloorId ? (state.beams || []).filter(b => b.floorId === currentFloorId) : [];
+    const currentFloorBeams = currentFloorId
+        ? (state.beams || []).filter(b => b.floorId === currentFloorId)
+        : (state.beams || []);
     if (currentFloorBeams.length > 0) {
          currentFloorBeams.forEach(beam => {
              if (state.isDragging && state.selectedObject?.type === 'beam' && state.selectedObject.object === beam) return;
@@ -358,7 +370,9 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
     }
 
     // Merdiven Köşe/Merkez Snap (Çizim modu DIŞINDA, sadece aktif kat)
-    const currentFloorStairs = currentFloorId ? (state.stairs || []).filter(s => s.floorId === currentFloorId) : [];
+    const currentFloorStairs = currentFloorId
+        ? (state.stairs || []).filter(s => s.floorId === currentFloorId)
+        : (state.stairs || []);
     if (state.currentMode !== 'drawStairs' && currentFloorStairs.length > 0) {
         for (const stair of currentFloorStairs) {
              if (state.isDragging && state.selectedObject?.type === 'stairs' && state.selectedObject.object === stair) continue;


### PR DESCRIPTION
CRITICAL FIX: Floor filtering was too strict - returning empty arrays when currentFloorId was undefined, breaking snap during drag operations and legacy project compatibility.

Problem:
- When dragging walls/nodes, snap to other objects was broken
- Extension snap (wall continuations) not working
- Empty arrays returned for walls, columns, beams, stairs when no currentFloorId
- Legacy projects without floor structure couldn't snap

Root cause:
```javascript
// WRONG: Returns [] if no currentFloorId
const walls = currentFloorId ? filter(...) : [];

// RIGHT: Fallback to all objects for legacy projects
const walls = currentFloorId ? filter(...) : (state.walls || []);
```

Files fixed (all with same pattern):

1. general-files/snap.js
   - getSmartSnapPoint: walls, columns, beams, stairs
   - getStairSnapPoint: walls, stairs
   - Now properly snaps during drag operations

2. draw/geometry.js - getOrCreateNode()
   - Node creation/reuse now works without currentFloorId
   - Essential for legacy projects

3. general-files/actions.js - getObjectAtPoint()
   - Object selection works in legacy projects
   - Maintains floor isolation when currentFloorId exists

4. draw/draw2d.js - draw2D()
   - Rendering works for legacy projects
   - Visual consistency

Behavior:
- WITH currentFloorId: Strict floor isolation (as before)
- WITHOUT currentFloorId: Show all objects (legacy compatibility)
- Snap during drag: WORKS AGAIN
- Extension snap: WORKS AGAIN
- Multi-floor projects: Still isolated per floor
- Legacy projects: Fully functional