### PR TITLE
Fix red dot transfer when moving to other side of wall

### DIFF
--- a/plumbing_v2/objects/service-box.js
+++ b/plumbing_v2/objects/service-box.js
@@ -172,8 +172,10 @@ export class ServisKutusu {
             this.y = projY + ny * offset;
 
             // Uzun kenar duvara paralel olacak şekilde döndür
+            // Duvarın diğer tarafına geçince çıkış noktası da diğer tarafa dönmeli
             const wallAngle = Math.atan2(dy, dx) * 180 / Math.PI;
-            this.rotation = wallAngle;
+            // side=-1 ise 180 derece ekle ki çıkış noktası doğru yöne baksın
+            this.rotation = side === -1 ? wallAngle + 180 : wallAngle;
         } else {
             this.x = point.x;
             this.y = point.y;


### PR DESCRIPTION
Rotate box 180 degrees when on opposite side of wall so exit point faces the correct direction away from the wall.