### PR TITLE
fix: Prevent snap oscillation with smart lock mechanism

### DIFF
--- a/pointer/pointer-up.js
+++ b/pointer/pointer-up.js
@@ -199,6 +199,7 @@ export function onPointerUp(e) {
         isSweeping: false,
         sweepWalls: [],
         columnRotationOffset: null,
-        tempNeighborWallsToDimension: null // Komşu duvar Set'ini temizle
+        tempNeighborWallsToDimension: null, // Komşu duvar Set'ini temizle
+        wallBodySnapLock: null // Body snap lock'u temizle
     });
 }


### PR DESCRIPTION
Fixed issue where dragging walls would oscillate left-right due to snap points changing every frame.

Changes:
- wall-handler.js (onPointerMove - body drag):
  - Added smart wallBodySnapLock mechanism
  - When snap is detected, lock to that position
  - Lock persists until mouse moves 10cm away from locked position
  - Prevents oscillation while maintaining smooth feel
  - Uses unsnappedPos to measure actual mouse distance from lock

- pointer-up.js:
  - Clean up wallBodySnapLock on release

Result: Snap is stable - no more left-right oscillation during drag. When snap is caught, it stays locked until you deliberately move away.