### PR TITLE
Fix SERVIS_KUTUSU placement - block was created but never added to state

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -421,6 +421,19 @@ export function onPointerDown(e) {
         // Diğer bloklar (SERVIS_KUTUSU)
         const newBlock = createPlumbingBlock(snappedPos.x, snappedPos.y, blockType);
 
+        // Duvar snap kontrolü - eğer duvara snap yapıldıysa rotasyonu ayarla
+        if (snappedPos.isSnapped && snappedPos.snapType === 'WALL') {
+            newBlock.rotation = snappedPos.snapAngle || 0;
+        }
+
+        if (!state.plumbingBlocks) state.plumbingBlocks = [];
+        state.plumbingBlocks.push(newBlock);
+
+        geometryChanged = true;
+        needsUpdate3D = true;
+        objectJustCreated = true;
+
+        console.log('✅', blockType, 'placed at', snappedPos.x, snappedPos.y);
 
         // --- Vana Çizim Modu (Boru Üzerinde) ---
     } else if (state.currentMode === "drawValve") {


### PR DESCRIPTION
The newBlock was being created but the code to add it to state.plumbingBlocks was missing, causing service boxes to not appear after clicking.