### PR TITLE
fix: Mouse move'daki infinite loop debug logları kaldırıldı

### DIFF
--- a/architectural-objects/plumbing-blocks.js
+++ b/architectural-objects/plumbing-blocks.js
@@ -184,13 +184,7 @@ export function getPlumbingBlockAtPoint(point) {
     const blocks = (state.plumbingBlocks || []).filter(b => b.floorId === currentFloorId);
     const tolerance = 8 / zoom;
 
-    console.log('🔍 getPlumbingBlockAtPoint called:', {
-        point,
-        tolerance,
-        totalBlocks: state.plumbingBlocks?.length || 0,
-        currentFloorBlocks: blocks.length,
-        currentFloorId
-    });
+    // Debug log kaldırıldı (her mouse move'da çağrılıyor)
 
     // Önce handle'ları kontrol et
     for (const block of blocks) {

--- a/architectural-objects/plumbing-pipes.js
+++ b/architectural-objects/plumbing-pipes.js
@@ -139,13 +139,7 @@ export function getPipeAtPoint(point, tolerance = 8) {
     const currentFloorId = state.currentFloor?.id;
     const pipes = (state.plumbingPipes || []).filter(p => p.floorId === currentFloorId);
 
-    console.log('🔍 getPipeAtPoint called:', {
-        point,
-        tolerance,
-        totalPipes: state.plumbingPipes?.length || 0,
-        currentFloorPipes: pipes.length,
-        currentFloorId
-    });
+    // Debug log kaldırıldı (her mouse move'da çağrılıyor)
 
     // Ters sırada kontrol et (en son eklenen önce)
     for (const pipe of [...pipes].reverse()) {


### PR DESCRIPTION
getPipeAtPoint ve getPlumbingBlockAtPoint her mouse move'da çağrılıyor, bu yüzden saniyede binlerce log üretiyordu.

Önemli log'lar (boru çizim sırasındakiler) korundu.