### PR TITLE
Fix subsequent pipe drawing and free angle movement

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -259,9 +259,6 @@ export class InteractionManager {
         if (!this.boruCizimAktif) {
             this.manager.activeTool = null;
         }
-
-        // İkon güncellemesi için setMode'u çağır
-        setMode("plumbingV2", true);
     }
 
     /**

--- a/plumbing_v2/interactions/tesisat-snap.js
+++ b/plumbing_v2/interactions/tesisat-snap.js
@@ -79,13 +79,14 @@ export class TesisatSnapSystem {
         const boruSnap = this.findBoruUzeriSnap(point, snapMesafesi);
         if (boruSnap) return boruSnap;
 
-        // 7. 10cm DIŞINDA - SADECE 90° AÇILARDA SNAP
-        if (this.currentStartPoint) {
-            const aci90Snap = this.find90DereceSnap(point, this.currentStartPoint);
-            if (aci90Snap) return aci90Snap;
-        }
+        // 7. 10cm DIŞINDA - SADECE 90° AÇILARDA SNAP (DEVREDİŞİ - serbest çizim için)
+        // Kullanıcı serbest açılarda çizebilsin
+        // if (this.currentStartPoint) {
+        //     const aci90Snap = this.find90DereceSnap(point, this.currentStartPoint);
+        //     if (aci90Snap) return aci90Snap;
+        // }
 
-        // Hiçbir snap bulunamadı
+        // Hiçbir snap bulunamadı - serbest çizim
         return null;
     }
 


### PR DESCRIPTION
- Remove setMode call from placeComponent that was blocking clicks
- Disable 90-degree angle snap to allow free drawing at any angle
- Users can now draw pipes in any direction without forced snapping