### PR TITLE
Mod butonlarını sol üst köşeye taşı ve duvar opacity sorununu çöz

### DIFF
--- a/draw/draw-walls.js
+++ b/draw/draw-walls.js
@@ -425,14 +425,14 @@ const drawNormalSegments = (ctx2d, segmentList, color, lineThickness, wallPx, BG
     }).filter(data => data !== null);
 
 
-    // --- 1. AŞAMA: Tüm Kenarlıkları Çiz ---
+    // --- 1. AŞAMA: Tüm Kenarlıkları Tek Path'te Çiz (overlap önleme) ---
+    ctx2d.beginPath(); // Tek path başlat
+
     segmentCornerData.forEach(data => {
         const { seg, wall, node1, node2, startLeft, startRight, endLeft, endRight, simpleStartLeft, simpleStartRight, simpleEndLeft, simpleEndRight, corner1, corner2 } = data;
         const seg_p1 = seg.p1; const seg_p2 = seg.p2;
 
-        ctx2d.beginPath();
-
-        // Ayarlanmış çizgileri çiz
+        // Ayarlanmış çizgileri path'e ekle
         ctx2d.moveTo(startLeft.x, startLeft.y);
         ctx2d.lineTo(endLeft.x, endLeft.y);
         ctx2d.moveTo(startRight.x, startRight.y);
@@ -453,9 +453,9 @@ const drawNormalSegments = (ctx2d, segmentList, color, lineThickness, wallPx, BG
              ctx2d.moveTo(capEndLeft.x, capEndLeft.y);
              ctx2d.lineTo(capEndRight.x, capEndRight.y);
         }
-
-        ctx2d.stroke(); // Bu segmentin çizgilerini çiz
     });
+
+    ctx2d.stroke(); // Tüm path'leri tek seferde çiz (overlap önlendi)
 
 
     // --- 2. AŞAMA: Tüm Dolguları Çiz ---

--- a/floor/floor-panel.js
+++ b/floor/floor-panel.js
@@ -51,13 +51,6 @@ export function createFloorPanel() {
     `;
 
     miniPanel.innerHTML = `
-        <!-- Proje Modları (MİMARİ / TESİSAT / KARMA) -->
-        <div id="drawing-mode-selector" style="display: flex; gap: 4px; margin-right: 8px; padding-right: 8px; border-right: 1px solid #5f6368;">
-            <button class="mode-btn" id="mode-mimari" title="Mimari Mod" style="padding: 6px 12px; font-size: 12px; font-weight: 600; background: rgba(60, 64, 67, 0.8); border: 1px solid #5f6368; color: #e8eaed; border-radius: 4px; cursor: pointer; transition: all 0.2s; white-space: nowrap;">MİMARİ</button>
-            <button class="mode-btn" id="mode-tesisat" title="Tesisat Mod" style="padding: 6px 12px; font-size: 12px; font-weight: 600; background: rgba(60, 64, 67, 0.8); border: 1px solid #5f6368; color: #e8eaed; border-radius: 4px; cursor: pointer; transition: all 0.2s; white-space: nowrap;">TESİSAT</button>
-            <button class="mode-btn active" id="mode-karma" title="Karma Mod" style="padding: 6px 12px; font-size: 12px; font-weight: 600; background: rgba(100, 149, 237, 0.4); border: 1px solid #87CEEB; color: #87CEEB; border-radius: 4px; cursor: pointer; transition: all 0.2s; white-space: nowrap; box-shadow: 0 0 8px rgba(135, 206, 235, 0.5);">KARMA</button>
-        </div>
-
         <div id="floor-expand-btn" style="cursor: pointer; padding: 4px 8px; background: transparent; border: 1px solid #5f6368; border-radius: 4px; transition: all 0.2s;" title="Katlar Panelini Aç">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#8ab4f8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                 <!-- Bina temeli -->
@@ -113,9 +106,6 @@ export function createFloorPanel() {
     // Kaydırma okları
     setupScrollButtons();
 
-    // Mod butonları
-    setupModeButtons();
-
     // Detaylı panel oluştur
     createDetailPanel();
 
@@ -128,79 +118,6 @@ export function createFloorPanel() {
             adjustFloorPanelPosition();
         }
     });
