### PR TITLE
Proje modlarını katlar menüsüne taşı ve çift tıklama engeli ekle

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -2,7 +2,7 @@
 // GÜNCELLENDİ: handleDelete, boru silindiğinde bağlantıyı "iyileştirecek" (heal) şekilde güncellendi.
 
 import * as THREE from "three"; // YENİ
-import { state, setState, setMode, dom, EXTEND_RANGE } from './main.js'; // dom import edildiğinden emin olun
+import { state, setState, setMode, dom, EXTEND_RANGE, isObjectInteractable } from './main.js'; // dom import edildiğinden emin olun
 import { getObjectAtPoint } from './actions.js';
 import { undo, redo, saveState, restoreState } from './history.js';
 import { startLengthEdit, cancelLengthEdit, showStairPopup, showRoomNamePopup, hideRoomNamePopup, positionLengthInput, toggle3DFullscreen } from './ui.js';
@@ -946,6 +946,12 @@ export function setupInputListeners() {
         const rect = dom.c2d.getBoundingClientRect();
         const clickPos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
         const object = getObjectAtPoint(clickPos);
+
+        // Nesneye çift tıklama için interaktif olup olmadığını kontrol et
+        if (object && !isObjectInteractable(object.type)) {
+            // TESİSAT modunda mimari nesnelere çift tıklanamaz
+            return;
+        }
 
         if (object && (object.type === 'room' || object.type === 'roomName' || object.type === 'roomArea')) {
             showRoomNamePopup(object.object, e);

--- a/index.html
+++ b/index.html
@@ -191,15 +191,6 @@
           </button>
         </div>
         <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none" />
-
-        <!-- ═══════════════════════════════════════════════════════════════ -->
-        <!-- ÇİZİM MODU SEÇME (MİMARİ / TESİSAT / KARMA) -->
-        <!-- ═══════════════════════════════════════════════════════════════ -->
-        <div class="drawing-mode-selector" id="drawing-mode-selector">
-          <button class="mode-btn" id="mode-mimari" title="Mimari Mod">MİMARİ</button>
-          <button class="mode-btn" id="mode-tesisat" title="Tesisat Mod">TESİSAT</button>
-          <button class="mode-btn active" id="mode-karma" title="Karma Mod">KARMA</button>
-        </div>
       </div>
 
       <button id="settings-btn" class="btn">


### PR DESCRIPTION
- Mod seçici butonlar (MİMARİ/TESİSAT/KARMA) artık katlar menüsünün içinde
- Katlar menüsü üstte ortalı, mod butonları en solda
- Mod butonları hover ve active efektleri ile tam entegre
- TESİSAT modunda mahal ve duvarlara çift tıklama engellendi
- Standalone mod selector HTML'den kaldırıldı
- CSS'de kullanılmayan stil kuralları temizlendi

Düzeltilen sorunlar:
- Mod butonları tavanda ama katlar menüsü tarafından örtülüyor → Mod butonları katlar menüsüne taşındı
- TESİSAT modunda mahal/duvara çift tıklanabiliyor → Çift tıklama engeli eklendi