### PR TITLE
Fix staircase not being displayed after creation

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -245,9 +245,9 @@ export function draw2D() {
     const walls = currentFloorId ? (state.walls || []).filter(w => w.floorId === currentFloorId) : (state.walls || []);
     // DÜZELTME: Kapılar duvar üzerinden filtrelenmeli (d.wall.floorId)
     const doors = currentFloorId ? (state.doors || []).filter(d => d.wall && (!d.wall.floorId || d.wall.floorId === currentFloorId)) : (state.doors || []);
-    const beams = currentFloorId ? (state.beams || []).filter(b => b.floorId === currentFloorId) : (state.beams || []);
-    const stairs = currentFloorId ? (state.stairs || []).filter(s => s.floorId === currentFloorId) : (state.stairs || []);
-    const columns = currentFloorId ? (state.columns || []).filter(c => c.floorId === currentFloorId) : (state.columns || []);
+    const beams = currentFloorId ? (state.beams || []).filter(b => !b.floorId || b.floorId === currentFloorId) : (state.beams || []);
+    const stairs = currentFloorId ? (state.stairs || []).filter(s => !s.floorId || s.floorId === currentFloorId) : (state.stairs || []);
+    const columns = currentFloorId ? (state.columns || []).filter(c => !c.floorId || c.floorId === currentFloorId) : (state.columns || []);
     const plumbingBlocks = currentFloorId ? (state.plumbingBlocks || []).filter(pb => pb.floorId === currentFloorId) : (state.plumbingBlocks || []);
 
     // Sadece aktif kata ait node'ları filtrele (duvarlardan topla)

--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -567,6 +567,16 @@ export function onPointerDown(e) {
                     state.stairs = [];
                 }
                 state.stairs.push(newStairs);
+                console.log('✅ Merdiven eklendi:', {
+                    id: newStairs.id,
+                    name: newStairs.name,
+                    floorId: newStairs.floorId,
+                    currentFloorId: state.currentFloor?.id,
+                    center: newStairs.center,
+                    width: newStairs.width,
+                    height: newStairs.height,
+                    totalStairs: state.stairs.length
+                });
                 needsUpdate3D = true;
                 objectJustCreated = true;
                 geometryChanged = true;


### PR DESCRIPTION
- Updated floor filtering for stairs, beams, and columns to allow objects without floorId
- This fixes the issue where newly created stairs were not visible because they had undefined floorId
- Added debug logging for stair creation to help diagnose future issues