### PR TITLE
Fix selection in select mode when boruCizimAktif is true

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -70,7 +70,8 @@ export function onPointerDown(e) {
     let geometryChanged = false; // Geometri değişti mi (saveState için)?
 
     // === BORU ÇİZİM MODU AKTİF İSE ÖNCELİKLİ İŞLE ===
-    if (plumbingManager.interactionManager?.boruCizimAktif) {
+    // Seç modunda boru çizim aktif olsa bile seçim öncelikli
+    if (plumbingManager.interactionManager?.boruCizimAktif && state.currentMode !== 'select') {
         const handled = plumbingManager.interactionManager.handlePointerDown(e);
         if (handled) {
             return;

--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -150,7 +150,8 @@ export function onPointerMove(e) {
     // --- Silme Modu Kontrolü Sonu ---
 
     // === BORU ÇİZİM MODU AKTİF İSE ÖNCELİKLİ İŞLE ===
-    if (plumbingManager.interactionManager?.boruCizimAktif) {
+    // Seç modunda boru çizim aktif olsa bile seçim öncelikli
+    if (plumbingManager.interactionManager?.boruCizimAktif && state.currentMode !== 'select') {
         const handled = plumbingManager.interactionManager.handlePointerMove(e);
         if (handled) {
             return;


### PR DESCRIPTION
Skip boru drawing handler in select mode to allow proper object selection and dragging through the standard select mode system.