### PR TITLE
Fix undo support, icon switch and mode handling

### DIFF
--- a/general-files/history.js
+++ b/general-files/history.js
@@ -4,6 +4,7 @@
 import { state, setState } from './main.js';
 // YENİ İMPORT: Boru tiplerini geri yüklemek için eklendi
 import { PLUMBING_PIPE_TYPES } from '../plumbing/plumbing-pipes.js';
+import { plumbingManager } from '../plumbing_v2/plumbing-manager.js';
 
 export function saveState() {
     // Mevcut state'in derin kopyasını oluşturmaya gerek yok, snapshot yeterli.
@@ -274,6 +275,10 @@ export function undo() {
     if (state.historyIndex > 0) {
         state.historyIndex--;
         restoreState(state.history[state.historyIndex]);
+        // Plumbing v2 manager'ı state'den yeniden yükle
+        if (plumbingManager) {
+            plumbingManager.loadFromState();
+        }
     }
 }
 
@@ -281,5 +286,9 @@ export function redo() {
     if (state.historyIndex < state.history.length - 1) {
         state.historyIndex++;
         restoreState(state.history[state.historyIndex]);
+        // Plumbing v2 manager'ı state'den yeniden yükle
+        if (plumbingManager) {
+            plumbingManager.loadFromState();
+        }
     }
 }

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -10,7 +10,7 @@ import { Sayac, createSayac } from '../objects/meter.js';
 import { Vana, createVana } from '../objects/valve.js';
 import { Cihaz, createCihaz } from '../objects/device.js';
 import { screenToWorld } from '../../draw/geometry.js';
-import { dom, state } from '../../general-files/main.js';
+import { dom, state, setMode } from '../../general-files/main.js';
 import { saveState } from '../../general-files/history.js';
 
 // Tool modları
@@ -233,10 +233,14 @@ export class InteractionManager {
         switch (component.type) {
             case 'servis_kutusu':
                 this.startBoruCizim(component.getCikisNoktasi(), component.id);
+                // İkon güncellemesi için activeTool'u boru olarak ayarla
+                this.manager.activeTool = 'boru';
                 break;
 
             case 'sayac':
                 this.handleSayacEkleme(component);
+                // İkon güncellemesi için activeTool'u boru olarak ayarla
+                this.manager.activeTool = 'boru';
                 break;
 
             case 'cihaz':
@@ -251,7 +255,13 @@ export class InteractionManager {
 
         // Temizle
         this.manager.tempComponent = null;
-        this.manager.activeTool = null;
+        // activeTool'u sadece boru moduna geçmiyorsak temizle
+        if (!this.boruCizimAktif) {
+            this.manager.activeTool = null;
+        }
+
+        // İkon güncellemesi için setMode'u çağır
+        setMode("plumbingV2", true);
     }
 
     /**


### PR DESCRIPTION
- Add plumbingManager.loadFromState() after undo/redo to sync state
- Set activeTool to 'boru' when auto-starting pipe mode from service box
- Call setMode to update icon after placing component