### PR TITLE
fix: Kapı görüntüleme sorunu düzeltildi (2D ve 3D kat modu)

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -236,7 +236,8 @@ export function draw2D() {
     // Eğer currentFloorId yoksa (eski projeler), tüm öğeleri göster
     const rooms = currentFloorId ? (state.rooms || []).filter(r => r.floorId === currentFloorId) : (state.rooms || []);
     const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : (state.walls || []);
-    const doors = currentFloorId ? (state.doors || []).filter(d => d.floorId === currentFloorId) : (state.doors || []);
+    // DÜZELTME: Kapılar duvar üzerinden filtrelenmeli (d.wall.floorId)
+    const doors = currentFloorId ? (state.doors || []).filter(d => d.wall && (!d.wall.floorId || d.wall.floorId === currentFloorId)) : (state.doors || []);
     const beams = currentFloorId ? (state.beams || []).filter(b => b.floorId === currentFloorId) : (state.beams || []);
     const stairs = currentFloorId ? (state.stairs || []).filter(s => s.floorId === currentFloorId) : (state.stairs || []);
     const columns = currentFloorId ? (state.columns || []).filter(c => c.floorId === currentFloorId) : (state.columns || []);

--- a/scene3d/scene3d-update.js
+++ b/scene3d/scene3d-update.js
@@ -68,7 +68,8 @@ export function update3DScene() {
     };
 
     const walls = (state.walls || []).filter(w => shouldShowFloor(w.floorId));
-    const doors = (state.doors || []).filter(d => shouldShowFloor(d.floorId));
+    // DÜZELTME: Kapılar duvar üzerinden filtrelenmeli (d.wall.floorId)
+    const doors = (state.doors || []).filter(d => d.wall && shouldShowFloor(d.wall.floorId));
     const columns = (state.columns || []).filter(c => shouldShowFloor(c.floorId));
     const beams = (state.beams || []).filter(b => shouldShowFloor(b.floorId));
     const rooms = (state.rooms || []).filter(r => shouldShowFloor(r.floorId));


### PR DESCRIPTION
KRİTİK HATA:
Kapılar arka planda ekleniyordu ama UI'da ve 3D kat modunda görünmüyordu.

SORUN:
- draw2d.js:239 - Kapılar d.floorId ile filtreleniyordu
- scene3d-update.js:71 - Kapılar d.floorId ile filtreleniyordu
- AMA kapılar duvar referansı üzerinden saklanıyor (state.doors)
- Pencereler wall.windows dizisinde olduğu için duvar filtresi otomatik çalışıyor
- Kapılar için wall.floorId kontrolü yapılması gerekiyor

ÇÖZÜM:
- draw2d.js:240 - d.wall && (!d.wall.floorId || d.wall.floorId === currentFloorId)
- scene3d-update.js:72 - d.wall && shouldShowFloor(d.wall.floorId)
- Artık kapılar DUVARIN floorId'sine göre filtreleniyor
- Eski projelerle uyumluluk için undefined floorId kontrolü eklendi

SONUÇ:
✓ Kapılar 2D UI'da görünüyor
✓ Kapılar 3D kat modunda görünüyor
✓ Bina modunda zaten çalışıyordu