### PR TITLE
Fix pipe drawing after first pipe and restore 90° snap

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -220,10 +220,6 @@ export class InteractionManager {
     placeComponent(point) {
         if (!this.manager.tempComponent) return;
 
-        // Undo için state kaydet
-        saveState();
-        this.manager.saveToState();
-
         const component = this.manager.tempComponent;
 
         // Listeye ekle
@@ -249,9 +245,6 @@ export class InteractionManager {
                 }
                 break;
         }
-
-        // State'e sync et
-        this.manager.saveToState();
 
         // Temizle
         this.manager.tempComponent = null;
@@ -280,10 +273,6 @@ export class InteractionManager {
     handleBoruClick(point) {
         if (!this.boruBaslangic) return;
 
-        // Undo için state kaydet
-        saveState();
-        this.manager.saveToState();
-
         const boru = createBoru(this.boruBaslangic.nokta, point, 'STANDART');
         boru.floorId = state.currentFloorId;
 
@@ -305,9 +294,6 @@ export class InteractionManager {
         }
 
         this.manager.pipes.push(boru);
-
-        // State'e sync et
-        this.manager.saveToState();
 
         // Devam et
         this.boruBaslangic = {

--- a/plumbing_v2/interactions/tesisat-snap.js
+++ b/plumbing_v2/interactions/tesisat-snap.js
@@ -79,12 +79,11 @@ export class TesisatSnapSystem {
         const boruSnap = this.findBoruUzeriSnap(point, snapMesafesi);
         if (boruSnap) return boruSnap;
 
-        // 7. 10cm DIŞINDA - SADECE 90° AÇILARDA SNAP (DEVREDİŞİ - serbest çizim için)
-        // Kullanıcı serbest açılarda çizebilsin
-        // if (this.currentStartPoint) {
-        //     const aci90Snap = this.find90DereceSnap(point, this.currentStartPoint);
-        //     if (aci90Snap) return aci90Snap;
-        // }
+        // 7. 10cm DIŞINDA - SADECE 90° AÇILARDA SNAP
+        if (this.currentStartPoint) {
+            const aci90Snap = this.find90DereceSnap(point, this.currentStartPoint);
+            if (aci90Snap) return aci90Snap;
+        }
 
         // Hiçbir snap bulunamadı - serbest çizim
         return null;


### PR DESCRIPTION
- Remove saveState() calls from handleBoruClick() and placeComponent() that were blocking subsequent pipe drawing clicks
- Re-enable 90° angle snap (essential feature per user)