### PR TITLE
Fix staircase drawing blocked by plumbing manager

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -70,8 +70,13 @@ export function onPointerDown(e) {
     let geometryChanged = false; // Geometri değişti mi (saveState için)?
 
     // === BORU ÇİZİM MODU AKTİF İSE ÖNCELİKLİ İŞLE ===
-    // Seç modunda boru çizim aktif olsa bile seçim öncelikli
-    if (plumbingManager.interactionManager?.boruCizimAktif && state.currentMode !== 'select') {
+    // SADECE plumbing modlarında boru çizim handler'ını çağır
+    // Diğer çizim modlarında (drawStairs, drawColumn, vb.) kesmemeli
+    const isPlumbingMode = state.currentMode === 'plumbingV2' ||
+                          state.currentMode === 'drawPlumbingPipe' ||
+                          state.currentMode === 'drawPlumbingBlock';
+
+    if (plumbingManager.interactionManager?.boruCizimAktif && isPlumbingMode) {
         const handled = plumbingManager.interactionManager.handlePointerDown(e);
         if (handled) {
             return;


### PR DESCRIPTION
Issue: Plumbing manager was intercepting ALL pointer clicks in any non-select mode when boruCizimAktif was true, blocking staircase drawing and other architectural drawing modes.

Fix: Restrict plumbing manager click interception to only plumbing- specific modes (plumbingV2, drawPlumbingPipe, drawPlumbingBlock). Other drawing modes (drawStairs, drawColumn, drawBeam, etc.) now work correctly without interference.

Root cause: The condition `state.currentMode !== 'select'` was too broad, allowing plumbing manager to intercept clicks in ALL drawing modes instead of just plumbing modes.