### PR TITLE
feat: Make wall dragging smooth and fluid

### DIFF
--- a/pointer/pointer-up.js
+++ b/pointer/pointer-up.js
@@ -199,8 +199,6 @@ export function onPointerUp(e) {
         isSweeping: false,
         sweepWalls: [],
         columnRotationOffset: null,
-        tempNeighborWallsToDimension: null, // Komşu duvar Set'ini temizle
-        wallNodeSnapLock: null, // Node snap lock'u temizle
-        wallBodySnapLock: null // Body snap lock'u temizle
+        tempNeighborWallsToDimension: null // Komşu duvar Set'ini temizle
     });
 }


### PR DESCRIPTION
Removed sticky snap lock mechanisms that caused jerky, abrupt movement during wall dragging. Replaced with smooth, direct mouse tracking.

Changes:
- wall-handler.js (onPointerMove):
  - BODY DRAG: Use unsnappedPos for smooth mouse tracking
  - NODE DRAG: Removed wallNodeSnapLock sticky mechanism
  - Simplified snap to direct application without lock/unlock transitions
  - Reduced snap distance to 20cm for better feel
  - Eliminated dragged walls from snap calculations

- pointer-up.js:
  - Removed unused wallNodeSnapLock and wallBodySnapLock cleanup

Result: Dragging now follows mouse smoothly without sudden jumps or locks. Snap still works but applies instantly without sticky behavior.