### PR TITLE
fix: Door/window snap, copy-paste, and symmetry improvements

### DIFF
--- a/architectural-objects/door-handler.js
+++ b/architectural-objects/door-handler.js
@@ -48,9 +48,10 @@ export function onPointerDownDraw(pos, clickedObject) {
     const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
     const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
 
-    // 1. Direkt duvara yerleştirmeyi dene
+    // 1. Direkt duvara yerleştirmeyi dene - SADECE duvara yakınsa
     let previewWall = null, minDistSqPreview = Infinity;
-    const bodyHitTolerancePreview = (state.wallThickness * 1.5) ** 2;
+    // Daha sıkı tolerans: sadece duvar kalınlığı kadar (önizleme ile aynı)
+    const bodyHitTolerancePreview = (state.wallThickness * 0.75) ** 2;
     for (const w of [...walls].reverse()) {
          if (!w.p1 || !w.p2) continue;
          const distSq = distToSegmentSquared(pos, w.p1, w.p2);

--- a/architectural-objects/window-handler.js
+++ b/architectural-objects/window-handler.js
@@ -135,9 +135,10 @@ export function onPointerDownDraw(pos, clickedObject) {
     const currentFloorId = state.currentFloor?.id;
     const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
 
-    // 1. Direkt duvara yerleştirmeyi dene
+    // 1. Direkt duvara yerleştirmeyi dene - SADECE duvara yakınsa
     let previewWall = null, minDistSqPreview = Infinity;
-    const bodyHitTolerancePreview = (state.wallThickness * 1.5) ** 2;
+    // Daha sıkı tolerans: sadece duvar kalınlığı kadar (önizleme ile aynı)
+    const bodyHitTolerancePreview = (state.wallThickness * 0.75) ** 2;
     for (const w of [...walls].reverse()) {
         if (!w.p1 || !w.p2) continue;
         const distSq = distToSegmentSquared(pos, w.p1, w.p2);

--- a/draw/draw-previews.js
+++ b/draw/draw-previews.js
@@ -13,12 +13,13 @@ export function drawObjectPlacementPreviews(ctx2d, state, getDoorPlacement, isSp
     const currentFloorId = state.currentFloor?.id;
     const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
 
-    // Kapı önizlemesi
+    // Kapı önizlemesi - SADECE duvara yakınsa göster
     if (currentMode === "drawDoor" && !isPanning && !isDragging) {
         const doorsToPreview = [];
 
         let closestWall = null, minDistSq = Infinity;
-        const bodyHitTolerance = (state.wallThickness * 1.5) ** 2;
+        // Daha sıkı tolerans: sadece duvar kalınlığı kadar
+        const bodyHitTolerance = (state.wallThickness * 0.75) ** 2;
 
         for (const w of [...walls].reverse()) {
             const distSq = distToSegmentSquared(mousePos, w.p1, w.p2);
@@ -40,10 +41,11 @@ export function drawObjectPlacementPreviews(ctx2d, state, getDoorPlacement, isSp
         });
     }
 
-    // Pencere önizlemesi
+    // Pencere önizlemesi - SADECE duvara yakınsa göster
     if (currentMode === "drawWindow" && !isPanning && !isDragging) {
         let closestWall = null, minDistSq = Infinity;
-        const bodyHitTolerance = (state.wallThickness * 1.5) ** 2;
+        // Daha sıkı tolerans: sadece duvar kalınlığı kadar
+        const bodyHitTolerance = (state.wallThickness * 0.75) ** 2;
 
         for (const w of [...walls].reverse()) {
             if (!w.p1 || !w.p2) continue;

--- a/draw/floor-operations-menu.js
+++ b/draw/floor-operations-menu.js
@@ -69,7 +69,6 @@ export function copyFloorArchitecture() {
                       floorClipboard.rooms.length;
 
     console.log(`Mimari plan kopyalandı: ${totalItems} eleman`);
-    alert(`Mimari plan kopyalandı!\n${floorClipboard.walls.length} duvar, ${floorClipboard.doors.length} kapı, ${floorClipboard.columns.length} kolon, ${floorClipboard.beams.length} kiriş, ${floorClipboard.stairs.length} merdiven, ${floorClipboard.rooms.length} oda`);
 }
 
 // Kopyalanan mimariyi mevcut kata yapıştır
@@ -221,14 +220,17 @@ export function pasteFloorArchitecture() {
                       floorClipboard.rooms.length;
 
     console.log(`Mimari plan yapıştırıldı: ${totalItems} eleman`);
-    alert(`Mimari plan yapıştırıldı!\n${floorClipboard.walls.length} duvar, ${floorClipboard.doors.length} kapı, ${floorClipboard.columns.length} kolon, ${floorClipboard.beams.length} kiriş, ${floorClipboard.stairs.length} merdiven, ${floorClipboard.rooms.length} oda`);
 }
 
 // Kopyalanan mimariyi diğer tüm katlara yapıştır
 function pasteToAllFloors() {
+    // Eğer clipboard boşsa, önce mevcut katı kopyala
     if (!floorClipboard) {
-        alert('Önce bir mimari plan kopyalamalısınız!');
-        return;
+        copyFloorArchitecture();
+        // Eğer hala boşsa (kopyalama başarısızsa), çık
+        if (!floorClipboard) {
+            return;
+        }
     }
 
     if (!state.floors || state.floors.length === 0) {
@@ -378,7 +380,6 @@ function pasteToAllFloors() {
     update3DScene();
 
     console.log(`Mimari plan ${pastedFloorCount} kata yapıştırıldı`);
-    alert(`Mimari plan ${pastedFloorCount} kata başarıyla yapıştırıldı!`);
 }
 
 // Mevcut kattaki tüm mimariyi sil
@@ -427,5 +428,4 @@ function clearFloorArchitecture() {
     update3DScene();
 
     console.log(`${totalItems} mimari eleman silindi`);
-    alert(`${totalItems} mimari eleman başarıyla silindi!`);
 }

--- a/draw/symmetry.js
+++ b/draw/symmetry.js
@@ -418,6 +418,23 @@ export function applyCopy(axisP1, axisP2) {
     const translationX = axisP2.x - axisP1.x;  // ÖNCEKİ: * 2
     const translationY = axisP2.y - axisP1.y;  // ÖNCEKİ: * 2
 
+    // FLOOR ISOLATION: Sadece aktif kattaki elemanları kopyala
+    const currentFloorId = state.currentFloor?.id;
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
+    const columns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
+    const beams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
+
+    // Aktif kattaki duvarlardan node'ları topla
+    const nodesSet = new Set();
+    walls.forEach(w => {
+        if (w.p1) nodesSet.add(w.p1);
+        if (w.p2) nodesSet.add(w.p2);
+    });
+    const nodes = Array.from(nodesSet);
+
     const nodeMap = new Map();
     const newWalls = [];
     const newDoors = [];
@@ -429,7 +446,7 @@ export function applyCopy(axisP1, axisP2) {
     const copiedRoomNames = new Map();
 
     // 1. Nodeları Kopyala (çeviri uygula)
-    state.nodes.forEach(node => {
+    nodes.forEach(node => {
         const copiedCoord = {
             x: node.x + translationX,
             y: node.y + translationY
@@ -439,7 +456,7 @@ export function applyCopy(axisP1, axisP2) {
     });
 
     // 2. Duvarları Oluştur
-    state.walls.forEach(wall => {
+    walls.forEach(wall => {
         const newP1 = nodeMap.get(wall.p1);
         const newP2 = nodeMap.get(wall.p2);
         if (newP1 && newP2 && newP1 !== newP2 && !wallExists(newP1, newP2)) {
@@ -479,7 +496,7 @@ export function applyCopy(axisP1, axisP2) {
     });
 
     // 3. Kapıları Oluştur
-    state.doors.forEach(door => {
+    doors.forEach(door => {
         const wall = door.wall;
         const newP1 = nodeMap.get(wall.p1);
         const newP2 = nodeMap.get(wall.p2);
@@ -491,7 +508,7 @@ export function applyCopy(axisP1, axisP2) {
     });
 
     // 4. Kolonları Oluştur (rotasyon aynı kalır)
-    state.columns.forEach(col => {
+    columns.forEach(col => {
         const copiedCenter = {
             x: col.center.x + translationX,
             y: col.center.y + translationY
@@ -509,7 +526,7 @@ export function applyCopy(axisP1, axisP2) {
     });
 
     // 5. Kirişleri Oluştur (rotasyon aynı kalır)
-    state.beams.forEach(beam => {
+    beams.forEach(beam => {
         const copiedCenter = {
             x: beam.center.x + translationX,
             y: beam.center.y + translationY
@@ -524,7 +541,7 @@ export function applyCopy(axisP1, axisP2) {
     });
 
     // 6. Merdivenleri Oluştur (rotasyon aynı kalır)
-    state.stairs.forEach(stair => {
+    stairs.forEach(stair => {
         const copiedCenter = {
             x: stair.center.x + translationX,
             y: stair.center.y + translationY
@@ -545,7 +562,7 @@ export function applyCopy(axisP1, axisP2) {
     });
 
     // 7. Oda İsimlerini Kopyala
-    state.rooms.forEach(room => {
+    rooms.forEach(room => {
         if (room.center) {
             const copiedCenter = {
                 x: room.center[0] + translationX,
@@ -604,6 +621,23 @@ export function applyCopy(axisP1, axisP2) {
 export function applySymmetry(axisP1, axisP2) {
     if (!axisP1 || !axisP2) return;
 
+    // FLOOR ISOLATION: Sadece aktif kattaki elemanları yansıt
+    const currentFloorId = state.currentFloor?.id;
+    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const doors = (state.doors || []).filter(d => !currentFloorId || !d.floorId || d.floorId === currentFloorId);
+    const columns = (state.columns || []).filter(c => !currentFloorId || !c.floorId || c.floorId === currentFloorId);
+    const beams = (state.beams || []).filter(b => !currentFloorId || !b.floorId || b.floorId === currentFloorId);
+    const stairs = (state.stairs || []).filter(s => !currentFloorId || !s.floorId || s.floorId === currentFloorId);
+    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
+
+    // Aktif kattaki duvarlardan node'ları topla
+    const nodesSet = new Set();
+    walls.forEach(w => {
+        if (w.p1) nodesSet.add(w.p1);
+        if (w.p2) nodesSet.add(w.p2);
+    });
+    const nodes = Array.from(nodesSet);
+
     const nodeMap = new Map();
     const newWalls = [];
     const newDoors = [];
@@ -618,7 +652,7 @@ export function applySymmetry(axisP1, axisP2) {
     const axisAngleRad = Math.atan2(axisP2.y - axisP1.y, axisP2.x - axisP1.x);
 
     // 1. Nodeları Yansıt
-    state.nodes.forEach(node => {
+    nodes.forEach(node => {
         const reflectedCoord = reflectPoint(node, axisP1, axisP2);
         if (reflectedCoord) {
             const newNode = getOrCreateNode(reflectedCoord.x, reflectedCoord.y);
@@ -627,7 +661,7 @@ export function applySymmetry(axisP1, axisP2) {
     });
 
     // 2. Duvarları Oluştur
-    state.walls.forEach(wall => {
+    walls.forEach(wall => {
         const newP1 = nodeMap.get(wall.p1);
         const newP2 = nodeMap.get(wall.p2);
         if (newP1 && newP2 && newP1 !== newP2 && !wallExists(newP1, newP2)) {
@@ -672,7 +706,7 @@ export function applySymmetry(axisP1, axisP2) {
     });
 
     // 3. Kapıları Oluştur
-    state.doors.forEach(door => {
+    doors.forEach(door => {
         const wall = door.wall;
         const newP1 = nodeMap.get(wall.p1);
         const newP2 = nodeMap.get(wall.p2);
@@ -689,7 +723,7 @@ export function applySymmetry(axisP1, axisP2) {
     });
 
     // 4. Kolonları Oluştur
-    state.columns.forEach(col => {
+    columns.forEach(col => {
         const reflectedCenter = reflectPoint(col.center, axisP1, axisP2);
         if (reflectedCenter) {
             const originalRotationRad = (col.rotation || 0) * Math.PI / 180;
@@ -707,7 +741,7 @@ export function applySymmetry(axisP1, axisP2) {
     });
 
     // 5. Kirişleri Oluştur
-    state.beams.forEach(beam => {
+    beams.forEach(beam => {
         const reflectedCenter = reflectPoint(beam.center, axisP1, axisP2);
         if (reflectedCenter) {
             const originalRotationRad = (beam.rotation || 0) * Math.PI / 180;
@@ -722,7 +756,7 @@ export function applySymmetry(axisP1, axisP2) {
     });
 
     // 6. Merdivenleri Oluştur
-    state.stairs.forEach(stair => {
+    stairs.forEach(stair => {
         const reflectedCenter = reflectPoint(stair.center, axisP1, axisP2);
         if (reflectedCenter) {
             const originalRotationRad = (stair.rotation || 0) * Math.PI / 180;
@@ -743,7 +777,7 @@ export function applySymmetry(axisP1, axisP2) {
     });
 
     // 7. Oda İsimlerini ve Göreceli Konumlarını Yansıt (DÜZELTİLMİŞ)
-    state.rooms.forEach(room => {
+    rooms.forEach(room => {
         if (room.center && room.centerOffset) { // centerOffset olduğundan emin ol
             const reflectedCenter = reflectPoint({ x: room.center[0], y: room.center[1] }, axisP1, axisP2);
             if (reflectedCenter) {

--- a/general-files/input.js
+++ b/general-files/input.js
@@ -771,6 +771,22 @@ export function setupInputListeners() {
         const clickPos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
         const object = getObjectAtPoint(clickPos);
 
+        // drawDoor modundayken duvara sağ tıklanırsa kapı ekle
+        if (state.currentMode === 'drawDoor' && object && object.type === 'wall') {
+            import('../architectural-objects/door-handler.js').then(module => {
+                module.onPointerDownDraw(clickPos, object);
+            });
+            return;
+        }
+
+        // drawWindow modundayken duvara sağ tıklanırsa pencere ekle
+        if (state.currentMode === 'drawWindow' && object && object.type === 'wall') {
+            import('../architectural-objects/window-handler.js').then(module => {
+                module.onPointerDownDraw(clickPos, object);
+            });
+            return;
+        }
+
         // Diğer tüm popupları/menüleri kapat
         hideRoomNamePopup();
         hideWallPanel();

--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
         <div class="context-submenu">
             <button id="floor-btn-copy" class="context-menu-btn">Mimari Planı Kopyala <span style="opacity: 0.6; font-size: 0.9em;">(CTRL + C)</span></button>
             <button id="floor-btn-paste" class="context-menu-btn">Mimari Planı Yapıştır <span style="opacity: 0.6; font-size: 0.9em;">(CTRL + V)</span></button>
-            <button id="floor-btn-paste-all" class="context-menu-btn">Mimari Planı Diğer Katlara Yapıştır</button>
+            <button id="floor-btn-paste-all" class="context-menu-btn">Bu Katın Mimari Planı Diğer Katlara Yapıştır</button>
             <div class="context-menu-divider"></div>
             <button id="floor-btn-clear" class="context-menu-btn context-menu-danger">Katın Mimari Planını Sil</button>
         </div>


### PR DESCRIPTION
This commit addresses multiple issues with door/window placement, copy-paste operations, and symmetry operations:

Door/Window Improvements:
- Reduced snap preview tolerance from 1.5x to 0.75x wall thickness to only show preview when mouse is actually on/near the wall
- Synchronized click placement tolerance with preview tolerance to ensure clicking matches what the preview shows
- Added right-click door/window placement in draw modes

Copy-Paste Improvements:
- Changed paste button text to "Bu Katın Mimari Planı Diğer Katlara Yapıştır"
- Made paste-to-all-floors auto-copy current floor if clipboard is empty
- Removed all alert messages from copy-paste operations (only console logs remain)

Symmetry/Copy Improvements:
- Added floor isolation to applySymmetry() and applyCopy() functions
- Symmetry operations now only affect elements on the current floor
- Prevents accidentally duplicating elements across multiple floors

Files modified:
- architectural-objects/door-handler.js
- architectural-objects/window-handler.js
- draw/draw-previews.js
- draw/floor-operations-menu.js
- draw/symmetry.js
- general-files/input.js
- index.html