### PR TITLE
fix: Kiriş pozisyonu ve kat kopyalama sorunları düzeltildi

### DIFF
--- a/draw/floor-operations-menu.js
+++ b/draw/floor-operations-menu.js
@@ -86,8 +86,10 @@ export function pasteFloorArchitecture() {
     const currentFloorId = state.currentFloor.id;
 
     // Önce mevcut kattaki mimariyi temizle
+    // DÜZELTME: Kapı filtresi için önce silinecek duvarları belirle
+    const wallsToDelete = state.walls.filter(w => w.floorId === currentFloorId);
+    state.doors = state.doors.filter(d => !d.wall || !wallsToDelete.includes(d.wall));
     state.walls = state.walls.filter(w => w.floorId !== currentFloorId);
-    state.doors = state.doors.filter(d => !d.wall || !state.walls.find(w => w === d.wall && w.floorId === currentFloorId));
     state.columns = state.columns.filter(c => c.floorId !== currentFloorId);
     state.beams = state.beams.filter(b => b.floorId !== currentFloorId);
     state.stairs = state.stairs.filter(s => s.floorId !== currentFloorId);
@@ -264,8 +266,10 @@ function pasteToAllFloors() {
         const floorId = floor.id;
 
         // Önce mevcut kattaki mimariyi temizle (normal yapıştırmadaki gibi)
+        // DÜZELTME: Kapı filtresi için önce silinecek duvarları belirle
+        const wallsToDelete = state.walls.filter(w => w.floorId === floorId);
+        state.doors = state.doors.filter(d => !d.wall || !wallsToDelete.includes(d.wall));
         state.walls = state.walls.filter(w => w.floorId !== floorId);
-        state.doors = state.doors.filter(d => !d.wall || d.wall.floorId !== floorId);
         state.columns = state.columns.filter(c => c.floorId !== floorId);
         state.beams = state.beams.filter(b => b.floorId !== floorId);
         state.stairs = state.stairs.filter(s => s.floorId !== floorId);
@@ -431,8 +435,10 @@ function clearFloorArchitecture() {
     }
 
     // Mimariyi temizle
+    // DÜZELTME: Kapı filtresi için önce silinecek duvarları belirle
+    const wallsToDelete = state.walls.filter(w => w.floorId === currentFloorId);
+    state.doors = state.doors.filter(d => !d.wall || !wallsToDelete.includes(d.wall));
     state.walls = state.walls.filter(w => w.floorId !== currentFloorId);
-    state.doors = state.doors.filter(d => !d.wall || !state.walls.find(w => w === d.wall && w.floorId === currentFloorId));
     state.columns = state.columns.filter(c => c.floorId !== currentFloorId);
     state.beams = state.beams.filter(b => b.floorId !== currentFloorId);
     state.stairs = state.stairs.filter(s => s.floorId !== currentFloorId);

--- a/scene3d/scene3d-update.js
+++ b/scene3d/scene3d-update.js
@@ -212,10 +212,10 @@ export function update3DScene() {
         beams.forEach(beam => {
             const m = createBeamMesh(beam, beamMaterial);
             if (m) {
-                // Kirişler katın üstünde (tavan seviyesinde) olmalı
+                // Kirişler katın içinde, üst sınırı tavan seviyesinde (tavana yapışık)
                 const floorElevation = getFloorElevation(beam.floorId);
                 const beamDepth = beam.depth || 20;
-                m.position.y = floorElevation + WALL_HEIGHT + (beamDepth / 2);
+                m.position.y = floorElevation + WALL_HEIGHT - (beamDepth / 2);
                 sceneObjects.add(m);
             }
         });


### PR DESCRIPTION
KRİTİK DÜZELTMELER:

1. Kiriş Pozisyonu (scene3d-update.js:218)
   - HATALI: floorElevation + WALL_HEIGHT + (beamDepth / 2)  [Tavanın ÜZERİNDE]
   - DOĞRU: floorElevation + WALL_HEIGHT - (beamDepth / 2)   [Tavana YAPIŞIK]
   - Kirişler artık katın içinde, üst sınırı tavan seviyesinde

2. Kat Kopyalama - Kapı Silme Hatası (floor-operations-menu.js)
   - SORUN: Duvarlar silinmeden önce kapı filtresi yapılıyordu
   - Duvar referansları kaybolunca kapılar yanlış filtreleniyordu
   - ÇÖZÜM: Önce silinecek duvarları belirle, sonra o duvarlardaki kapıları sil
   - Bu düzeltme 3 yerde uygulandı:
     * pasteFloorArchitecture() - Tek kata yapıştır
     * pasteToAllFloors() - Tüm katlara yapıştır * clearFloorArchitecture() - Kat mimari temizle

CTRL+C/V: Zaten tanımlı ve çalışıyor (input.js:362-363, 863-864)