### PR TITLE
Servis kutusu sadece duvar yüzeyine snap yapacak şekilde düzenlendi

### DIFF
--- a/plumbing/snap-plumbing.js
+++ b/plumbing/snap-plumbing.js
@@ -310,6 +310,20 @@ export function getPlumbingSnapPoint(wm, screenMouse, SNAP_RADIUS_PIXELS) {
 
     if (candidates.length === 0) return null;
 
+    // ✅ SERVİS KUTUSU: SADECE DUVAR YÜZEYİNE SNAP YAP
+    const isServiceBox = (isBlockMode && state.currentPlumbingBlockType === 'SERVIS_KUTUSU') ||
+                         (isDraggingBlock && draggedBlock && draggedBlock.blockType === 'SERVIS_KUTUSU');
+
+    if (isServiceBox) {
+        // Sadece duvar yüzeyi snap türlerini tut (köşeler, kesişimler, blok kenarları hariç)
+        candidates = candidates.filter(c =>
+            c.type === 'PLUMBING_WALL_SURFACE' ||
+            c.type === 'PLUMBING_WALL_SURFACE_PERPENDICULAR'
+        );
+
+        if (candidates.length === 0) return null;
+    }
+
     // ✅ ÖNCELİK SIRASI: DİK snap'ler EN ÖNCELİKLİ
     const priority = isPipeDrawing ? {
         // Boru çizimi sırasında: DİK snap en öncelikli


### PR DESCRIPTION
- Servis kutusu eklerken veya taşırken sadece PLUMBING_WALL_SURFACE ve PLUMBING_WALL_SURFACE_PERPENDICULAR snap türlerine izin verildi
- Duvar köşeleri, kesişimler, blok kenarları ve diğer snap noktalarına artık snap yapmıyor
- Bu sayede servis kutusu yerleştirme daha hassas ve kontrollü hale geldi