### PR TITLE
Enable pipe body movement in select mode

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -213,8 +213,16 @@ export function onPointerDown(e) {
                         dragInfo.dragOffset = { x: clickedObject.object.center.x - pos.x, y: clickedObject.object.center.y - pos.y };
                         break;
                     case 'plumbingPipe':
-                        // v2'de plumbingManager üzerinden yönetiliyor
-                        dragInfo.startPointForDragging = pos;
+                        // v2'de plumbingManager üzerinden yönetiliyor - boru gövdesi taşıma
+                        const pipe = clickedObject.object;
+                        // Borunun merkez noktasını hesapla
+                        const pipeCenterX = (pipe.p1.x + pipe.p2.x) / 2;
+                        const pipeCenterY = (pipe.p1.y + pipe.p2.y) / 2;
+                        dragInfo.startPointForDragging = { x: pipeCenterX, y: pipeCenterY };
+                        dragInfo.dragOffset = { x: pipeCenterX - pos.x, y: pipeCenterY - pos.y };
+                        // Başlangıç pozisyonlarını kaydet
+                        dragInfo.initialP1 = { x: pipe.p1.x, y: pipe.p1.y };
+                        dragInfo.initialP2 = { x: pipe.p2.x, y: pipe.p2.y };
                         break;
                     case 'wall': dragInfo = onPointerDownSelectWall(clickedObject, pos, snappedPos, e); break;
                     case 'door': dragInfo = onPointerDownSelectDoor(clickedObject, pos); break;

--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -276,7 +276,24 @@ export function onPointerMove(e) {
                 }
                 break;
             case 'plumbingPipe':
-                // v2'de plumbingManager üzerinden yönetiliyor
+                // v2'de plumbingManager üzerinden yönetiliyor - boru gövdesi taşıma
+                if (state.selectedObject?.object?.p1 && state.selectedObject?.object?.p2) {
+                    const pipeObj = state.selectedObject.object;
+                    // Yeni merkez pozisyonunu hesapla (offset ile)
+                    const newCenterX = snappedPos.x + (dragInfo.dragOffset?.x || 0);
+                    const newCenterY = snappedPos.y + (dragInfo.dragOffset?.y || 0);
+                    // Başlangıç merkezini hesapla
+                    const initialCenterX = (dragInfo.initialP1.x + dragInfo.initialP2.x) / 2;
+                    const initialCenterY = (dragInfo.initialP1.y + dragInfo.initialP2.y) / 2;
+                    // Delta hesapla
+                    const deltaX = newCenterX - initialCenterX;
+                    const deltaY = newCenterY - initialCenterY;
+                    // Her iki uç noktayı da taşı
+                    pipeObj.p1.x = dragInfo.initialP1.x + deltaX;
+                    pipeObj.p1.y = dragInfo.initialP1.y + deltaY;
+                    pipeObj.p2.x = dragInfo.initialP2.x + deltaX;
+                    pipeObj.p2.y = dragInfo.initialP2.y + deltaY;
+                }
                 break;
             case 'valve':
                 // Vana taşıma (boru üzerinde kaydırma ve başka boruya geçirme)


### PR DESCRIPTION
Allow pipes to be dragged as a whole in select mode by updating both p1 and p2 endpoints together. Previously only individual endpoints could be moved.