### PR TITLE
feat: Tesisat nesneleri geliştirmeleri ve UI iyileştirmeleri

### DIFF
--- a/architectural-objects/plumbing-blocks.js
+++ b/architectural-objects/plumbing-blocks.js
@@ -16,31 +16,32 @@ export const PLUMBING_BLOCK_TYPES = {
     SERVIS_KUTUSU: {
         id: 'servis-kutusu',
         name: 'Servis Kutusu',
-        // 3D boyutlar (cm)
-        width: 31,      // en (X ekseni)
-        height: 15,     // derinlik (2D Y ekseni, 3D Z ekseni) - üstten bakınca görünen
-        depth: 64,      // yükseklik (3D Y ekseni) - duvara dik yükseliş
-        cornerRadius: 1, // 1 cm yuvarlama
+        // 3D boyutlar (cm) - 20x40x70
+        width: 40,      // duvar boyunca (X ekseni)
+        height: 20,     // duvardan dışa çıkan (2D Y ekseni, 3D Z ekseni)
+        depth: 70,      // yükseklik (3D Y ekseni) - duvara dik yükseliş
+        cornerRadius: 2, // 2 cm yuvarlama
         // Bağlantı noktası (merkeze göre offset)
         connectionPoints: [
-            { x: 15.5, y: 0, label: 'çıkış' } // Sağda ortada
+            { x: 20, y: 10, label: 'çıkış' } // Sağ üst köşede dışarıda
         ],
         mountType: 'wall', // duvara monte
-        color: 0xF5F5F5, // Beyaza yakın gri
+        color: 0xA8A8A8, // Gri ton
     },
     SAYAC: {
         id: 'sayac',
         name: 'Sayaç',
-        width: 20,
-        height: 21,
-        depth: 12,
-        cornerRadius: 1, // 1 cm yuvarlama
+        // 3D boyutlar (cm) - 15x30x30
+        width: 30,      // duvar boyunca (X ekseni)
+        height: 15,     // duvardan dışa çıkan (2D Y ekseni, 3D Z ekseni)
+        depth: 30,      // yükseklik (3D Y ekseni)
+        cornerRadius: 2, // 2 cm yuvarlama
         connectionPoints: [
-            { x: -7, y: 10.5, label: 'giriş' },   // Sol üst
-            { x: 7, y: 10.5, label: 'çıkış' }      // Sağ üst
+            { x: -10, y: 7.5, label: 'giriş' },   // Sol üst
+            { x: 10, y: 7.5, label: 'çıkış' }      // Sağ üst
         ],
         mountType: 'wall',
-        color: 0xF5F5F5, // Beyaza yakın gri
+        color: 0xA8A8A8, // Gri ton
     },
     VANA: {
         id: 'vana',

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -937,9 +937,13 @@ function initializeDraggableGroups() {
             isDragging = true;
             group.classList.add('dragging');
 
-            const rect = group.getBoundingClientRect();
-            initialX = e.clientX - rect.left;
-            initialY = e.clientY - rect.top;
+            // Mevcut pozisyonu al (parent'a göre)
+            const currentLeft = parseInt(group.style.left) || 0;
+            const currentTop = parseInt(group.style.top) || 0;
+
+            // Fare ile mevcut pozisyon arasındaki offset
+            initialX = e.clientX - currentLeft;
+            initialY = e.clientY - currentTop;
 
             e.preventDefault();
         });

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -127,7 +127,7 @@ canvas {
 }
 
 #group-plumbing {
-    top: 480px;
+    top: 580px;
     left: 0;
 }
 

--- a/index.html
+++ b/index.html
@@ -32,14 +32,6 @@
 <!-- ═══════════════════════════════════════════════════════════════ -->
 <div class="button-group draggable-group" id="group-architecture">
   <div class="group-label drag-handle">MİMARİ</div>
