### PR TITLE
fix: Prevent objects from snapping to themselves during drag

### DIFF
--- a/general-files/snap.js
+++ b/general-files/snap.js
@@ -282,13 +282,27 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
         ? (state.walls || []).filter(w => w.floorId === currentFloorId)
         : (state.walls || []);
 
+    // Sürüklenen duvarları tespit et
+    const draggedWalls = [];
+    if (state.isDragging && state.selectedObject?.type === 'wall') {
+        // Tek duvar veya grup sürükleniyor
+        if (state.selectedGroup && state.selectedGroup.length > 0) {
+            draggedWalls.push(...state.selectedGroup);
+        } else {
+            draggedWalls.push(state.selectedObject.object);
+        }
+    }
+
+    // Sürüklenen duvarları snap hesaplamalarından ÇIKAR
+    const wallsForSnap = currentFloorWalls.filter(w => !draggedWalls.includes(w));
+
     // Taranacak duvarlar
     const wallsToScan = state.snapOptions.nearestOnly
-        ? currentFloorWalls.map(wall => ({ wall, distance: Math.sqrt(distToSegmentSquared(wm, wall.p1, wall.p2)) }))
+        ? wallsForSnap.map(wall => ({ wall, distance: Math.sqrt(distToSegmentSquared(wm, wall.p1, wall.p2)) }))
           .sort((a, b) => a.distance - b.distance)
           .slice(0, 5)
           .map(item => item.wall)
-        : currentFloorWalls;
+        : wallsForSnap;
 
     const candidates = [];
     let draggedNode = (state.isDragging && state.selectedObject?.type === "wall" && state.selectedObject.handle !== "body")

--- a/wall/wall-handler.js
+++ b/wall/wall-handler.js
@@ -275,7 +275,17 @@ export function onPointerDownSelect(selectedObject, pos, snappedPos, e) {
  */
 export function onPointerMove(snappedPos, unsnappedPos) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+
+    // Sürüklenen duvarları tespit et
+    const draggedWalls = state.selectedGroup && state.selectedGroup.length > 0
+        ? state.selectedGroup
+        : [state.selectedObject.object];
+
+    // Snap için kullanılacak duvarlar - sürüklenen duvarları ÇIKAR
+    const walls = (state.walls || [])
+        .filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId)
+        .filter(w => !draggedWalls.includes(w));
+
     let neighborWallsToDimension = new Set(); // Komşu duvarları saklamak için Set
 
     if (state.selectedObject.handle !== "body") {


### PR DESCRIPTION
Fixed issue where dragged walls would snap to their own endpoints, surfaces, and midpoints, causing unwanted self-locking behavior.

Changes:
- snap.js (getSmartSnapPoint):
  - Detect dragged walls (single or group) via selectedObject/selectedGroup
  - Filter dragged walls from snap calculations
  - Prevents self-snap for endpoints, midpoints, and intersections

- wall-handler.js (onPointerMove):
  - Filter dragged walls from wall surface snap calculations
  - Ensures walls cannot snap to their own surfaces during body/node drag

Now objects only snap to OTHER objects, never to themselves.