### PR TITLE
Mod seçici butonları tavana taşı ve duvarlar/odalar için opacity ekle

### DIFF
--- a/draw/draw-rooms.js
+++ b/draw/draw-rooms.js
@@ -1,4 +1,4 @@
-import { state, dom } from '../general-files/main.js';
+import { state, dom, getObjectOpacity } from '../general-files/main.js';
 import { getObjectAtPoint } from '../general-files/actions.js';
 
 // --- EKSİK SABİTİ EKLEYİN ---
@@ -31,6 +31,11 @@ export function drawRoomPolygons(ctx2d, state) {
         currentMode, mousePos,
         isDraggingRoomName // Sürüklenen mahal adı state'i
     } = state;
+
+    // Çizim moduna göre opacity ayarla
+    const opacity = getObjectOpacity('room');
+    ctx2d.save();
+    ctx2d.globalAlpha = opacity;
 
     // Fare sürüklenmiyorsa ve seçim modundaysa, üzerine gelinen nesneyi bul
     const hoveredObject = (!isDragging && currentMode === 'select') ? getObjectAtPoint(mousePos) : null;
@@ -106,6 +111,8 @@ export function drawRoomPolygons(ctx2d, state) {
             }
         });
     }
+
+    ctx2d.restore(); // Opacity'yi geri al
 }
 // --- drawRoomPolygons FONKSİYONU SONU ---
 

--- a/draw/draw-walls.js
+++ b/draw/draw-walls.js
@@ -1,4 +1,4 @@
-import { state, dom, BG } from '../general-files/main.js';
+import { state, dom, BG, getObjectOpacity } from '../general-files/main.js';
 
 // --- YARDIMCI FONKSİYONLAR ---
 
@@ -571,6 +571,11 @@ export function drawWallGeometry(ctx2d, state, BG) {
     const { walls, doors, selectedObject, selectedGroup, wallBorderColor, lineThickness, nodes } = state;
     const wallPx = state.wallThickness;
 
+    // Çizim moduna göre opacity ayarla
+    const opacity = getObjectOpacity('wall');
+    ctx2d.save();
+    ctx2d.globalAlpha = opacity;
+
     // --- KÖŞE HESAPLAMALARI (Çizimden Önce) ---
     const nodeWallConnections = new Map();
     nodes.forEach(node => nodeWallConnections.set(node, []));
@@ -714,4 +719,6 @@ export function drawWallGeometry(ctx2d, state, BG) {
     // Varsayılan ayarlara dön
     ctx2d.lineCap = "butt";
     ctx2d.lineJoin = "miter";
+
+    ctx2d.restore(); // Opacity'yi geri al
 }

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -971,14 +971,42 @@ function initialize() {
         return false;
     });
 
-    // Mimari butonlar - otomatik MİMARİ moduna geç
-    dom.bWall.addEventListener("click", () => { setDrawingMode("MİMARİ"); setMode("drawWall", true); });
-    dom.bRoom.addEventListener("click", () => { setDrawingMode("MİMARİ"); setMode("drawRoom", true); });
-    dom.bDoor.addEventListener("click", () => { setDrawingMode("MİMARİ"); setMode("drawDoor", true); });
-    dom.bWindow.addEventListener("click", () => { setDrawingMode("MİMARİ"); setMode("drawWindow", true); });
-    dom.bColumn.addEventListener("click", () => { setDrawingMode("MİMARİ"); setMode("drawColumn", true); });
-    dom.bBeam.addEventListener("click", () => { setDrawingMode("MİMARİ"); setMode("drawBeam", true); });
-    dom.bStairs.addEventListener("click", () => { setDrawingMode("MİMARİ"); setMode("drawStairs", true); });
+    // Mimari butonlar - otomatik MİMARİ moduna geç ve boru modundan çık
+    dom.bWall.addEventListener("click", () => {
+        if (plumbingManager.interactionManager) plumbingManager.interactionManager.boruCizimAktif = false;
+        setDrawingMode("MİMARİ");
+        setMode("drawWall", true);
+    });
+    dom.bRoom.addEventListener("click", () => {
+        if (plumbingManager.interactionManager) plumbingManager.interactionManager.boruCizimAktif = false;
+        setDrawingMode("MİMARİ");
+        setMode("drawRoom", true);
+    });
+    dom.bDoor.addEventListener("click", () => {
+        if (plumbingManager.interactionManager) plumbingManager.interactionManager.boruCizimAktif = false;
+        setDrawingMode("MİMARİ");
+        setMode("drawDoor", true);
+    });
+    dom.bWindow.addEventListener("click", () => {
+        if (plumbingManager.interactionManager) plumbingManager.interactionManager.boruCizimAktif = false;
+        setDrawingMode("MİMARİ");
+        setMode("drawWindow", true);
+    });
+    dom.bColumn.addEventListener("click", () => {
+        if (plumbingManager.interactionManager) plumbingManager.interactionManager.boruCizimAktif = false;
+        setDrawingMode("MİMARİ");
+        setMode("drawColumn", true);
+    });
+    dom.bBeam.addEventListener("click", () => {
+        if (plumbingManager.interactionManager) plumbingManager.interactionManager.boruCizimAktif = false;
+        setDrawingMode("MİMARİ");
+        setMode("drawBeam", true);
+    });
+    dom.bStairs.addEventListener("click", () => {
+        if (plumbingManager.interactionManager) plumbingManager.interactionManager.boruCizimAktif = false;
+        setDrawingMode("MİMARİ");
+        setMode("drawStairs", true);
+    });
 
     // Tesisat butonları - otomatik TESİSAT moduna geç (v2 sistemi)
     dom.bServisKutusu.addEventListener("click", () => {

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -1017,7 +1017,7 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
 /* ═══════════════════════════════════════════════════════════════ */
 .drawing-mode-selector {
     position: absolute;
-    top: 10px;
+    top: 0px; /* Tavana temas etmeli */
     left: 10px; /* Sol üst köşe */
     z-index: 100;
     display: flex;


### PR DESCRIPTION
- Mod seçici butonları artık tavana temas ediyor (top: 0px)
- Duvar çizimlerine opacity eklendi (TESİSAT modunda soluk)
- Oda/mahal poligonlarına opacity eklendi (TESİSAT modunda soluk)
- Mimari butonlara tıklandığında boru çizim modundan çıkış eklendi
- Kolonlar, kirişler, merdivenler zaten opacity kontrolüne sahip

Düzeltilen sorunlar:
- Mod butonları tavana temas etmiyor → Düzeltildi (top: 0px)
- Duvarlar TESİSAT modunda soluk değil → Düzeltildi
- Odalar TESİSAT modunda soluk değil → Düzeltildi
- Mimari butona tıklayınca boru modundan çıkılmıyor → Düzeltildi