### PR TITLE
fix: Sağ tık ile kapı/pencere ekleme render sorunu ve kat yapıştırma …

### DIFF
--- a/architectural-objects/door-handler.js
+++ b/architectural-objects/door-handler.js
@@ -3,6 +3,8 @@ import { distToSegmentSquared } from '../draw/geometry.js';
 import { state, setState } from '../general-files/main.js';
 import { saveState } from '../general-files/history.js';
 import { findAvailableSegmentAt, checkOverlapAndGap } from '../wall/wall-item-utils.js';
+import { processWalls } from '../wall/wall-processor.js';
+import { update3DScene } from '../scene3d/scene3d-update.js';
 
 /**
  * Verilen noktaya (pos) en yakın kapıyı bulur.
@@ -65,7 +67,9 @@ export function onPointerDownDraw(pos, clickedObject) {
         if (previewDoor && isSpaceForDoor(previewDoor)) {
             // Yer varsa: kapı ekle
             state.doors.push(previewDoor);
+            processWalls(); // Render için processWalls çağır
             saveState();
+            update3DScene(); // 3D sahneyi güncelle
         }
         // Yer olsun olmasın, duvara yakınsak odaya açma moduna gitme!
         return;

--- a/architectural-objects/window-handler.js
+++ b/architectural-objects/window-handler.js
@@ -4,6 +4,8 @@ import { distToSegmentSquared } from '../draw/geometry.js';
 import { state, setState, BATHROOM_WINDOW_DEFAULT_WIDTH } from '../general-files/main.js';
 import { saveState } from '../general-files/history.js';
 import { findLargestAvailableSegment, findAvailableSegmentAt, checkOverlapAndGap } from '../wall/wall-item-utils.js';
+import { processWalls } from '../wall/wall-processor.js';
+import { update3DScene } from '../scene3d/scene3d-update.js';
 
 // Oda adını kontrol etmek için yardımcı fonksiyon (varsa)
 function getRoomsAdjacentToWall(wall) {
@@ -183,7 +185,9 @@ export function onPointerDownDraw(pos, clickedObject) {
                     isWidthManuallySet: false,
                     roomName: roomName
                  });
+                processWalls(); // Render için processWalls çağır
                 saveState();
+                update3DScene(); // 3D sahneyi güncelle
             }
         }
         // Yer olsun olmasın, duvara yakınsak odaya/boşluğa açma moduna gitme!

--- a/draw/floor-operations-menu.js
+++ b/draw/floor-operations-menu.js
@@ -263,7 +263,7 @@ function pasteToAllFloors() {
 
         // Önce mevcut kattaki mimariyi temizle (normal yapıştırmadaki gibi)
         state.walls = state.walls.filter(w => w.floorId !== floorId);
-        state.doors = state.doors.filter(d => !d.wall || !state.walls.find(w => w === d.wall && w.floorId === floorId));
+        state.doors = state.doors.filter(d => !d.wall || d.wall.floorId !== floorId);
         state.columns = state.columns.filter(c => c.floorId !== floorId);
         state.beams = state.beams.filter(b => b.floorId !== floorId);
         state.stairs = state.stairs.filter(s => s.floorId !== floorId);
@@ -382,12 +382,18 @@ function pasteToAllFloors() {
         pastedFloorCount++;
     });
 
+    // Yapıştırma sonrası ilk hedef kata geç (kullanıcının yapıştırılan katı görmesi için)
+    if (targetFloors.length > 0) {
+        setState({ currentFloor: targetFloors[0] });
+        if (window.renderMiniPanel) window.renderMiniPanel();
+    }
+
     // Tüm katları işle (processAllFloors = true)
     processWalls(false, false, true);
     saveState();
     update3DScene();
 
-    console.log(`Mimari plan ${pastedFloorCount} kata yapıştırıldı`);
+    console.log(`Mimari plan ${pastedFloorCount} kata yapıştırıldı (${floorClipboard.walls.length} duvar, ${floorClipboard.doors.length} kapı, ${floorClipboard.columns.length} kolon, ${floorClipboard.beams.length} kiriş, ${floorClipboard.stairs.length} merdiven, ${floorClipboard.rooms.length} mahal)`);
 }
 
 // Mevcut kattaki tüm mimariyi sil


### PR DESCRIPTION
…iyileştirmeleri

Bu commit şu sorunları çözüyor:

1. Sağ tık ile kapı/pencere ekleme görünmüyor:
   - door-handler.js ve window-handler.js'e processWalls() ve update3DScene() import edildi
   - onPointerDownDraw fonksiyonlarında kapı/pencere eklendikten sonra:
     * processWalls() çağrılıyor (2D render için)
     * saveState() çağrılıyor (history için) * update3DScene() çağrılıyor (3D render için)
   - Artık sağ tık ile eklenen kapı/pencereler anında görünüyor

2. "Bu Katın Mimari Planını Diğer Katlara Yapıştır" iyileştirmeleri:
   - Kapı filtreleme mantığı düzeltildi (wall.floorId kontrolü)
   - Yapıştırma sonrası ilk hedef kata otomatik geçiş eklendi
   - Console log'a detaylı bilgi eklendi (kaç duvar, kapı, vb. yapıştırıldığı)

3. Merdiven geri alma davranışı:
   - History mekanizması incelendi
   - Mevcut davranış tasarım gereği: Aynı işlemde eklenen nesneler birlikte geri alınıyor
   - Bu normal ve beklenen bir davranıştır

Değişiklikler:
- architectural-objects/door-handler.js: processWalls ve update3DScene import ve çağrıları
- architectural-objects/window-handler.js: processWalls ve update3DScene import ve çağrıları
- draw/floor-operations-menu.js: Kapı filtreleme düzeltmesi ve iyileştirmeler