### PR TITLE
fix: Kutu ve boru bağlantı sorunları düzeltildi

### DIFF
--- a/architectural-objects/plumbing-blocks.js
+++ b/architectural-objects/plumbing-blocks.js
@@ -444,17 +444,17 @@ function updateConnectedPipes(block, oldCenter, newCenter) {
             // blockId var ama bu blok değil → başka bloğa bağlı (mesela sayaca)
             // ASLA YAKALAMA! (skip)
         }
-        // DURUM 3: Hiçbir bloğa bağlı değil (GERÇEKTEN serbest) - tolerance ile yakala
-        else {
-            const tolerance = 15;
-            for (let i = 0; i < oldConnections.length; i++) {
-                if (Math.hypot(pipe.p1.x - oldConnections[i].x, pipe.p1.y - oldConnections[i].y) < tolerance) {
-                    startIndex = i;
-                    shouldUpdateStart = true;
-                    break; // İlk eşleşen noktayı kullan (index değişmesin)
-                }
-            }
-        }
+        // DURUM 3: Hiçbir bloğa bağlı değil (GERÇEKTEN serbest) - YAKALAMA (kutu boruları içine çekmesin!)
+        // else {
+        //     const tolerance = 15;
+        //     for (let i = 0; i < oldConnections.length; i++) {
+        //         if (Math.hypot(pipe.p1.x - oldConnections[i].x, pipe.p1.y - oldConnections[i].y) < tolerance) {
+        //             startIndex = i;
+        //             shouldUpdateStart = true;
+        //             break; // İlk eşleşen noktayı kullan (index değişmesin)
+        //         }
+        //     }
+        // }
 
         // ========== BORU BİTİŞİ (p2) ==========
         // DURUM 1: Zaten bu bloğa bağlı mı? (ID veya referans kontrolü)
@@ -473,17 +473,17 @@ function updateConnectedPipes(block, oldCenter, newCenter) {
             // blockId var ama bu blok değil → başka bloğa bağlı (mesela sayaca)
             // ASLA YAKALAMA! (skip)
         }
-        // DURUM 3: Hiçbir bloğa bağlı değil (GERÇEKTEN serbest) - tolerance ile yakala
-        else {
-            const tolerance = 15;
-            for (let i = 0; i < oldConnections.length; i++) {
-                if (Math.hypot(pipe.p2.x - oldConnections[i].x, pipe.p2.y - oldConnections[i].y) < tolerance) {
-                    endIndex = i;
-                    shouldUpdateEnd = true;
-                    break; // İlk eşleşen noktayı kullan (index değişmesin)
-                }
-            }
-        }
+        // DURUM 3: Hiçbir bloğa bağlı değil (GERÇEKTEN serbest) - YAKALAMA (kutu boruları içine çekmesin!)
+        // else {
+        //     const tolerance = 15;
+        //     for (let i = 0; i < oldConnections.length; i++) {
+        //         if (Math.hypot(pipe.p2.x - oldConnections[i].x, pipe.p2.y - oldConnections[i].y) < tolerance) {
+        //             endIndex = i;
+        //             shouldUpdateEnd = true;
+        //             break; // İlk eşleşen noktayı kullan (index değişmesin)
+        //         }
+        //     }
+        // }
 
         // Hiçbir ucu bu kutuya bağlı değilse, atla
         if (!shouldUpdateStart && !shouldUpdateEnd) return;


### PR DESCRIPTION
3 önemli sorun düzeltildi:

1. SERVIS_KUTUSU bağlantı kontrolü:
   - Kutunun bir noktasından BORU çıktıysa, o kutuya başka tesisat BAĞLANAMAZ
   - snapToConnectionPoint fonksiyonuna SERVIS_KUTUSU için özel kontrol eklendi

2. Kutu taşıma mantığı:
   - Kutu taşınırken serbest uçları yakalayan kod kaldırıldı
   - Artık sadece ZATEN bağlı olan borular kutu ile birlikte taşınıyor
   - Kutu başka boruları içine çekmiyor

3. SAYAÇ bağlantı kontrolü güçlendirildi:
   - İki yöntemli kontrol: Bağlantı bilgisi (connections) + Pozisyon kontrolü
   - CONNECTION_TOLERANCE 10 cm'ye çıkarıldı (daha hassas kontrol)
   - Her bağlantı noktasına sadece BİR boru bağlanabiliyor

Dosyalar:
- architectural-objects/plumbing-pipes.js
- architectural-objects/plumbing-blocks.js