### PR TITLE
Mimari ve Tesisat modlarını ayır - Sağ üst köşede mod seçici ekle

### DIFF
--- a/draw/renderer2d.js
+++ b/draw/renderer2d.js
@@ -4,7 +4,7 @@ import { screenToWorld, distToSegmentSquared, getLineIntersectionPoint } from '.
 import { getColumnCorners, isPointInColumn } from '../architectural-objects/columns.js';
 import { getBeamCorners } from '../architectural-objects/beams.js';
 import { getStairCorners } from '../architectural-objects/stairs.js';
-import { state, dom, BG, WINDOW_BOTTOM_HEIGHT, WINDOW_TOP_HEIGHT } from '../general-files/main.js'; // Sabitleri import et
+import { state, dom, BG, WINDOW_BOTTOM_HEIGHT, WINDOW_TOP_HEIGHT, getObjectOpacity } from '../general-files/main.js'; // Sabitleri ve yeni fonksiyonu import et
 
 // Node'a bağlı duvar sayısını çizer (Şu an içeriği boş veya yorumlanmış)
 export function drawNodeWallCount(node) {
@@ -20,8 +20,17 @@ export function drawNodeWallCount(node) {
 export function drawDoorSymbol(door, isPreview = false, isSelected = false) {
     const { ctx2d } = dom;
     const { wallBorderColor, lineThickness } = state;
+
+    // Çizim moduna göre opacity ayarla
+    const opacity = getObjectOpacity('door');
+    ctx2d.save();
+    ctx2d.globalAlpha = opacity;
+
     const wall = door.wall;
-    if (!wall || !wall.p1 || !wall.p2) return; // Geçersiz kapı/duvar ise çık
+    if (!wall || !wall.p1 || !wall.p2) {
+        ctx2d.restore();
+        return; // Geçersiz kapı/duvar ise çık
+    }
     const wallLen = Math.hypot(wall.p2.x - wall.p1.x, wall.p2.y - wall.p1.y);
     if (wallLen < 1) return; // Çok kısa duvar ise çık
     // Duvar yön vektörleri
@@ -95,13 +104,24 @@ export function drawDoorSymbol(door, isPreview = false, isSelected = false) {
     ctx2d.moveTo(jamb2_start.x, jamb2_start.y);
     ctx2d.lineTo(jamb2_end.x, jamb2_end.y);
     ctx2d.stroke(); // Çizgileri çiz
+
+    ctx2d.restore(); // Opacity'yi geri al
 }
 
 // --- GÜNCELLENMİŞ Pencere Sembolü Çizimi ---
 export function drawWindowSymbol(wall, window, isPreview = false, isSelected = false) {
     const { ctx2d } = dom;
     const { selectedObject, wallBorderColor, lineThickness, zoom } = state; // zoom eklendi
-    if (!wall || !wall.p1 || !wall.p2) return;
+
+    // Çizim moduna göre opacity ayarla
+    const opacity = getObjectOpacity('window');
+    ctx2d.save();
+    ctx2d.globalAlpha = opacity;
+
+    if (!wall || !wall.p1 || !wall.p2) {
+        ctx2d.restore();
+        return;
+    }
     const wallLen = Math.hypot(wall.p2.x - wall.p1.x, wall.p2.y - wall.p1.y);
     if (wallLen < 0.1) return;
     const dx = (wall.p2.x - wall.p1.x) / wallLen; const dy = (wall.p2.y - wall.p1.y) / wallLen; const nx = -dy, ny = dx;
@@ -222,6 +242,8 @@ export function drawWindowSymbol(wall, window, isPreview = false, isSelected = f
 
     ctx2d.stroke(); // Kayıt çizgilerini çiz
     // --- YENİ KAYIT ÇİZİMİ SONU ---
+
+    ctx2d.restore(); // Opacity'yi geri al
 }
 // --- GÜNCELLENMİŞ Pencere Sembolü Çizimi SONU ---
 
@@ -269,6 +291,11 @@ export function drawColumnSymbol(node) {
 export function drawColumn(column, isSelected = false) {
     const { ctx2d } = dom;
     const { zoom, wallBorderColor, lineThickness, currentFloor } = state;
+
+    // Çizim moduna göre opacity ayarla
+    const opacity = getObjectOpacity('column');
+    ctx2d.save();
+    ctx2d.globalAlpha = opacity;
 
     // FLOOR ISOLATION: Sadece aktif kattaki duvarlar ve kolonlarla kesişim kontrolü yap
     const currentFloorId = currentFloor?.id;
@@ -463,6 +490,8 @@ export function drawColumn(column, isSelected = false) {
         ctx2d.fillStyle = state.roomFillColor; ctx2d.strokeStyle = isSelected ? '#8ab4f8' : wallBorderColor; ctx2d.lineWidth = lineThickness / zoom;
         ctx2d.beginPath(); ctx2d.moveTo(hollowCorners[0].x, hollowCorners[0].y); for (let i = 1; i < hollowCorners.length; i++) { ctx2d.lineTo(hollowCorners[i].x, hollowCorners[i].y); } ctx2d.closePath(); ctx2d.fill(); ctx2d.stroke();
     }
+
+    ctx2d.restore(); // Opacity'yi geri al
 }
 // --- drawColumn Sonu ---
 
@@ -470,6 +499,11 @@ export function drawColumn(column, isSelected = false) {
 export function drawBeam(beam, isSelected = false) {
     const { ctx2d } = dom;
     const { zoom, lineThickness } = state;
+
+    // Çizim moduna göre opacity ayarla
+    const opacity = getObjectOpacity('beam');
+    ctx2d.save();
+    ctx2d.globalAlpha = opacity;
 
     const corners = getBeamCorners(beam); // Kiriş köşe noktaları
     const beamColor = isSelected ? '#8ab4f8' : state.wallBorderColor;
@@ -518,12 +552,19 @@ export function drawBeam(beam, isSelected = false) {
     ctx2d.textBaseline = "middle";
     ctx2d.fillText("Kiriş", 0, 0);
     ctx2d.restore();
+
+    ctx2d.restore(); // Opacity'yi geri al
 }
 
 // GÜNCELLENMİŞ Merdiven Çizimi (Tek çizgi, ok mantığı düzeltilmiş)
 export function drawStairs(stair, isSelected = false) {
     const { ctx2d } = dom;
     const { zoom, lineThickness, wallBorderColor, roomFillColor } = state;
+
+    // Çizim moduna göre opacity ayarla
+    const opacity = getObjectOpacity('stair');
+    ctx2d.save();
+    ctx2d.globalAlpha = opacity;
 
     const corners = getStairCorners(stair); // Köşe noktalarını al
     const stairColor = isSelected ? '#8ab4f8' : wallBorderColor;
@@ -626,6 +667,8 @@ export function drawStairs(stair, isSelected = false) {
         // --- OK ÇİZİMİ SONU ---
     }
     // SAHANLIK İSE, BURADA OK ÇİZİLMEZ (sadece kenarlık/dolgu çizildi)
+
+    ctx2d.restore(); // Opacity'yi geri al
 }
 export function drawGuides(ctx2d, state) {
     const { guides, zoom, selectedObject } = state;

--- a/general-files/actions.js
+++ b/general-files/actions.js
@@ -2,7 +2,7 @@
 // GÜNCELLENMİŞ: Bu dosya artık sadece bir "hit testing" yönlendiricisi
 // ve birkaç genel yardımcı fonksiyon içeriyor.
 
-import { state } from './main.js';
+import { state, isObjectInteractable } from './main.js';
 import { getColumnAtPoint } from '../architectural-objects/columns.js';
 import { getBeamAtPoint } from '../architectural-objects/beams.js';
 import { getStairAtPoint } from '../architectural-objects/stairs.js';
@@ -368,4 +368,19 @@ export function getMinWallLength(wall) {
     // Gerekli minimum uzunluk, sadece marjlar için gerekenden veya öğelerle birlikte gerekenden büyük olanıdır.
     // Ayrıca en az 10 gibi mutlak bir minimum da olabilir.
     return Math.max(10, minLengthFromMargins, requiredByItems);
+}
+
+/**
+ * getObjectAtPoint'in filtrelenmiş versiyonu - sadece mevcut çizim modunda interaktif nesneleri döndürür
+ * @param {object} pos - Dünya koordinatlarında nokta {x, y}
+ * @returns {object|null} - Eğer nesne mevcut modda interaktif ise nesne, değilse null
+ */
+export function getInteractableObjectAtPoint(pos) {
+    const result = getObjectAtPoint(pos);
+
+    if (!result) return null;
+
+    // Nesne tipine göre interaktiflik kontrolü
+    const interactable = isObjectInteractable(result.type);
+    return interactable ? result : null;
 }

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -1011,3 +1011,55 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
     background: #5f6368;
     margin: 8px 0;
 }
+
+/* ═══════════════════════════════════════════════════════════════ */
+/* ÇİZİM MODU SEÇME (MİMARİ / TESİSAT / KARMA) */
+/* ═══════════════════════════════════════════════════════════════ */
+.drawing-mode-selector {
+    position: absolute;
+    top: 10px;
+    right: 140px; /* 3D butonunun soluna yerleştir */
+    z-index: 100;
+    display: flex;
+    gap: 4px;
+    background: rgba(30, 31, 32, 0.85);
+    padding: 4px;
+    border-radius: 8px;
+    border: 1px solid rgba(100, 149, 237, 0.3);
+    backdrop-filter: blur(4px);
+    pointer-events: auto;
+}
+
+.mode-btn {
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    background: rgba(60, 64, 67, 0.8);
+    border: 1px solid #5f6368;
+    color: #e8eaed;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+    min-width: 80px;
+    text-align: center;
+}
+
+.mode-btn:hover {
+    background: rgba(80, 84, 87, 0.9);
+    border-color: #87CEEB;
+    transform: scale(1.05);
+    box-shadow: 0 2px 4px rgba(135, 206, 235, 0.3);
+}
+
+.mode-btn.active {
+    background: rgba(100, 149, 237, 0.4);
+    border-color: #87CEEB;
+    box-shadow: 0 0 8px rgba(135, 206, 235, 0.5);
+    color: #87CEEB;
+}
+
+/* 3D açıkken de göster */
+.main.show-3d .drawing-mode-selector {
+    display: flex;
+}

--- a/index.html
+++ b/index.html
@@ -191,6 +191,15 @@
           </button>
         </div>
         <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none" />
+
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+        <!-- ÇİZİM MODU SEÇME (MİMARİ / TESİSAT / KARMA) -->
+        <!-- ═══════════════════════════════════════════════════════════════ -->
+        <div class="drawing-mode-selector" id="drawing-mode-selector">
+          <button class="mode-btn" id="mode-mimari" title="Mimari Mod">MİMARİ</button>
+          <button class="mode-btn" id="mode-tesisat" title="Tesisat Mod">TESİSAT</button>
+          <button class="mode-btn active" id="mode-karma" title="Karma Mod">KARMA</button>
+        </div>
       </div>
 
       <button id="settings-btn" class="btn">

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -8,6 +8,7 @@ import { SERVIS_KUTUSU_CONFIG, CIKIS_YONLERI } from './objects/service-box.js';
 import { SAYAC_CONFIG } from './objects/meter.js';
 import { VANA_CONFIG, VANA_TIPLERI } from './objects/valve.js';
 import { CIHAZ_TIPLERI, FLEKS_CONFIG } from './objects/device.js';
+import { getObjectOpacity } from '../general-files/main.js';
 
 export class PlumbingRenderer {
     constructor() {
@@ -47,6 +48,11 @@ export class PlumbingRenderer {
     drawPipes(ctx, pipes) {
         if (!pipes) return;
 
+        // Çizim moduna göre opacity ayarla
+        const opacity = getObjectOpacity('plumbing');
+        ctx.save();
+        ctx.globalAlpha = opacity;
+
         ctx.lineCap = 'round';
         ctx.lineJoin = 'round';
 
@@ -69,6 +75,8 @@ export class PlumbingRenderer {
 
         // Dirsek görüntülerini çiz
         this.drawElbows(ctx, pipes, breakPoints);
+
+        ctx.restore(); // Opacity'yi geri al
     }
 
     findBreakPoints(pipes) {
@@ -187,6 +195,11 @@ export class PlumbingRenderer {
 
     drawComponent(ctx, comp) {
         ctx.save();
+
+        // Çizim moduna göre opacity ayarla
+        const opacity = getObjectOpacity('plumbing');
+        ctx.globalAlpha = opacity;
+
         ctx.translate(comp.x, comp.y);
         if (comp.rotation) ctx.rotate(comp.rotation * Math.PI / 180);
 

--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -16,7 +16,7 @@ import { getSmartSnapPoint } from '../general-files/snap.js';
 import { currentModifierKeys } from '../general-files/input.js';
 import { saveState } from '../general-files/history.js';
 import { cancelLengthEdit } from '../general-files/ui.js';
-import { getObjectAtPoint } from '../general-files/actions.js';
+import { getObjectAtPoint, getInteractableObjectAtPoint } from '../general-files/actions.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
 import { processWalls } from '../wall/wall-processor.js';
 // plumbingManager zaten yukarıda import edildi
@@ -102,8 +102,8 @@ export function onPointerDown(e) {
         // Uzunluk düzenleme modu aktifse iptal et
         if (state.isEditingLength) { cancelLengthEdit(); return; }
 
-        // Tıklanan nesneyi bul
-        const clickedObject = getObjectAtPoint(pos);
+        // Tıklanan nesneyi bul (mevcut çizim modunda interaktif olanları)
+        const clickedObject = getInteractableObjectAtPoint(pos);
 
         // Silme modu (Sadece Alt tuşu basılıysa)
         if (currentModifierKeys.alt && !currentModifierKeys.ctrl && !currentModifierKeys.shift) {
@@ -303,14 +303,14 @@ export function onPointerDown(e) {
 
         // --- Kapı Çizim Modu ---
     } else if (state.currentMode === "drawDoor") {
-        onPointerDownDrawDoor(pos, getObjectAtPoint(pos));
+        onPointerDownDrawDoor(pos, getInteractableObjectAtPoint(pos));
         needsUpdate3D = true;
         objectJustCreated = true;
         setState({ selectedObject: null });
 
         // --- Pencere Çizim Modu ---
     } else if (state.currentMode === "drawWindow") {
-        onPointerDownDrawWindow(pos, getObjectAtPoint(pos));
+        onPointerDownDrawWindow(pos, getInteractableObjectAtPoint(pos));
         needsUpdate3D = true;
         objectJustCreated = true;
         setState({ selectedObject: null });


### PR DESCRIPTION
Sağ üst köşede MİMARİ/TESİSAT/KARMA seçici butonlar eklendi.

- MİMARİ MODDA: Sadece mimari nesnelerle (duvar, kapı, pencere, kolon, kiriş, merdiven, oda) çalışılabilir. Tesisat nesneleri soluk görünür ve dokunulamaz.
- TESİSAT MODUNDA: Sadece tesisat nesneleriyle (kutu, sayaç, vana, boru, cihaz) çalışılabilir. Mimari nesneler soluk görünür ve dokunulamaz.
- KARMA MODDA: Tüm nesnelerle normal şekilde çalışılabilir (varsayılan mod).

Değişiklikler:
- State'e currentDrawingMode eklendi (MİMARİ/TESİSAT/KARMA)
- UI'ya 3'lü mod seçici buton grubu eklendi (sağ üst köşe)
- CSS ile stil ve hover efektleri eklendi
- getObjectOpacity() fonksiyonu: Aktif olmayan nesneler için opacity 0.3
- isObjectInteractable() fonksiyonu: Mod bazlı interaksiyon kontrolü
- Tüm render fonksiyonlarında (kapı, pencere, kolon, kiriş, merdiven, tesisat) opacity uygulandı
- getInteractableObjectAtPoint() wrapper fonksiyonu eklendi
- pointer-down.js'te mod bazlı interaksiyon filtrelemesi eklendi