### PR TITLE
fix: Duvara sağ tık ile kapı/pencere ekleme sorunu

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -776,13 +776,13 @@ export function setupInputListeners() {
 
         // drawDoor modundayken sağ tıklanırsa kapı ekle (sadece duvara)
         if (state.currentMode === 'drawDoor') {
-            doorPointerDownDraw(clickPos, null);
+            doorPointerDownDraw(clickPos, object);
             return;
         }
 
         // drawWindow modundayken sağ tıklanırsa pencere ekle (sadece duvara)
         if (state.currentMode === 'drawWindow') {
-            windowPointerDownDraw(clickPos, null);
+            windowPointerDownDraw(clickPos, object);
             return;
         }
 


### PR DESCRIPTION
- Sağ tık event handler'ında object parametresi doorPointerDownDraw ve windowPointerDownDraw fonksiyonlarına gönderilmiyordu
- Artık duvara sağ tıklayıp kapı/pencere eklerken doğru çalışıyor