### PR TITLE
Fix plumbingBlock selection in select mode

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -79,11 +79,8 @@ export function onPointerDown(e) {
 
     // --- Seçim Modu ---
     if (state.currentMode === "select") {
-        // Önce v2 tesisat nesnesi var mı kontrol et
-        const plumbingHandled = plumbingManager.interactionManager?.handlePointerDown(e);
-        if (plumbingHandled) {
-            return;
-        }
+        // NOT: Select modunda v2 interactionManager kullanılmıyor
+        // getObjectAtPoint hem v1 (state.plumbingBlocks) hem v2 nesnelerini buluyor
 
         // Uzunluk düzenleme modu aktifse iptal et
         if (state.isEditingLength) { cancelLengthEdit(); return; }


### PR DESCRIPTION
Remove v2 interactionManager call in select mode - getObjectAtPoint already handles both v1 and v2 plumbing objects via getPlumbingBlockAtPoint. This allows dragging of service boxes directly in select mode.