### PR TITLE
fix: Kiriş 3D konumu, icon metni ve kapı ekleme düzeltildi

### DIFF
--- a/architectural-objects/door-handler.js
+++ b/architectural-objects/door-handler.js
@@ -143,7 +143,11 @@ export function onPointerDownDraw(pos, clickedObject) {
                 }
             }
         });
-        if (doorsAdded > 0) saveState();
+        if (doorsAdded > 0) {
+            processWalls(); // Render için processWalls çağır
+            saveState();
+            update3DScene(); // 3D sahneyi güncelle
+        }
     }
 }
 

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -164,6 +164,9 @@ canvas {
     min-width: 42px; /* 28 * 1.5 */
     height: 42px;
     padding: 9px; /* 6 * 1.5 */
+    font-size: 0; /* Metni gizle */
+    gap: 0; /* Gap gerekmez */
+    justify-content: center; /* İkonu ortala */
 }
 
 #ui.display-big-icon .btn svg {

--- a/scene3d/scene3d-structures.js
+++ b/scene3d/scene3d-structures.js
@@ -35,10 +35,13 @@ export function createBeamMesh(beam, material) {
      if (beamLength < 1) return null;
 
     const beamGeom = new THREE.BoxGeometry(beamLength, beamDepth, beamThickness);
-    const yPosition = WALL_HEIGHT + (beamDepth / 2); // Katın üstüne yerleştir (tavan seviyesi)
+    // Y pozisyonu relative olarak ayarla (kat yüksekliği + kiriş derinliği/2)
+    const relativeY = WALL_HEIGHT + (beamDepth / 2);
     const beamMesh = new THREE.Mesh(beamGeom, material);
-    beamMesh.position.set(beam.center.x, yPosition, beam.center.y);
+    beamMesh.position.set(beam.center.x, relativeY, beam.center.y);
     beamMesh.rotation.y = -(beam.rotation || 0) * Math.PI / 180;
+    // Kiriş derinliğini mesh'e ekle (update3DScene'de kullanılacak)
+    beamMesh.userData.beamDepth = beamDepth;
     return beamMesh;
 }
 

--- a/scene3d/scene3d-update.js
+++ b/scene3d/scene3d-update.js
@@ -212,7 +212,10 @@ export function update3DScene() {
         beams.forEach(beam => {
             const m = createBeamMesh(beam, beamMaterial);
             if (m) {
-                m.position.y = getFloorElevation(beam.floorId);
+                // Kirişler katın üstünde (tavan seviyesinde) olmalı
+                const floorElevation = getFloorElevation(beam.floorId);
+                const beamDepth = beam.depth || 20;
+                m.position.y = floorElevation + WALL_HEIGHT + (beamDepth / 2);
                 sceneObjects.add(m);
             }
         });


### PR DESCRIPTION
SORUNLAR:
1. Kirişler yanlış konumlanıyordu (zemin seviyesinde)
2. Büyük icon modunda metin görünüyordu
3. Odaya tıklayarak kapı eklerken render yapılmıyordu

ÇÖZÜMLER:
- scene3d-structures.js: Kiriş Y pozisyonu için userData eklendi
- scene3d-update.js: Kirişler için doğru Y hesaplama (floorElevation + WALL_HEIGHT + beamDepth/2)
- style.css: display-big-icon moduna font-size: 0, gap: 0, justify-content: center eklendi
- door-handler.js: Odaya tıklayınca kapı ekleme sonrası processWalls ve update3DScene çağrıları eklendi