### PR TITLE
fix: Architecture paste and project loading improvements

### DIFF
--- a/draw/floor-operations-menu.js
+++ b/draw/floor-operations-menu.js
@@ -40,7 +40,7 @@ export function initFloorOperationsMenu() {
 }
 
 // Mevcut kattaki tüm mimariyi kopyala
-function copyFloorArchitecture() {
+export function copyFloorArchitecture() {
     if (!state.currentFloor) {
         alert('Aktif kat bulunamadı!');
         return;
@@ -73,7 +73,7 @@ function copyFloorArchitecture() {
 }
 
 // Kopyalanan mimariyi mevcut kata yapıştır
-function pasteFloorArchitecture() {
+export function pasteFloorArchitecture() {
     if (!floorClipboard) {
         alert('Önce bir mimari plan kopyalamalısınız!');
         return;
@@ -362,7 +362,8 @@ function pasteToAllFloors() {
         pastedFloorCount++;
     });
 
-    processWalls();
+    // Tüm katları işle (processAllFloors = true)
+    processWalls(false, false, true);
     saveState();
     update3DScene();
 

--- a/general-files/file-io.js
+++ b/general-files/file-io.js
@@ -262,8 +262,8 @@ function openProject(e) {
                     renderMiniPanel();
                 }
 
-                // Duvarları işle ve history'ye kaydet
-                processWalls();
+                // Duvarları işle ve history'ye kaydet - TÜM KATLARI İŞLE
+                processWalls(false, false, true);
                 saveState();
 
                 console.log('JSON Proje başarıyla yüklendi!');

--- a/general-files/input.js
+++ b/general-files/input.js
@@ -12,6 +12,7 @@ import { screenToWorld, worldToScreen, getOrCreateNode, distToSegmentSquared, fi
 import { showGuideContextMenu, hideGuideContextMenu } from '../draw/guide-menu.js';
 import { fitDrawingToScreen, onWheel } from '../draw/zoom.js'; // Fit to Screen ve onWheel zoom.js'den
 import { showWallPanel, hideWallPanel } from '../wall/wall-panel.js'; // <-- HIDEWALLPANEL EKLENDİ
+import { copyFloorArchitecture, pasteFloorArchitecture } from '../draw/floor-operations-menu.js'; // <-- KAT MİMARİSİ KOPYALA/YAPIŞTIR
 import { onPointerDown } from '../pointer/pointer-down.js';
 import { onPointerMove } from '../pointer/pointer-move.js';
 import { onPointerUp } from '../pointer/pointer-up.js';
@@ -67,8 +68,15 @@ function extendWallOnTabPress() {
 
 // Kopyalama Fonksiyonu
 function handleCopy(e) {
-    if (!state.selectedObject && state.selectedGroup.length === 0) return;
     if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA' || document.activeElement === dom.roomNameSelect) return; // roomNameSelect eklendi
+
+    // Hiçbir obje seçili değilse, kat mimarisini kopyala
+    if (!state.selectedObject && state.selectedGroup.length === 0) {
+        e.preventDefault();
+        copyFloorArchitecture();
+        return;
+    }
+
     e.preventDefault();
     let dataToCopy = null;
     let referencePoint = null;
@@ -104,8 +112,15 @@ function handleCopy(e) {
 
 // Yapıştırma Fonksiyonu
 function handlePaste(e) {
-    if (!state.clipboard) return;
     if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA' || document.activeElement === dom.roomNameSelect) return; // roomNameSelect eklendi
+
+    // Eğer clipboard boşsa, kat mimarisi yapıştırmayı dene
+    if (!state.clipboard) {
+        e.preventDefault();
+        pasteFloorArchitecture();
+        return;
+    }
+
     e.preventDefault();
     const pastePos = state.mousePos;
     if (!pastePos) return;

--- a/general-files/xml-io.js
+++ b/general-files/xml-io.js
@@ -641,8 +641,8 @@ export function importFromXML(xmlString) {
     }
 
     // Duvarları process et ama room detection'ı skip et (room'lar XML'den geldi)
-    console.log("\nprocessWalls çağrılıyor (skipRoomDetection=true)...");
-    processWalls(false, true); // skipMerge=false, skipRoomDetection=true
+    console.log("\nprocessWalls çağrılıyor (skipRoomDetection=true, processAllFloors=true)...");
+    processWalls(false, true, true); // skipMerge=false, skipRoomDetection=true, processAllFloors=true
 
     saveState();
     // 'dom' artık import edildiği için bu kontrol çalışacaktır

--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@
             <button id="floor-btn-paste" class="context-menu-btn">Mimari Planı Yapıştır <span style="opacity: 0.6; font-size: 0.9em;">(CTRL + V)</span></button>
             <button id="floor-btn-paste-all" class="context-menu-btn">Mimari Planı Diğer Katlara Yapıştır</button>
             <div class="context-menu-divider"></div>
-            <button id="floor-btn-clear" class="context-menu-btn context-menu-danger">Mimariyi Sil</button>
+            <button id="floor-btn-clear" class="context-menu-btn context-menu-danger">Katın Mimari Planını Sil</button>
         </div>
     </div>
 </div>

--- a/wall/wall-processor.js
+++ b/wall/wall-processor.js
@@ -69,15 +69,18 @@ export function mergeNode(node) {
     return null;
 }
 
-function unifyNearbyNodes(tolerance) {
+function unifyNearbyNodes(tolerance, processAllFloors = false) {
     // KAT BAZLI NODE BIRLEŞTIRME: Her kat için ayrı ayrı merge yap
     const floors = state.floors || [];
     const currentFloorId = state.currentFloor?.id;
 
+    // Eğer processAllFloors true ise tüm katları işle
     // Eğer currentFloorId varsa sadece o katı işle, yoksa tüm katları işle (legacy)
-    const floorsToProcess = currentFloorId
-        ? floors.filter(f => f.id === currentFloorId)
-        : (floors.length > 0 ? floors : [{ id: null }]); // Legacy: kat yoksa null id kullan
+    const floorsToProcess = processAllFloors
+        ? (floors.length > 0 ? floors : [{ id: null }])
+        : currentFloorId
+            ? floors.filter(f => f.id === currentFloorId)
+            : (floors.length > 0 ? floors : [{ id: null }]); // Legacy: kat yoksa null id kullan
 
     floorsToProcess.forEach(floor => {
         const floorId = floor.id;
@@ -378,13 +381,13 @@ function mergeColumnsWithWalls() {
     });
 }
 
-export function processWalls(skipMerge = false, skipRoomDetection = false) {
+export function processWalls(skipMerge = false, skipRoomDetection = false, processAllFloors = false) {
     // Kolon node'larını duvar sisteminden ayır
     state.nodes = state.nodes.filter(n => !n.isColumnNode);
 
     // LOKAL KALINLIK İÇİN: skipMerge true ise birleştirme yapma
     if (!skipMerge) {
-        unifyNearbyNodes(1.0);
+        unifyNearbyNodes(1.0, processAllFloors);
     }
 
     const filteredWalls = state.walls.filter(w => {


### PR DESCRIPTION
- Fix paste to all floors: walls and other elements now appear correctly
- Fix project loading: all floors are now processed and loaded at startup
- Fix room visibility: rooms now appear without needing to click walls
- Add CTRL+C/V keyboard shortcuts for floor architecture copy/paste
- Update menu text: "Mimariyi Sil" -> "Katın Mimari Planını Sil"

Changes:
- Modified processWalls() to accept processAllFloors parameter
- Updated pasteToAllFloors() to process all floors correctly
- Updated openProject() and importFromXML() to process all floors
- Exported copyFloorArchitecture() and pasteFloorArchitecture()
- Added keyboard shortcuts for floor architecture operations
- Improved menu text clarity