### PR TITLE
fix: Servis kutusu taşınırken boru kopma düzeltmesi

### DIFF
--- a/architectural-objects/plumbing-blocks.js
+++ b/architectural-objects/plumbing-blocks.js
@@ -398,45 +398,14 @@ function checkIfBlockIsConnected(block) {
 /**
  * Bağlı boruları güncelle
  * GÜNCELLENDİ: Vana pozisyonlarını da güncelle
- * GÜNCELLENDİ: Servis kutusu için bağlantı bilgisini temizle (boru ucu sabit kalsın)
+ * GÜNCELLENDİ: Servis kutusu için de boru ucunu taşı (kopmasın)
  */
 function updateConnectedPipes(block, oldCenter, newCenter) {
     const oldConnections = getConnectionPointsAtPosition(block, oldCenter);
     const newConnections = getConnectionPoints(block);
 
-    // KULLANICI İSTEĞİ: Servis kutusu taşınırken boru uçları sabit kalmalı
-    // Bağlantı bilgisini temizle ki boru serbest kalsın
-    if (block.blockType === 'SERVIS_KUTUSU') {
-        console.log('🔒 Servis kutusu taşınıyor - boru bağlantıları temizleniyor');
-
-        oldConnections.forEach((oldConn, index) => {
-            const tolerance = 15;
-
-            (state.plumbingPipes || []).forEach(pipe => {
-                // p1 bağlantısını kontrol et
-                if (pipe.connections?.start?.blockId === block && pipe.connections.start.connectionIndex === index) {
-                    pipe.connections.start = null;
-                    console.log('🔓 P1 bağlantısı temizlendi');
-                } else if (Math.hypot(pipe.p1.x - oldConn.x, pipe.p1.y - oldConn.y) < tolerance) {
-                    if (!pipe.connections) pipe.connections = { start: null, end: null };
-                    pipe.connections.start = null;
-                }
-
-                // p2 bağlantısını kontrol et
-                if (pipe.connections?.end?.blockId === block && pipe.connections.end.connectionIndex === index) {
-                    pipe.connections.end = null;
-                    console.log('🔓 P2 bağlantısı temizlendi');
-                } else if (Math.hypot(pipe.p2.x - oldConn.x, pipe.p2.y - oldConn.y) < tolerance) {
-                    if (!pipe.connections) pipe.connections = { start: null, end: null };
-                    pipe.connections.end = null;
-                }
-            });
-        });
-
-        return; // Koordinatları güncelleme, sadece bağlantıyı temizle
-    }
-
-    // Diğer bloklar için normal güncelleme
+    // KULLANICI İSTEĞİ: Servis kutusu taşınırken boru uçları kutuyla birlikte taşınsın
+    // Normal güncelleme mantığı kullanılacak (diğer bloklarla aynı)
 
     oldConnections.forEach((oldConn, index) => {
         const newConn = newConnections[index];

--- a/draw/draw-plumbing.js
+++ b/draw/draw-plumbing.js
@@ -729,15 +729,6 @@ export function drawPlumbingPipePreview() {
             ctx2d.fill();
             ctx2d.stroke();
 
-            // Label göster (zoom yeterliyse)
-            if (zoom > 0.3) {
-                ctx2d.fillStyle = '#FFFFFF';
-                ctx2d.font = `${12 / zoom}px Arial`;
-                ctx2d.textAlign = 'center';
-                ctx2d.textBaseline = 'bottom';
-                ctx2d.fillText(closestPoint.label, closestPoint.x, closestPoint.y - 8 / zoom);
-            }
-
             ctx2d.restore();
         }
 


### PR DESCRIPTION
- Kutu taşınırken boru ucu kutuyla birlikte taşınır (ASLA kopma olmaz)
- Boru çizim modunda label gösterilmiyor (sadece yeşil nokta)

Değişiklikler:
- plumbing-blocks.js: Servis kutusu için özel durum kaldırıldı, normal güncelleme kullanılıyor
- draw-plumbing.js: Label gösterme kodu kaldırıldı