-  <button id="bAssignNames" class="btn" title="Mahal Tanımla">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M5 9h14v10H5z"/>
-      <path d="M9 9V7c0-1.1.9-2 2-2h2c1.1 0 2 .9 2 2v2"/>
-      <path d="M19 13h2c1.1 0 2 .9 2 2v0c0 1.1-.9 2-2 2h-2"/>
-    </svg>
-    Mahal Tanımla
-  </button>
   <button id="bSel" class="btn" title="Seç">
     <svg viewBox="0 0 24 24"><path d="M3 3l7.07 16.97 2.51-7.39 7.39-2.51L3 3z" stroke-width="1.5"></path></svg>
     Seç
@@ -95,6 +87,14 @@
     </svg>
     Simetri
   </button>
+  <button id="bAssignNames" class="btn" title="Mahal Tanımla">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M5 9h14v10H5z"/>
+      <path d="M9 9V7c0-1.1.9-2 2-2h2c1.1 0 2 .9 2 2v2"/>
+      <path d="M19 13h2c1.1 0 2 .9 2 2v0c0 1.1-.9 2-2 2h-2"/>
+    </svg>
+    Mahal Tanımla
+  </button>
 </div>
 
 <!-- ═══════════════════════════════════════════════════════════════ -->
@@ -105,7 +105,7 @@
   <button id="bServisKutusu" class="btn" title="Servis Kutusu">
     <svg viewBox="0 0 24 24" stroke="currentColor" fill="none">
       <rect x="6" y="4" width="12" height="16" rx="1" stroke-width="1.5"/>
-      <circle cx="16" cy="14" r="1.5" fill="currentColor"/>
+      <circle cx="19.5" cy="14" r="1.5" fill="currentColor"/>
     </svg>
     Servis Kutusu
   </button>
@@ -114,13 +114,17 @@
       <rect x="7" y="8" width="10" height="8" rx="1" stroke-width="1.5"/>
       <circle cx="10" cy="8" r="1" fill="#0F0"/>
       <circle cx="14" cy="8" r="1" fill="#F00"/>
+      <!-- Sol kol (sola döner) -->
+      <path d="M 10 8 L 10 5 M 10 5 L 8 6" stroke-width="1.5" stroke-linecap="round"/>
+      <!-- Sağ kol (sağa döner) -->
+      <path d="M 14 8 L 14 5 M 14 5 L 16 6" stroke-width="1.5" stroke-linecap="round"/>
     </svg>
     Sayaç
   </button>
   <button id="bVana" class="btn" title="Vana">
     <svg viewBox="0 0 24 24" stroke="currentColor" fill="currentColor">
-      <path d="M 4 12 L 10 8 L 10 16 Z"/>
-      <path d="M 20 12 L 14 8 L 14 16 Z"/>
+      <path d="M 10 12 L 4 8 L 4 16 Z"/>
+      <path d="M 14 12 L 20 8 L 20 16 Z"/>
     </svg>
     Vana
   </button>

--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -333,6 +333,9 @@ export function onPointerDown(e) {
             geometryChanged = true;
             needsUpdate3D = true;
             objectJustCreated = true;
+
+            // Blok eklendikten sonra komuttan çık
+            setMode("select");
         }
     // --- Merdiven Çizim Modu ---
     } else if (state.currentMode === "drawStairs") {


### PR DESCRIPTION
- Tesisat nesneleri 1 kez eklendikten sonra otomatik select moduna geçiş
- Servis kutusu: 20x40x70 cm, gri ton (0xA8A8A8), 2cm yuvarlama
- Sayaç: 15x30x30 cm, gri ton (0xA8A8A8), 2cm yuvarlama
- Mahal Tanımla butonu mimari grubunun en altına taşındı
- Araç çubukları üstüste binmeyecek şekilde pozisyonlandı (580px)
- Araç çubuğu taşıma offset sorunu düzeltildi
- Vana ikonu >< şeklinde ters çevrildi
- Sayaç ikonuna üstte 2 ters dönen kol eklendi
- Servis kutusu ikonunda çıkış noktası dışa taşındı