### PR TITLE
fix: Merdiven floorId sorununu düzelt (undo/redo)

### DIFF
--- a/general-files/history.js
+++ b/general-files/history.js
@@ -59,7 +59,8 @@ export function saveState() {
             topElevation: s.topElevation,
             connectedStairId: s.connectedStairId,
             isLanding: s.isLanding,
-            showRailing: s.showRailing // <-- DÜZELTME: Korkuluk bilgisi eklendi
+            showRailing: s.showRailing, // <-- DÜZELTME: Korkuluk bilgisi eklendi
+            floorId: s.floorId // FLOOR ISOLATION: floorId kaydet
         })))),
         guides: JSON.parse(JSON.stringify(state.guides || [])), // <-- REFERANS ÇİZGİSİ EKLENDİ
         floors: JSON.parse(JSON.stringify(state.floors || [])), // FLOOR ISOLATION: floors kaydet
@@ -152,7 +153,8 @@ export function restoreState(snapshot) {
             topElevation: s.topElevation,
             connectedStairId: s.connectedStairId,
             isLanding: s.isLanding,
-            showRailing: s.showRailing || false // <-- DÜZELTME: Korkuluk bilgisi okundu
+            showRailing: s.showRailing || false, // <-- DÜZELTME: Korkuluk bilgisi okundu
+            floorId: s.floorId // FLOOR ISOLATION: floorId geri yükle
         })),
         guides: snapshot.guides || [], // <-- REFERANS ÇİZGİSİ EKLENDİ
         floors: restoredFloors, // FLOOR ISOLATION: floors geri yükle


### PR DESCRIPTION
history.js'de stairs için floorId kaydetme ve geri yükleme eksikti. Kapılar için yapılan düzeltme merdivenler için de uygulandı.

- saveState: stairs için floorId kaydetme eklendi
- restoreState: stairs için floorId geri yükleme eklendi