### PR TITLE
fix: Boru kopma sorunu - hem connections hem tolerance kontrolü eklendi

### DIFF
--- a/architectural-objects/plumbing-blocks.js
+++ b/architectural-objects/plumbing-blocks.js
@@ -95,6 +95,7 @@ export function createPlumbingBlock(centerX, centerY, blockType = 'SERVIS_KUTUSU
     return {
         type: 'plumbingBlock',
         blockType: blockType,
+        id: `block_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`, // Unique ID
         center: { x: centerX, y: centerY },
         rotation: 0,
         floorId: state.currentFloor?.id,
@@ -280,14 +281,24 @@ function checkPipeValveLengthBeforeMove(block, newCenter) {
             let affectsP1 = false;
             let affectsP2 = false;
 
-            // Explicit connection kontrolü
-            if (pipe.connections?.start?.blockId === block && pipe.connections.start.connectionIndex === index) {
+            // Explicit connection kontrolü (ID veya referans bazlı)
+            const isP1ConnectedToThisBlock = pipe.connections?.start?.blockId && (
+                pipe.connections.start.blockId === block.id || // ID kontrolü
+                pipe.connections.start.blockId === block      // Referans kontrolü
+            ) && pipe.connections.start.connectionIndex === index;
+
+            const isP2ConnectedToThisBlock = pipe.connections?.end?.blockId && (
+                pipe.connections.end.blockId === block.id || // ID kontrolü
+                pipe.connections.end.blockId === block      // Referans kontrolü
+            ) && pipe.connections.end.connectionIndex === index;
+
+            if (isP1ConnectedToThisBlock) {
                 affectsP1 = true;
             } else if (Math.hypot(pipe.p1.x - oldConn.x, pipe.p1.y - oldConn.y) < tolerance) {
                 affectsP1 = true;
             }
 
-            if (pipe.connections?.end?.blockId === block && pipe.connections.end.connectionIndex === index) {
+            if (isP2ConnectedToThisBlock) {
                 affectsP2 = true;
             } else if (Math.hypot(pipe.p2.x - oldConn.x, pipe.p2.y - oldConn.y) < tolerance) {
                 affectsP2 = true;
@@ -408,6 +419,7 @@ function updateConnectedPipes(block, oldCenter, newCenter) {
     // 1. Zaten bu kutuya bağlı olan boruları güncelle (bağlantı noktası değişmemeli)
     // 2. Serbest uçları (connections null) güncelle (tolerance ile)
     // 3. BAŞKA bloklara bağlı uçları ASLA yakalama
+    // NOT: Hem ID bazlı (yeni sistem) hem referans bazlı (eski sistem) kontrol yapılıyor
 
     (state.plumbingPipes || []).forEach(pipe => {
         let shouldUpdateStart = false;
@@ -416,8 +428,14 @@ function updateConnectedPipes(block, oldCenter, newCenter) {
         let endIndex = null;
 
         // ========== BORU BAŞLANGICI (p1) ==========
-        if (pipe.connections?.start?.blockId === block) {
-            // DURUM 1: Zaten bu bloğa bağlı - mevcut index'i kullan (DEĞİŞTİRME!)
+        // DURUM 1: Zaten bu bloğa bağlı mı? (ID veya referans kontrolü)
+        const isStartConnectedToThisBlock = pipe.connections?.start?.blockId && (
+            pipe.connections.start.blockId === block.id || // ID kontrolü (yeni sistem)
+            pipe.connections.start.blockId === block      // Referans kontrolü (eski sistem)
+        );
+
+        if (isStartConnectedToThisBlock) {
+            // Zaten bu bloğa bağlı - mevcut index'i kullan (DEĞİŞTİRME!)
             startIndex = pipe.connections.start.connectionIndex;
             shouldUpdateStart = true;
         } else if (!pipe.connections?.start || !pipe.connections.start.blockId) {
@@ -434,8 +452,14 @@ function updateConnectedPipes(block, oldCenter, newCenter) {
         // DURUM 3: Başka bloğa bağlı - yakalama (hiçbir şey yapma)
 
         // ========== BORU BİTİŞİ (p2) ==========
-        if (pipe.connections?.end?.blockId === block) {
-            // DURUM 1: Zaten bu bloğa bağlı - mevcut index'i kullan (DEĞİŞTİRME!)
+        // DURUM 1: Zaten bu bloğa bağlı mı? (ID veya referans kontrolü)
+        const isEndConnectedToThisBlock = pipe.connections?.end?.blockId && (
+            pipe.connections.end.blockId === block.id || // ID kontrolü (yeni sistem)
+            pipe.connections.end.blockId === block      // Referans kontrolü (eski sistem)
+        );
+
+        if (isEndConnectedToThisBlock) {
+            // Zaten bu bloğa bağlı - mevcut index'i kullan (DEĞİŞTİRME!)
             endIndex = pipe.connections.end.connectionIndex;
             shouldUpdateEnd = true;
         } else if (!pipe.connections?.end || !pipe.connections.end.blockId) {
@@ -462,10 +486,10 @@ function updateConnectedPipes(block, oldCenter, newCenter) {
             pipe.p1.x = newConn.x;
             pipe.p1.y = newConn.y;
 
-            // Bağlantı bilgisini güncelle
+            // Bağlantı bilgisini güncelle (ID kullan, yoksa object - backward compat)
             if (!pipe.connections) pipe.connections = { start: null, end: null };
             pipe.connections.start = {
-                blockId: block,
+                blockId: block.id || block, // ID varsa ID, yoksa object referansı
                 connectionIndex: startIndex,
                 blockType: block.blockType
             };
@@ -476,10 +500,10 @@ function updateConnectedPipes(block, oldCenter, newCenter) {
             pipe.p2.x = newConn.x;
             pipe.p2.y = newConn.y;
 
-            // Bağlantı bilgisini güncelle
+            // Bağlantı bilgisini güncelle (ID kullan, yoksa object - backward compat)
             if (!pipe.connections) pipe.connections = { start: null, end: null };
             pipe.connections.end = {
-                blockId: block,
+                blockId: block.id || block, // ID varsa ID, yoksa object referansı
                 connectionIndex: endIndex,
                 blockType: block.blockType
             };
@@ -526,13 +550,24 @@ function updateConnectedPipesAfterRotation(block, oldRotation, newRotation) {
             let shouldUpdateStart = false;
             let shouldUpdateEnd = false;
 
-            if (pipe.connections?.start?.blockId === block && pipe.connections.start.connectionIndex === index) {
+            // ID veya referans bazlı kontrol
+            const isStartConnectedToThisBlock = pipe.connections?.start?.blockId && (
+                pipe.connections.start.blockId === block.id || // ID kontrolü
+                pipe.connections.start.blockId === block      // Referans kontrolü
+            ) && pipe.connections.start.connectionIndex === index;
+
+            const isEndConnectedToThisBlock = pipe.connections?.end?.blockId && (
+                pipe.connections.end.blockId === block.id || // ID kontrolü
+                pipe.connections.end.blockId === block      // Referans kontrolü
+            ) && pipe.connections.end.connectionIndex === index;
+
+            if (isStartConnectedToThisBlock) {
                 shouldUpdateStart = true;
             } else if (Math.hypot(pipe.p1.x - oldConn.x, pipe.p1.y - oldConn.y) < tolerance) {
                 shouldUpdateStart = true;
             }
 
-            if (pipe.connections?.end?.blockId === block && pipe.connections.end.connectionIndex === index) {
+            if (isEndConnectedToThisBlock) {
                 shouldUpdateEnd = true;
             } else if (Math.hypot(pipe.p2.x - oldConn.x, pipe.p2.y - oldConn.y) < tolerance) {
                 shouldUpdateEnd = true;
@@ -544,7 +579,7 @@ function updateConnectedPipesAfterRotation(block, oldRotation, newRotation) {
 
                 if (!pipe.connections) pipe.connections = { start: null, end: null };
                 pipe.connections.start = {
-                    blockId: block,
+                    blockId: block.id || block, // ID varsa ID, yoksa referans
                     connectionIndex: index,
                     blockType: block.blockType
                 };
@@ -556,7 +591,7 @@ function updateConnectedPipesAfterRotation(block, oldRotation, newRotation) {
 
                 if (!pipe.connections) pipe.connections = { start: null, end: null };
                 pipe.connections.end = {
-                    blockId: block,
+                    blockId: block.id || block, // ID varsa ID, yoksa referans
                     connectionIndex: index,
                     blockType: block.blockType
                 };

--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -797,22 +797,22 @@ export function onPointerDown(e) {
                     if (startBlockSnap) {
                         // p1 bir bloğa bağlı
                         newPipe.connections.start = {
-                            blockId: startBlockSnap.block,
+                            blockId: startBlockSnap.block.id || startBlockSnap.block, // ID varsa ID kullan, yoksa object (backward compat)
                             connectionIndex: startBlockSnap.connectionIndex,
                             blockType: startBlockSnap.block.blockType
                         };
-                        console.log('✅ P1 connected to', startBlockSnap.block.blockType, 'connection', startBlockSnap.connectionIndex);
+                        console.log('✅ P1 connected to', startBlockSnap.block.blockType, 'ID:', startBlockSnap.block.id, 'connection', startBlockSnap.connectionIndex);
                     }
 
                     const endBlockSnap = snapToConnectionPoint(p2, 2); // 2 cm tolerans
                     if (endBlockSnap) {
                         // p2 bir bloğa bağlı
                         newPipe.connections.end = {
-                            blockId: endBlockSnap.block,
+                            blockId: endBlockSnap.block.id || endBlockSnap.block, // ID varsa ID kullan, yoksa object (backward compat)
                             connectionIndex: endBlockSnap.connectionIndex,
                             blockType: endBlockSnap.block.blockType
                         };
-                        console.log('✅ P2 connected to', endBlockSnap.block.blockType, 'connection', endBlockSnap.connectionIndex);
+                        console.log('✅ P2 connected to', endBlockSnap.block.blockType, 'ID:', endBlockSnap.block.id, 'connection', endBlockSnap.connectionIndex);
                     }
 
                     // Borunun bağlantı durumunu belirle (kesikli/düz çizgi için)


### PR DESCRIPTION
Sorun:
- Boru çizilirken connections bilgisi sadece 2cm tolerance ile kaydediliyor
- Tam snap olmazsa connections null kalıyor
- Önceki commit sadece connections kontrolü yaptığı için null olanlar kopuyordu

Çözüm: 3 durumlu kontrol
1. DURUM 1: Zaten bu bloğa bağlı (pipe.connections.start.blockId === block) -> Mevcut connectionIndex kullan (DEĞİŞTİRME - sabit kalsın)

2. DURUM 2: Serbest uç (connections null veya blockId null) -> Tolerance (15cm) ile ara ve yakala -> İlk eşleşen noktayı kullan (index değişmesin)

3. DURUM 3: Başka bloğa bağlı -> ASLA yakalama (hiçbir şey yapma)

Sonuç:
✅ Mevcut bağlantılar kopmaz
✅ Bağlantı noktası sabit kalır (hızlı hareket sırasında) ✅ Serbest uçlar yakalanır (tolerance ile)
✅ Başka bloklara bağlı uçlar yakalanmaz