### PR TITLE
fix: Critical door/window snap and right-click fixes

### DIFF
--- a/architectural-objects/door-handler.js
+++ b/architectural-objects/door-handler.js
@@ -48,9 +48,8 @@ export function onPointerDownDraw(pos, clickedObject) {
     const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
     const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
 
-    // 1. Direkt duvara yerleştirmeyi dene - SADECE duvara yakınsa
+    // 1. Duvara yakın mı kontrol et (simülasyon ile aynı tolerans)
     let previewWall = null, minDistSqPreview = Infinity;
-    // Daha sıkı tolerans: sadece duvar kalınlığı kadar (önizleme ile aynı)
     const bodyHitTolerancePreview = (state.wallThickness * 0.75) ** 2;
     for (const w of [...walls].reverse()) {
          if (!w.p1 || !w.p2) continue;
@@ -59,16 +58,20 @@ export function onPointerDownDraw(pos, clickedObject) {
              minDistSqPreview = distSq; previewWall = w;
          }
     }
+
+    // Eğer duvara yakınsak (simülasyon gösteriyorsa):
     if (previewWall) {
         const previewDoor = getDoorPlacement(previewWall, pos);
         if (previewDoor && isSpaceForDoor(previewDoor)) {
+            // Yer varsa: kapı ekle
             state.doors.push(previewDoor);
             saveState();
-            return;
         }
+        // Yer olsun olmasın, duvara yakınsak odaya açma moduna gitme!
+        return;
     }
 
-    // 2. Odaya tıklayarak komşulara kapı eklemeyi dene
+    // 2. Duvara yakın DEĞİLSEK, odaya tıklayarak komşulara kapı eklemeyi dene
     if (clickedObject && clickedObject.type === 'room') {
         const clickedRoom = clickedObject.object;
         if (!clickedRoom.polygon || !clickedRoom.polygon.geometry) return;

--- a/architectural-objects/window-handler.js
+++ b/architectural-objects/window-handler.js
@@ -135,9 +135,8 @@ export function onPointerDownDraw(pos, clickedObject) {
     const currentFloorId = state.currentFloor?.id;
     const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
 
-    // 1. Direkt duvara yerleştirmeyi dene - SADECE duvara yakınsa
+    // 1. Duvara yakın mı kontrol et (simülasyon ile aynı tolerans)
     let previewWall = null, minDistSqPreview = Infinity;
-    // Daha sıkı tolerans: sadece duvar kalınlığı kadar (önizleme ile aynı)
     const bodyHitTolerancePreview = (state.wallThickness * 0.75) ** 2;
     for (const w of [...walls].reverse()) {
         if (!w.p1 || !w.p2) continue;
@@ -146,6 +145,8 @@ export function onPointerDownDraw(pos, clickedObject) {
             minDistSqPreview = distSq; previewWall = w;
         }
     }
+
+    // Eğer duvara yakınsak (simülasyon gösteriyorsa):
     if (previewWall) {
         // Duvar tipini kontrol et
         const wallType = previewWall.wallType || 'normal';
@@ -169,7 +170,7 @@ export function onPointerDownDraw(pos, clickedObject) {
             const roomName = adjacentRoom ? adjacentRoom.name : null;
             const isBathroom = roomName === 'BANYO';
 
-            const previewWindowData = getWindowPlacement(previewWall, pos, isBathroom); // isBathroom bilgisini gönder
+            const previewWindowData = getWindowPlacement(previewWall, pos, isBathroom);
             if (previewWindowData && isSpaceForWindow(previewWindowData)) {
                 if (previewWall.windows && previewWall.windows.length > 0) {
                      return;
@@ -180,15 +181,16 @@ export function onPointerDownDraw(pos, clickedObject) {
                     width: previewWindowData.width,
                     type: 'window',
                     isWidthManuallySet: false,
-                    roomName: roomName // Oda adını ekle
+                    roomName: roomName
                  });
                 saveState();
-                return;
             }
         }
+        // Yer olsun olmasın, duvara yakınsak odaya/boşluğa açma moduna gitme!
+        return;
     }
 
-    // 2. Odaya tıklayarak dış duvarlara pencere ekle
+    // 2. Duvara yakın DEĞİLSEK, odaya tıklayarak dış duvarlara pencere ekle
     if (clickedObject && clickedObject.type === 'room') {
         const clickedRoom = clickedObject.object; const TOLERANCE = 1;
         if (!clickedRoom.polygon || !clickedRoom.polygon.geometry) return;

--- a/general-files/input.js
+++ b/general-files/input.js
@@ -13,10 +13,12 @@ import { showGuideContextMenu, hideGuideContextMenu } from '../draw/guide-menu.j
 import { fitDrawingToScreen, onWheel } from '../draw/zoom.js'; // Fit to Screen ve onWheel zoom.js'den
 import { showWallPanel, hideWallPanel } from '../wall/wall-panel.js'; // <-- HIDEWALLPANEL EKLENDİ
 import { copyFloorArchitecture, pasteFloorArchitecture } from '../draw/floor-operations-menu.js'; // <-- KAT MİMARİSİ KOPYALA/YAPIŞTIR
+import { onPointerDownDraw as doorPointerDownDraw } from '../architectural-objects/door-handler.js'; // SAĞTIK İÇİN
+import { onPointerDownDraw as windowPointerDownDraw } from '../architectural-objects/window-handler.js'; // SAĞTIK İÇİN
 import { onPointerDown } from '../pointer/pointer-down.js';
 import { onPointerMove } from '../pointer/pointer-move.js';
 import { onPointerUp } from '../pointer/pointer-up.js';
-import { isFPSMode } from '../scene3d/scene3d-camera.js'; 
+import { isFPSMode } from '../scene3d/scene3d-camera.js';
 import { update3DScene } from '../scene3d/scene3d-update.js'; 
 import { fit3DViewToScreen, scene, camera, renderer, sceneObjects } from '../scene3d/scene3d-core.js'; 
 import { wallExists } from '../wall/wall-handler.js';
@@ -771,19 +773,15 @@ export function setupInputListeners() {
         const clickPos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
         const object = getObjectAtPoint(clickPos);
 
-        // drawDoor modundayken duvara sağ tıklanırsa kapı ekle
-        if (state.currentMode === 'drawDoor' && object && object.type === 'wall') {
-            import('../architectural-objects/door-handler.js').then(module => {
-                module.onPointerDownDraw(clickPos, object);
-            });
+        // drawDoor modundayken sağ tıklanırsa kapı ekle (sadece duvara)
+        if (state.currentMode === 'drawDoor') {
+            doorPointerDownDraw(clickPos, null);
             return;
         }
 
-        // drawWindow modundayken duvara sağ tıklanırsa pencere ekle
-        if (state.currentMode === 'drawWindow' && object && object.type === 'wall') {
-            import('../architectural-objects/window-handler.js').then(module => {
-                module.onPointerDownDraw(clickPos, object);
-            });
+        // drawWindow modundayken sağ tıklanırsa pencere ekle (sadece duvara)
+        if (state.currentMode === 'drawWindow') {
+            windowPointerDownDraw(clickPos, null);
             return;
         }
 

--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
         <div class="context-submenu">
             <button id="floor-btn-copy" class="context-menu-btn">Mimari Planı Kopyala <span style="opacity: 0.6; font-size: 0.9em;">(CTRL + C)</span></button>
             <button id="floor-btn-paste" class="context-menu-btn">Mimari Planı Yapıştır <span style="opacity: 0.6; font-size: 0.9em;">(CTRL + V)</span></button>
-            <button id="floor-btn-paste-all" class="context-menu-btn">Bu Katın Mimari Planı Diğer Katlara Yapıştır</button>
+            <button id="floor-btn-paste-all" class="context-menu-btn">Bu Katın Mimari Planını Diğer Katlara Yapıştır</button>
             <div class="context-menu-divider"></div>
             <button id="floor-btn-clear" class="context-menu-btn context-menu-danger">Katın Mimari Planını Sil</button>
         </div>


### PR DESCRIPTION
MAJOR FIXES:

Door/Window Snap Issues (FULLY FIXED):
- Fixed simulation showing snap but click not snapping to wall
- When simulation shows wall snap, clicking now ALWAYS adds to wall
- Prevents accidental room-mode activation when near walls
- Click behavior now perfectly matches preview simulation

Right-Click Placement (FULLY FIXED):
- Right-click now correctly adds doors in drawDoor mode
- Right-click now correctly adds windows in drawWindow mode
- Changed from async import to sync import for reliability
- Always attempts wall placement, never triggers room modes

Button Text:
- Changed to "Bu Katın Mimari Planını Diğer Katlara Yapıştır"

Technical Changes:
- Modified onPointerDownDraw() in door-handler.js
  - Added early return when near wall (prevents room mode)
  - Consistent tolerance check between preview and click
- Modified onPointerDownDraw() in window-handler.js
  - Added early return when near wall (prevents room mode)
  - Fixed fallthrough to empty space mode
- Modified contextmenu handler in input.js
  - Added static imports for door/window handlers
  - Simplified right-click logic

Files modified:
- architectural-objects/door-handler.js
- architectural-objects/window-handler.js
- general-files/input.js
- index.html