### PR TITLE
fix: Sağ tık ile kapı/pencere eklerken floorId sorunu

### DIFF
--- a/architectural-objects/door-handler.js
+++ b/architectural-objects/door-handler.js
@@ -47,8 +47,8 @@ export function getDoorAtPoint(pos, tolerance) {
  */
 export function onPointerDownDraw(pos, clickedObject) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
-    const rooms = (state.rooms || []).filter(r => !currentFloorId || !r.floorId || r.floorId === currentFloorId);
+    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : (state.walls || []);
+    const rooms = currentFloorId ? (state.rooms || []).filter(r => r.floorId === currentFloorId) : (state.rooms || []);
 
     // 1. Duvara yakın mı kontrol et (simülasyon ile aynı tolerans)
     let previewWall = null, minDistSqPreview = Infinity;

--- a/architectural-objects/window-handler.js
+++ b/architectural-objects/window-handler.js
@@ -135,7 +135,7 @@ function addWindowToWallMiddle(wall, roomName = null) { // Oda adı parametresi 
  */
 export function onPointerDownDraw(pos, clickedObject) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = (state.walls || []).filter(w => !currentFloorId || !w.floorId || w.floorId === currentFloorId);
+    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : (state.walls || []);
 
     // 1. Duvara yakın mı kontrol et (simülasyon ile aynı tolerans)
     let previewWall = null, minDistSqPreview = Infinity;


### PR DESCRIPTION
Root Cause:
- door-handler.js ve window-handler.js, duvar filtrelerken floorId olmayan duvarları da dahil ediyordu (!w.floorId)
- Bu duvarlara kapı/pencere eklendiğinde, door.floorId = wall.floorId = undefined oluyordu
- Render sırasında draw2d.js, sadece d.floorId === currentFloorId olanları gösterdiği için undefined floorId'li kapılar KAT modunda görünmüyordu
- BİNA modunda filter olmadığı için tüm kapılar görünüyordu

Solution:
- Duvar filtrelerini render filtreleriyle eşleştirdim
- Artık sadece currentFloorId ile eşleşen duvarlar seçiliyor
- Walls without floorId are excluded when in floor mode

Bu sayede sağ tıkla eklenen kapı/pencereler artık doğru floorId ile oluşturuluyor ve KAT modunda da görünüyor.