-}
-
-/**
- * Mod butonlarını kurar (MİMARİ, TESİSAT, KARMA)
- */
-function setupModeButtons() {
-    const modeMimari = miniPanel.querySelector('#mode-mimari');
-    const modeTesisat = miniPanel.querySelector('#mode-tesisat');
-    const modeKarma = miniPanel.querySelector('#mode-karma');
-
-    if (!modeMimari || !modeTesisat || !modeKarma) return;
-
-    // Buton hover efektleri
-    [modeMimari, modeTesisat, modeKarma].forEach(btn => {
-        btn.addEventListener('mouseenter', () => {
-            if (!btn.classList.contains('active')) {
-                btn.style.background = 'rgba(80, 84, 87, 0.9)';
-                btn.style.borderColor = '#87CEEB';
-                btn.style.transform = 'scale(1.05)';
-                btn.style.boxShadow = '0 2px 4px rgba(135, 206, 235, 0.3)';
-            }
-        });
-        btn.addEventListener('mouseleave', () => {
-            if (!btn.classList.contains('active')) {
-                btn.style.background = 'rgba(60, 64, 67, 0.8)';
-                btn.style.borderColor = '#5f6368';
-                btn.style.transform = 'scale(1)';
-                btn.style.boxShadow = 'none';
-            }
-        });
-    });
-
-    // Aktif buton stilini güncelle
-    function updateActiveButton(activeMode) {
-        [modeMimari, modeTesisat, modeKarma].forEach(btn => {
-            btn.classList.remove('active');
-            btn.style.background = 'rgba(60, 64, 67, 0.8)';
-            btn.style.borderColor = '#5f6368';
-            btn.style.color = '#e8eaed';
-            btn.style.boxShadow = 'none';
-        });
-
-        const activeBtn = activeMode === 'MİMARİ' ? modeMimari :
-                         activeMode === 'TESİSAT' ? modeTesisat : modeKarma;
-        activeBtn.classList.add('active');
-        activeBtn.style.background = 'rgba(100, 149, 237, 0.4)';
-        activeBtn.style.borderColor = '#87CEEB';
-        activeBtn.style.color = '#87CEEB';
-        activeBtn.style.boxShadow = '0 0 8px rgba(135, 206, 235, 0.5)';
-    }
-
-    // Buton click event'leri
-    modeMimari.addEventListener('click', (e) => {
-        e.stopPropagation();
-        setDrawingMode('MİMARİ');
-        updateActiveButton('MİMARİ');
-    });
-
-    modeTesisat.addEventListener('click', (e) => {
-        e.stopPropagation();
-        setDrawingMode('TESİSAT');
-        updateActiveButton('TESİSAT');
-    });
-
-    modeKarma.addEventListener('click', (e) => {
-        e.stopPropagation();
-        setDrawingMode('KARMA');
-        setMode('select', true); // KARMA modunda otomatik SEÇ moduna geç
-        updateActiveButton('KARMA');
-    });
-
-    // İlk yüklemede aktif modu ayarla
-    updateActiveButton(state.currentDrawingMode);
 }
 
 /**

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -443,6 +443,37 @@ export const dom = {
     b3d: document.getElementById("b3d"), // 3D Göster butonu
 };
 
+// Proje modu butonlarını kurar (MİMARİ, TESİSAT, KARMA)
+function setupModeButtons() {
+    const modeMimari = document.getElementById("mode-mimari");
+    const modeTesisat = document.getElementById("mode-tesisat");
+    const modeKarma = document.getElementById("mode-karma");
+
+    if (!modeMimari || !modeTesisat || !modeKarma) {
+        console.warn('Mode buttons not found in DOM');
+        return;
+    }
+
+    // Mimari mod butonu
+    modeMimari.addEventListener('click', (e) => {
+        e.stopPropagation();
+        setDrawingMode('MİMARİ');
+    });
+
+    // Tesisat mod butonu
+    modeTesisat.addEventListener('click', (e) => {
+        e.stopPropagation();
+        setDrawingMode('TESİSAT');
+    });
+
+    // Karma mod butonu
+    modeKarma.addEventListener('click', (e) => {
+        e.stopPropagation();
+        setDrawingMode('KARMA');
+        setMode('select', true); // KARMA modunda otomatik SEÇ moduna geç
+    });
+}
+
 // Çizim modu değiştirme fonksiyonu (MİMARİ, TESİSAT, KARMA)
 export function setDrawingMode(mode) {
     setState({ currentDrawingMode: mode });
@@ -1060,6 +1091,9 @@ function initialize() {
     dom.bSymmetry.addEventListener("click", () => { setDrawingMode("MİMARİ"); setMode("drawSymmetry", true); });
 
     dom.bAssignNames.addEventListener("click", assignRoomNames); // Artık güncellenmiş fonksiyonu çağıracak
+
+    // Proje modu butonları (MİMARİ, TESİSAT, KARMA)
+    setupModeButtons();
 
     window.addEventListener("resize", resize);
 

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -1059,7 +1059,24 @@ cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" wid
     color: #87CEEB;
 }
 
+/* Proje Modları - En sol üst köşe */
+#drawing-mode-selector {
+    position: fixed;
+    top: 0;
+    left: 0;
+    display: flex;
+    gap: 4px;
+    padding: 6px;
+    background: rgba(42, 43, 44, 0.95);
+    border-bottom: 1px solid #5f6368;
+    border-right: 1px solid #5f6368;
+    border-bottom-right-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    z-index: 10000;
+    backdrop-filter: blur(4px);
+}
+
 /* 3D açıkken de göster */
-.main.show-3d .drawing-mode-selector {
+.main.show-3d #drawing-mode-selector {
     display: flex;
 }

--- a/index.html
+++ b/index.html
@@ -10,6 +10,13 @@
 </head>
 
 <body>
+  <!-- Proje Modları - En sol üst köşe -->
+  <div id="drawing-mode-selector">
+    <button class="mode-btn" id="mode-mimari" title="Mimari Mod">MİMARİ</button>
+    <button class="mode-btn" id="mode-tesisat" title="Tesisat Mod">TESİSAT</button>
+    <button class="mode-btn active" id="mode-karma" title="Karma Mod">KARMA</button>
+  </div>
+
   <div class="main" id="main-container">
     <div id="p2d" class="panel">
       <div id="ui">


### PR DESCRIPTION
- Mod butonlarını (MİMARİ/TESİSAT/KARMA) floor-panel.js'den çıkar
- index.html'de ekranın en sol üst köşesine taşı (fixed position)
- CSS ile sol üst köşede konumlandır (border-radius ile köşe yuvarlama)
- main.js'de setupModeButtons() fonksiyonu ile event listener'ları kur
- floor-panel.js'deki setupModeButtons() fonksiyonunu kaldır

Duvar opacity sorunu:
- Tesisat modunda duvarlar soluklaştığında kesişimlerde çift çizgi görünüyordu
- drawNormalSegments() fonksiyonunda tüm segment'leri tek path'te çiz
- Her segment için ayrı stroke() yerine, tüm path'leri topla ve tek stroke() çağır
- Böylece overlap olmaz ve kesişimlerde fazlalık çizgi görünmez