### PR TITLE
debug: Tesisat nesneleri için debug logları eklendi

### DIFF
--- a/architectural-objects/plumbing-blocks.js
+++ b/architectural-objects/plumbing-blocks.js
@@ -184,6 +184,14 @@ export function getPlumbingBlockAtPoint(point) {
     const blocks = (state.plumbingBlocks || []).filter(b => b.floorId === currentFloorId);
     const tolerance = 8 / zoom;
 
+    console.log('🔍 getPlumbingBlockAtPoint called:', {
+        point,
+        tolerance,
+        totalBlocks: state.plumbingBlocks?.length || 0,
+        currentFloorBlocks: blocks.length,
+        currentFloorId
+    });
+
     // Önce handle'ları kontrol et
     for (const block of blocks) {
         const corners = getPlumbingBlockCorners(block);

--- a/architectural-objects/plumbing-pipes.js
+++ b/architectural-objects/plumbing-pipes.js
@@ -139,6 +139,14 @@ export function getPipeAtPoint(point, tolerance = 8) {
     const currentFloorId = state.currentFloor?.id;
     const pipes = (state.plumbingPipes || []).filter(p => p.floorId === currentFloorId);
 
+    console.log('🔍 getPipeAtPoint called:', {
+        point,
+        tolerance,
+        totalPipes: state.plumbingPipes?.length || 0,
+        currentFloorPipes: pipes.length,
+        currentFloorId
+    });
+
     // Ters sırada kontrol et (en son eklenen önce)
     for (const pipe of [...pipes].reverse()) {
         if (isPointOnPipe(point, pipe, tolerance)) {

--- a/draw/draw-plumbing.js
+++ b/draw/draw-plumbing.js
@@ -414,7 +414,7 @@ export function drawPlumbingPipe(pipe, isSelected = false) {
 
     // Kesikli çizgi kontrolü - eğer vanaya bağlı değilse kesikli çiz
     if (!pipe.isConnectedToValve) {
-        ctx2d.setLineDash([8 / zoom, 6 / zoom]);
+        ctx2d.setLineDash([15 / zoom, 10 / zoom]); // Daha açık kesikli çizgi
     }
 
     ctx2d.beginPath();


### PR DESCRIPTION
- getPipeAtPoint ve getPlumbingBlockAtPoint fonksiyonlarına debug logları eklendi
- Kesikli çizgi aralığı artırıldı (15-10, daha açık)

Bu loglar ile tesisat nesnelerinin seçilip seçilmediğini, kaç tane nesne olduğunu görebiliriz.