### PR TITLE
fix: Snap, room names, column copy-paste, and context menu improvements

### DIFF
--- a/draw/floor-operations-menu.js
+++ b/draw/floor-operations-menu.js
@@ -169,6 +169,7 @@ export function pasteFloorArchitecture() {
     floorClipboard.columns.forEach(columnData => {
         const newColumn = {
             ...columnData,
+            center: { x: columnData.center.x, y: columnData.center.y }, // Deep copy
             floorId: currentFloorId
         };
         state.columns.push(newColumn);
@@ -178,6 +179,7 @@ export function pasteFloorArchitecture() {
     floorClipboard.beams.forEach(beamData => {
         const newBeam = {
             ...beamData,
+            center: { x: beamData.center.x, y: beamData.center.y }, // Deep copy
             floorId: currentFloorId
         };
         state.beams.push(newBeam);
@@ -187,6 +189,7 @@ export function pasteFloorArchitecture() {
     floorClipboard.stairs.forEach(stairData => {
         const newStair = {
             ...stairData,
+            center: { x: stairData.center.x, y: stairData.center.y }, // Deep copy
             id: `stair_${Date.now()}_${Math.random().toString(16).slice(2)}`,
             name: getNextStairLetter(),
             connectedStairId: null,
@@ -199,6 +202,8 @@ export function pasteFloorArchitecture() {
     floorClipboard.rooms.forEach(roomData => {
         const newRoom = {
             ...roomData,
+            center: roomData.center ? [...roomData.center] : undefined, // Deep copy array
+            centerOffset: roomData.centerOffset ? { ...roomData.centerOffset } : undefined, // Deep copy object
             floorId: currentFloorId
         };
         state.rooms.push(newRoom);
@@ -324,6 +329,7 @@ function pasteToAllFloors() {
         floorClipboard.columns.forEach(columnData => {
             const newColumn = {
                 ...columnData,
+                center: { x: columnData.center.x, y: columnData.center.y }, // Deep copy
                 floorId: floorId
             };
             state.columns.push(newColumn);
@@ -333,6 +339,7 @@ function pasteToAllFloors() {
         floorClipboard.beams.forEach(beamData => {
             const newBeam = {
                 ...beamData,
+                center: { x: beamData.center.x, y: beamData.center.y }, // Deep copy
                 floorId: floorId
             };
             state.beams.push(newBeam);
@@ -342,6 +349,7 @@ function pasteToAllFloors() {
         floorClipboard.stairs.forEach(stairData => {
             const newStair = {
                 ...stairData,
+                center: { x: stairData.center.x, y: stairData.center.y }, // Deep copy
                 id: `stair_${Date.now()}_${Math.random().toString(16).slice(2)}`,
                 name: getNextStairLetter(),
                 connectedStairId: null,
@@ -354,6 +362,8 @@ function pasteToAllFloors() {
         floorClipboard.rooms.forEach(roomData => {
             const newRoom = {
                 ...roomData,
+                center: roomData.center ? [...roomData.center] : undefined, // Deep copy array
+                centerOffset: roomData.centerOffset ? { ...roomData.centerOffset } : undefined, // Deep copy object
                 floorId: floorId
             };
             state.rooms.push(newRoom);

--- a/draw/guide-menu.js
+++ b/draw/guide-menu.js
@@ -6,6 +6,7 @@ import { saveState } from '../general-files/history.js';
 let guideMenuEl = null;
 let menuWorldPos = null;
 let clickOutsideListener = null;
+let blurListener = null;
 
 export function initGuideContextMenu() {
     guideMenuEl = document.getElementById('guide-context-menu');
@@ -99,6 +100,13 @@ export function showGuideContextMenu(screenX, screenY, worldPos) {
     };
     // Use setTimeout to avoid capturing the same click that opened the menu
     setTimeout(() => window.addEventListener('pointerdown', clickOutsideListener, { capture: true, once: true }), 0);
+
+    // Add blur listener to close menu when focus is lost
+    blurListener = () => {
+        // Small delay to allow clicks on menu items to register first
+        setTimeout(() => hideGuideContextMenu(), 100);
+    };
+    window.addEventListener('blur', blurListener);
 }
 
 export function hideGuideContextMenu() {
@@ -108,6 +116,10 @@ export function hideGuideContextMenu() {
     if (clickOutsideListener) {
         window.removeEventListener('pointerdown', clickOutsideListener, { capture: true });
         clickOutsideListener = null;
+    }
+    if (blurListener) {
+        window.removeEventListener('blur', blurListener);
+        blurListener = null;
     }
     menuWorldPos = null;
 }

--- a/general-files/file-io.js
+++ b/general-files/file-io.js
@@ -56,7 +56,8 @@ function saveProject() {
             area: r.area,
             center: r.center,
             name: r.name,
-            centerOffset: r.centerOffset // EKLENDİ
+            centerOffset: r.centerOffset, // EKLENDİ
+            floorId: r.floorId // EKLENDİ
         })),
         columns: state.columns, // <-- GÜNCELLENDİ/EKLENDİ
         beams: state.beams, 
@@ -210,7 +211,8 @@ function openProject(e) {
                     area: r.area,
                     center: r.center,
                     name: r.name,
-                    centerOffset: r.centerOffset
+                    centerOffset: r.centerOffset,
+                    floorId: r.floorId
                 }));
 
                 // Kolonları, Kirişleri ve Merdivenleri geri yükle

--- a/general-files/snap.js
+++ b/general-files/snap.js
@@ -395,7 +395,8 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
         }
     }
 
-    // Rehber (Guide) Snap Noktaları ve Kesişimleri
+    // Rehber (Guide) Snap Noktaları ve Kesişimleri - DEVRE DIŞI
+    /*
     const guides = state.guides || [];
     if (guides.length > 0 && state.selectedObject?.type !== 'guide') {
         // Önce rehber kesişimlerini hesapla (yüksek öncelikli)
@@ -536,6 +537,7 @@ export function getSmartSnapPoint(e, applyGridSnapFallback = true) {
             }
         }
     }
+    */
 
     // Uzantı Çizgileri ve Kesişimler
     let bestVSnap = { x: null, dist: Infinity, origin: null };


### PR DESCRIPTION
- Disable guide snapping to restore original snap behavior
- Fix room names not loading properly on project open (add floorId)
- Fix column/beam/stair lines not appearing after copy-paste (deep copy centers)
- Fix rooms center and centerOffset deep copy in paste operations
- Fix context menu to close on window blur/focus loss

Changes:
- Disabled guide snap in snap.js (commented out guide snap block)
- Added floorId to room save/load in file-io.js
- Deep copy center objects for columns, beams, stairs in floor-operations-menu.js
- Deep copy center and centerOffset for rooms in floor-operations-menu.js
- Added blur listener to close context menu in guide-menu.js