### PR TITLE
fix: Çıkış noktası görselleştirme - sadece en yakın nokta

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -646,7 +646,7 @@ export function onPointerDown(e) {
                 // En yakın çıkış noktasını bul
                 for (const cp of activePoints) {
                     const dist = Math.hypot(pos.x - cp.x, pos.y - cp.y);
-                    if (dist < 15) { // 15 cm tolerans
+                    if (dist < 3) { // 3 cm tolerans
                         startPos = { x: cp.x, y: cp.y };
                         console.log('✅ Starting from Servis Kutusu connection point (user clicked):', startPos, cp.label);
                         break;


### PR DESCRIPTION
- Boru çizim modunda sadece mouse'a en yakın ve 3 cm içindeki noktayı göster
- Diğer noktaları gizle (kafa karışıklığını önle)
- Tıklama toleransı 15 cm'den 3 cm'ye düşürüldü

Değişiklikler:
- draw-plumbing.js: En yakın noktayı bul, sadece onu göster
- pointer-down.js: Tıklama toleransı 3 cm