### PR TITLE
fix: Panel görüntüleme modları düzeltildi ve kapı ekleme sorunu çözüldü

### DIFF
--- a/architectural-objects/door-handler.js
+++ b/architectural-objects/door-handler.js
@@ -14,7 +14,8 @@ import { update3DScene } from '../scene3d/scene3d-update.js';
  */
 export function getDoorAtPoint(pos, tolerance) {
     const currentFloorId = state.currentFloor?.id;
-    const doors = currentFloorId ? (state.doors || []).filter(d => d.floorId === currentFloorId) : (state.doors || []);
+    // floorId undefined olan kapıları da dahil et (eski projelerle uyumluluk için)
+    const doors = currentFloorId ? (state.doors || []).filter(d => !d.floorId || d.floorId === currentFloorId) : (state.doors || []);
 
     for (const door of [...doors].reverse()) {
         const wall = door.wall;
@@ -47,8 +48,9 @@ export function getDoorAtPoint(pos, tolerance) {
  */
 export function onPointerDownDraw(pos, clickedObject) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : (state.walls || []);
-    const rooms = currentFloorId ? (state.rooms || []).filter(r => r.floorId === currentFloorId) : (state.rooms || []);
+    // floorId undefined olan duvarları da dahil et (eski projelerle uyumluluk için)
+    const walls = currentFloorId ? (state.walls || []).filter(w => !w.floorId || w.floorId === currentFloorId) : (state.walls || []);
+    const rooms = currentFloorId ? (state.rooms || []).filter(r => !r.floorId || r.floorId === currentFloorId) : (state.rooms || []);
 
     // 1. Duvara yakın mı kontrol et (simülasyon ile aynı tolerans)
     let previewWall = null, minDistSqPreview = Infinity;

--- a/architectural-objects/window-handler.js
+++ b/architectural-objects/window-handler.js
@@ -43,7 +43,8 @@ function getRoomsAdjacentToWall(wall) {
  */
 export function getWindowAtPoint(pos, tolerance) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : (state.walls || []);
+    // floorId undefined olan duvarları da dahil et (eski projelerle uyumluluk için)
+    const walls = currentFloorId ? (state.walls || []).filter(w => !w.floorId || w.floorId === currentFloorId) : (state.walls || []);
 
     for (const wall of walls) {
         if (!wall.windows || wall.windows.length === 0 || !wall.p1 || !wall.p2) continue;
@@ -135,7 +136,8 @@ function addWindowToWallMiddle(wall, roomName = null) { // Oda adı parametresi 
  */
 export function onPointerDownDraw(pos, clickedObject) {
     const currentFloorId = state.currentFloor?.id;
-    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : (state.walls || []);
+    // floorId undefined olan duvarları da dahil et (eski projelerle uyumluluk için)
+    const walls = currentFloorId ? (state.walls || []).filter(w => !w.floorId || w.floorId === currentFloorId) : (state.walls || []);
 
     // 1. Duvara yakın mı kontrol et (simülasyon ile aynı tolerans)
     let previewWall = null, minDistSqPreview = Infinity;

--- a/draw/draw-previews.js
+++ b/draw/draw-previews.js
@@ -11,7 +11,8 @@ export function drawObjectPlacementPreviews(ctx2d, state, getDoorPlacement, isSp
 
     // FLOOR ISOLATION: Sadece aktif kattaki duvarları kullan
     const currentFloorId = state.currentFloor?.id;
-    const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : (state.walls || []);
+    // floorId undefined olan duvarları da dahil et (eski projelerle uyumluluk için)
+    const walls = currentFloorId ? (state.walls || []).filter(w => !w.floorId || w.floorId === currentFloorId) : (state.walls || []);
 
     // Snap uygulanmamış pozisyonu kullan (eğer yoksa snapli olanı kullan)
     const previewMousePos = unsnappedMousePos || state.mousePos;

--- a/draw/panel-display-menu.js
+++ b/draw/panel-display-menu.js
@@ -12,10 +12,8 @@ function setPanelDisplayMode(mode) {
     // Tüm mod sınıflarını kaldır
     ui.classList.remove('display-small-icon', 'display-small-icon-text', 'display-big-icon', 'display-big-icon-text');
 
-    // Yeni modu ekle (small-icon varsayılan olduğu için sınıf eklemeye gerek yok)
-    if (mode !== 'small-icon') {
-        ui.classList.add(`display-${mode}`);
-    }
+    // Yeni modu ekle
+    ui.classList.add(`display-${mode}`);
 
     // Tercihi localStorage'a kaydet
     localStorage.setItem('panelDisplayMode', mode);
@@ -54,7 +52,7 @@ export function showPanelDisplayMenu(clientX, clientY) {
     menu.style.display = 'block';
 
     // Aktif modu vurgula
-    const currentMode = localStorage.getItem('panelDisplayMode') || 'small-icon';
+    const currentMode = localStorage.getItem('panelDisplayMode') || 'big-icon-text';
     document.querySelectorAll('.display-mode-option').forEach(btn => {
         const btnMode = btn.getAttribute('data-mode');
         if (btnMode === currentMode) {
@@ -113,12 +111,11 @@ export function initPanelDisplayMenu() {
     }
 
     // Sayfa yüklendiğinde kaydedilmiş modu uygula
-    const savedMode = localStorage.getItem('panelDisplayMode') || 'small-icon';
+    const savedMode = localStorage.getItem('panelDisplayMode') || 'big-icon-text';
     if (ui) {
         ui.classList.remove('display-small-icon', 'display-small-icon-text', 'display-big-icon', 'display-big-icon-text');
-        if (savedMode !== 'small-icon') {
-            ui.classList.add(`display-${savedMode}`);
-        }
+        // Varsayılan mod artık big-icon-text olduğu için herzaman sınıfı ekle
+        ui.classList.add(`display-${savedMode}`);
     }
 
     console.log('Panel display menü başlatıldı. Aktif mod:', savedMode);

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -125,8 +125,8 @@ canvas {
     gap: 8px;
 }
 
-/* YENİ KURAL: UI içindeki butonları sadece ikon göster */
-#ui .btn {
+/* YENİ KURAL: UI içindeki butonları sadece ikon göster (küçük ikon modu) */
+#ui.display-small-icon .btn {
     width: auto; /* Otomatik genişlik */
     min-width: 28px; /* Minimum genişlik - kat çubuğu ile uyumlu */
     height: 28px; /* Sabit yükseklik - kat çubuğu ile uyumlu */
@@ -138,8 +138,8 @@ canvas {
     gap: 0; /* Gap gerekmez */
 }
 
-/* UI içindeki buton iconları */
-#ui .btn svg {
+/* UI içindeki buton iconları (küçük ikon modu) */
+#ui.display-small-icon .btn svg {
     width: 16px; /* Kat çubuğu ile uyumlu boyut */
     height: 16px;
 }
@@ -151,6 +151,12 @@ canvas {
     width: auto;
     min-width: auto;
     padding: 6px 12px;
+    justify-content: flex-start; /* Sola dayalı */
+}
+
+#ui.display-small-icon-text .btn svg {
+    width: 16px;
+    height: 16px;
 }
 
 /* Display Mode: Büyük İkon */
@@ -167,11 +173,12 @@ canvas {
 
 /* Display Mode: Büyük İkon + Metin */
 #ui.display-big-icon-text .btn {
-    font-size: 16.8px; /* 14 * 1.2 */
-    gap: 10px; /* 8 * 1.25 */
+    font-size: 14px; /* Küçük ikonla aynı font boyutu */
+    gap: 8px; /* İkon ve metin arası boşluk */
     width: auto;
     min-width: auto;
-    padding: 9px 15px; /* Biraz daha geniş padding */
+    padding: 9px 12px; /* Büyük padding ama mantıklı */
+    justify-content: flex-start; /* Sola dayalı */
 }
 
 #ui.display-big-icon-text .btn svg {


### PR DESCRIPTION
Panel Görüntüleme Modları:
- Metinli modlarda butonlar artık sola dayalı (justify-content: flex-start)
- Büyük İkon ve Büyük İkon+Metin modlarında ikon boyutu aynı (24px)
- Metin boyutu her zaman 14px (küçük ikonla aynı)
- Varsayılan mod: Büyük İkon + Metin
- CSS sınıf mantığı düzeltildi (tüm modlar için sınıf ekleniyor)

Kapı/Pencere Ekleme Sorunu:
- Eski projelerle uyumluluk için floorId undefined olan duvarlar/kapılar artık mevcut kata dahil ediliyor
- Bu sayede floorId'si olmayan nesnelere de kapı/pencere eklenebiliyor
- Filtreleme mantığı: !w.floorId || w.floorId === currentFloorId

Değiştirilen dosyalar:
- style.css: Görüntüleme modları için CSS kuralları
- panel-display-menu.js: Varsayılan mod ve sınıf yönetimi
- door-handler.js: Duvar ve kapı filtreleme
- window-handler.js: Duvar filtreleme
- draw-previews.js: Duvar filtreleme