### PR TITLE
Fix servis kutusu rotation and add pipe endpoint dragging

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -329,6 +329,30 @@ export class InteractionManager {
     }
 
     findObjectAt(point) {
+        // Önce boru uçlarını kontrol et (öncelikli)
+        const boruUcu = this.findBoruUcuAt(point, 8);
+        if (boruUcu) {
+            const boru = this.manager.pipes.find(p => p.id === boruUcu.boruId);
+            if (boru) {
+                return {
+                    type: 'boru_ucu',
+                    boru: boru,
+                    uc: boruUcu.uc, // 'p1' veya 'p2'
+                    // move metodu endpoint için
+                    move: (x, y) => {
+                        if (boruUcu.uc === 'p1') {
+                            boru.p1.x = x;
+                            boru.p1.y = y;
+                        } else {
+                            boru.p2.x = x;
+                            boru.p2.y = y;
+                        }
+                        return null;
+                    }
+                };
+            }
+        }
+
         for (const comp of this.manager.components) {
             if (comp.containsPoint && comp.containsPoint(point)) {
                 return comp;

--- a/plumbing_v2/objects/service-box.js
+++ b/plumbing_v2/objects/service-box.js
@@ -140,10 +140,11 @@ export class ServisKutusu {
         this.snapliDuvar = wall;
 
         // Duvar açısına dön (uzun kenar duvara paralel)
+        // +180° ile çıkış yönü içeri bakacak şekilde
         if (wall.p1 && wall.p2) {
             const dx = wall.p2.x - wall.p1.x;
             const dy = wall.p2.y - wall.p1.y;
-            this.rotation = Math.atan2(dy, dx) * 180 / Math.PI;
+            this.rotation = (Math.atan2(dy, dx) * 180 / Math.PI) + 180;
         }
     }
 


### PR DESCRIPTION
- ServisKutusu now rotates 180° when snapped to wall (output faces inward)
- Pipe endpoints can now be grabbed and dragged independently