### PR TITLE
Opacity yerine renk soluklaştırma kullan

### DIFF
--- a/draw/draw-rooms.js
+++ b/draw/draw-rooms.js
@@ -1,4 +1,4 @@
-import { state, dom, getObjectOpacity } from '../general-files/main.js';
+import { state, dom, getAdjustedColor } from '../general-files/main.js';
 import { getObjectAtPoint } from '../general-files/actions.js';
 
 // --- EKSİK SABİTİ EKLEYİN ---
@@ -32,10 +32,8 @@ export function drawRoomPolygons(ctx2d, state) {
         isDraggingRoomName // Sürüklenen mahal adı state'i
     } = state;
 
-    // Çizim moduna göre opacity ayarla
-    const opacity = getObjectOpacity('room');
-    ctx2d.save();
-    ctx2d.globalAlpha = opacity;
+    // Çizim moduna göre renk ayarla (opacity yerine)
+    const adjustedRoomColor = getAdjustedColor(roomFillColor, 'room');
 
     // Fare sürüklenmiyorsa ve seçim modundaysa, üzerine gelinen nesneyi bul
     const hoveredObject = (!isDragging && currentMode === 'select') ? getObjectAtPoint(mousePos) : null;
@@ -48,7 +46,7 @@ export function drawRoomPolygons(ctx2d, state) {
             if (tempPolygon?.geometry?.coordinates && tempPolygon.geometry.coordinates[0]) {
                 const coords = tempPolygon.geometry.coordinates[0];
                 if (coords.length >= 3) {
-                    ctx2d.fillStyle = darkenColor(roomFillColor, 20);
+                    ctx2d.fillStyle = darkenColor(adjustedRoomColor, 20);
                     ctx2d.strokeStyle = "rgba(138, 180, 248, 0.5)";
                     ctx2d.lineWidth = 2 / zoom;
                     ctx2d.beginPath();
@@ -92,9 +90,9 @@ export function drawRoomPolygons(ctx2d, state) {
             // DOLGU RENGİNİ AYARLAMA
             // Eğer bu oda, adı sürüklenen oda ise VEYA fare bu odanın adının üzerindeyse VEYA bu oda seçili ise vurgu rengini kullan
             if (room === isDraggingRoomName || room === hoveredRoom || room === selectedRoom) {
-                ctx2d.fillStyle = darkenColor(roomFillColor, 20); // Vurgu rengi
+                ctx2d.fillStyle = darkenColor(adjustedRoomColor, 20); // Vurgu rengi
             } else {
-                ctx2d.fillStyle = roomFillColor; // Normal renk
+                ctx2d.fillStyle = adjustedRoomColor; // Normal renk (mod'a göre ayarlanmış)
             }
 
             ctx2d.beginPath();
@@ -111,8 +109,6 @@ export function drawRoomPolygons(ctx2d, state) {
             }
         });
     }
-
-    ctx2d.restore(); // Opacity'yi geri al
 }
 // --- drawRoomPolygons FONKSİYONU SONU ---
 

--- a/draw/draw-walls.js
+++ b/draw/draw-walls.js
@@ -1,4 +1,4 @@
-import { state, dom, BG, getObjectOpacity } from '../general-files/main.js';
+import { state, dom, BG, getAdjustedColor } from '../general-files/main.js';
 
 // --- YARDIMCI FONKSİYONLAR ---
 
@@ -571,10 +571,8 @@ export function drawWallGeometry(ctx2d, state, BG) {
     const { walls, doors, selectedObject, selectedGroup, wallBorderColor, lineThickness, nodes } = state;
     const wallPx = state.wallThickness;
 
-    // Çizim moduna göre opacity ayarla
-    const opacity = getObjectOpacity('wall');
-    ctx2d.save();
-    ctx2d.globalAlpha = opacity;
+    // Çizim moduna göre renk ayarla (opacity yerine)
+    const adjustedWallColor = getAdjustedColor(wallBorderColor, 'wall');
 
     // --- KÖŞE HESAPLAMALARI (Çizimden Önce) ---
     const nodeWallConnections = new Map();
@@ -677,48 +675,45 @@ export function drawWallGeometry(ctx2d, state, BG) {
         currentSegments.forEach((seg) => { let p1 = { x: w.p1.x + dx * seg.start, y: w.p1.y + dy * seg.start }; let p2 = { x: w.p1.x + dx * seg.end, y: w.p1.y + dy * seg.end }; const segmentData = { p1: {...p1}, p2: {...p2}, wall: w }; if (isSelected) { targetList.selected.push(segmentData); } else if (isOrthogonal) { targetList.ortho.push(segmentData); } else { targetList.nonOrtho.push(segmentData); } });
      });
 
-    // Gruplanmış segmentleri ilgili çizim fonksiyonlarıyla çiz
-    // (Artık hepsi önce stroke, sonra bg_fill çizecek)
-    drawNormalSegments(ctx2d, normalSegments.ortho, wallBorderColor, lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
-    drawNormalSegments(ctx2d, normalSegments.nonOrtho, wallBorderColor, lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
+    // Gruplanmış segmentleri ilgili çizim fonksiyonlarıyla çiz (renk ayarlı)
+    drawNormalSegments(ctx2d, normalSegments.ortho, adjustedWallColor, lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
+    drawNormalSegments(ctx2d, normalSegments.nonOrtho, adjustedWallColor, lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
     drawNormalSegments(ctx2d, normalSegments.selected, "#8ab4f8", lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
 
-    drawBalconySegments(ctx2d, balconySegments.ortho, wallBorderColor);
-    drawBalconySegments(ctx2d, balconySegments.nonOrtho, wallBorderColor);
+    drawBalconySegments(ctx2d, balconySegments.ortho, adjustedWallColor);
+    drawBalconySegments(ctx2d, balconySegments.nonOrtho, adjustedWallColor);
     drawBalconySegments(ctx2d, balconySegments.selected, "#8ab4f8");
 
-    drawGlassSegments(ctx2d, glassSegments.ortho, wallBorderColor, wallPx);
-    drawGlassSegments(ctx2d, glassSegments.nonOrtho, wallBorderColor, wallPx);
+    drawGlassSegments(ctx2d, glassSegments.ortho, adjustedWallColor, wallPx);
+    drawGlassSegments(ctx2d, glassSegments.nonOrtho, adjustedWallColor, wallPx);
     drawGlassSegments(ctx2d, glassSegments.selected, "#8ab4f8", wallPx);
 
     // Yarım duvarlar (stroke -> bg_fill -> half_fill)
-    drawHalfSegments(ctx2d, halfSegments.ortho, wallBorderColor, lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
-    drawHalfSegments(ctx2d, halfSegments.nonOrtho,wallBorderColor, lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
+    drawHalfSegments(ctx2d, halfSegments.ortho, adjustedWallColor, lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
+    drawHalfSegments(ctx2d, halfSegments.nonOrtho, adjustedWallColor, lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
     drawHalfSegments(ctx2d, halfSegments.selected, "#8ab4f8", lineThickness, wallPx, BG, nodeWallConnections, precalculatedCorners);
 
     // Arc normal duvarlar
-    drawArcSegments(ctx2d, arcNormalSegments.ortho, wallBorderColor, lineThickness, wallPx, BG);
-    drawArcSegments(ctx2d, arcNormalSegments.nonOrtho, wallBorderColor, lineThickness, wallPx, BG);
+    drawArcSegments(ctx2d, arcNormalSegments.ortho, adjustedWallColor, lineThickness, wallPx, BG);
+    drawArcSegments(ctx2d, arcNormalSegments.nonOrtho, adjustedWallColor, lineThickness, wallPx, BG);
     drawArcSegments(ctx2d, arcNormalSegments.selected, "#8ab4f8", lineThickness, wallPx, BG);
 
     // Arc balkon duvarlar
-    drawArcBalconySegments(ctx2d, arcBalconySegments.ortho, wallBorderColor);
-    drawArcBalconySegments(ctx2d, arcBalconySegments.nonOrtho, wallBorderColor);
+    drawArcBalconySegments(ctx2d, arcBalconySegments.ortho, adjustedWallColor);
+    drawArcBalconySegments(ctx2d, arcBalconySegments.nonOrtho, adjustedWallColor);
     drawArcBalconySegments(ctx2d, arcBalconySegments.selected, "#8ab4f8");
 
     // Arc camekan duvarlar
-    drawArcGlassSegments(ctx2d, arcGlassSegments.ortho, wallBorderColor);
-    drawArcGlassSegments(ctx2d, arcGlassSegments.nonOrtho, wallBorderColor);
+    drawArcGlassSegments(ctx2d, arcGlassSegments.ortho, adjustedWallColor);
+    drawArcGlassSegments(ctx2d, arcGlassSegments.nonOrtho, adjustedWallColor);
     drawArcGlassSegments(ctx2d, arcGlassSegments.selected, "#8ab4f8");
 
     // Arc yarım duvarlar
-    drawArcHalfSegments(ctx2d, arcHalfSegments.ortho, wallBorderColor, lineThickness, wallPx, BG);
-    drawArcHalfSegments(ctx2d, arcHalfSegments.nonOrtho, wallBorderColor, lineThickness, wallPx, BG);
+    drawArcHalfSegments(ctx2d, arcHalfSegments.ortho, adjustedWallColor, lineThickness, wallPx, BG);
+    drawArcHalfSegments(ctx2d, arcHalfSegments.nonOrtho, adjustedWallColor, lineThickness, wallPx, BG);
     drawArcHalfSegments(ctx2d, arcHalfSegments.selected, "#8ab4f8", lineThickness, wallPx, BG);
 
     // Varsayılan ayarlara dön
     ctx2d.lineCap = "butt";
     ctx2d.lineJoin = "miter";
-
-    ctx2d.restore(); // Opacity'yi geri al
 }

--- a/draw/renderer2d.js
+++ b/draw/renderer2d.js
@@ -4,7 +4,7 @@ import { screenToWorld, distToSegmentSquared, getLineIntersectionPoint } from '.
 import { getColumnCorners, isPointInColumn } from '../architectural-objects/columns.js';
 import { getBeamCorners } from '../architectural-objects/beams.js';
 import { getStairCorners } from '../architectural-objects/stairs.js';
-import { state, dom, BG, WINDOW_BOTTOM_HEIGHT, WINDOW_TOP_HEIGHT, getObjectOpacity } from '../general-files/main.js'; // Sabitleri ve yeni fonksiyonu import et
+import { state, dom, BG, WINDOW_BOTTOM_HEIGHT, WINDOW_TOP_HEIGHT, getAdjustedColor } from '../general-files/main.js'; // Sabitleri ve renk ayarlama fonksiyonunu import et
 
 // Node'a bağlı duvar sayısını çizer (Şu an içeriği boş veya yorumlanmış)
 export function drawNodeWallCount(node) {
@@ -21,14 +21,8 @@ export function drawDoorSymbol(door, isPreview = false, isSelected = false) {
     const { ctx2d } = dom;
     const { wallBorderColor, lineThickness } = state;
 
-    // Çizim moduna göre opacity ayarla
-    const opacity = getObjectOpacity('door');
-    ctx2d.save();
-    ctx2d.globalAlpha = opacity;
-
     const wall = door.wall;
     if (!wall || !wall.p1 || !wall.p2) {
-        ctx2d.restore();
         return; // Geçersiz kapı/duvar ise çık
     }
     const wallLen = Math.hypot(wall.p2.x - wall.p1.x, wall.p2.y - wall.p1.y);
@@ -105,7 +99,6 @@ export function drawDoorSymbol(door, isPreview = false, isSelected = false) {
     ctx2d.lineTo(jamb2_end.x, jamb2_end.y);
     ctx2d.stroke(); // Çizgileri çiz
 
-    ctx2d.restore(); // Opacity'yi geri al
 }
 
 // --- GÜNCELLENMİŞ Pencere Sembolü Çizimi ---
@@ -113,13 +106,7 @@ export function drawWindowSymbol(wall, window, isPreview = false, isSelected = f
     const { ctx2d } = dom;
     const { selectedObject, wallBorderColor, lineThickness, zoom } = state; // zoom eklendi
 
-    // Çizim moduna göre opacity ayarla
-    const opacity = getObjectOpacity('window');
-    ctx2d.save();
-    ctx2d.globalAlpha = opacity;
-
     if (!wall || !wall.p1 || !wall.p2) {
-        ctx2d.restore();
         return;
     }
     const wallLen = Math.hypot(wall.p2.x - wall.p1.x, wall.p2.y - wall.p1.y);
@@ -243,7 +230,6 @@ export function drawWindowSymbol(wall, window, isPreview = false, isSelected = f
     ctx2d.stroke(); // Kayıt çizgilerini çiz
     // --- YENİ KAYIT ÇİZİMİ SONU ---
 
-    ctx2d.restore(); // Opacity'yi geri al
 }
 // --- GÜNCELLENMİŞ Pencere Sembolü Çizimi SONU ---
 
@@ -291,11 +277,6 @@ export function drawColumnSymbol(node) {
 export function drawColumn(column, isSelected = false) {
     const { ctx2d } = dom;
     const { zoom, wallBorderColor, lineThickness, currentFloor } = state;
-
-    // Çizim moduna göre opacity ayarla
-    const opacity = getObjectOpacity('column');
-    ctx2d.save();
-    ctx2d.globalAlpha = opacity;
 
     // FLOOR ISOLATION: Sadece aktif kattaki duvarlar ve kolonlarla kesişim kontrolü yap
     const currentFloorId = currentFloor?.id;
@@ -491,7 +472,6 @@ export function drawColumn(column, isSelected = false) {
         ctx2d.beginPath(); ctx2d.moveTo(hollowCorners[0].x, hollowCorners[0].y); for (let i = 1; i < hollowCorners.length; i++) { ctx2d.lineTo(hollowCorners[i].x, hollowCorners[i].y); } ctx2d.closePath(); ctx2d.fill(); ctx2d.stroke();
     }
 
-    ctx2d.restore(); // Opacity'yi geri al
 }
 // --- drawColumn Sonu ---
 
@@ -501,9 +481,7 @@ export function drawBeam(beam, isSelected = false) {
     const { zoom, lineThickness } = state;
 
     // Çizim moduna göre opacity ayarla
-    const opacity = getObjectOpacity('beam');
     ctx2d.save();
-    ctx2d.globalAlpha = opacity;
 
     const corners = getBeamCorners(beam); // Kiriş köşe noktaları
     const beamColor = isSelected ? '#8ab4f8' : state.wallBorderColor;
@@ -553,7 +531,6 @@ export function drawBeam(beam, isSelected = false) {
     ctx2d.fillText("Kiriş", 0, 0);
     ctx2d.restore();
 
-    ctx2d.restore(); // Opacity'yi geri al
 }
 
 // GÜNCELLENMİŞ Merdiven Çizimi (Tek çizgi, ok mantığı düzeltilmiş)
@@ -562,9 +539,7 @@ export function drawStairs(stair, isSelected = false) {
     const { zoom, lineThickness, wallBorderColor, roomFillColor } = state;
 
     // Çizim moduna göre opacity ayarla
-    const opacity = getObjectOpacity('stair');
     ctx2d.save();
-    ctx2d.globalAlpha = opacity;
 
     const corners = getStairCorners(stair); // Köşe noktalarını al
     const stairColor = isSelected ? '#8ab4f8' : wallBorderColor;
@@ -668,7 +643,6 @@ export function drawStairs(stair, isSelected = false) {
     }
     // SAHANLIK İSE, BURADA OK ÇİZİLMEZ (sadece kenarlık/dolgu çizildi)
 
-    ctx2d.restore(); // Opacity'yi geri al
 }
 export function drawGuides(ctx2d, state) {
     const { guides, zoom, selectedObject } = state;


### PR DESCRIPTION
Tesisat modunda mimari nesnelerin opacity ile soluklaştırılması, duvar kesişimlerinde ve kolon altlarında fazladan çizgilerin görünmesine neden oluyordu. Bu sorunu çözmek için:

- getAdjustedColor() fonksiyonu ekle: Rengi background'a blend ederek soluklaştır
- blendColorWithBackground() helper fonksiyonu ekle
- getObjectOpacity() deprecated, artık her zaman 1.0 döner

Değişiklikler:
- draw-walls.js: globalAlpha yerine adjustedWallColor kullan
- draw-rooms.js: globalAlpha yerine adjustedRoomColor kullan
- renderer2d.js: Opacity kullanımını kaldır (getObjectOpacity zaten 1.0 döner)
- main.js: Renk blend sistemi ekle (85% background blend = çok soluk)

Artık tesisat modunda:
- Mimari nesneler %85 background'a blend edilerek çok soluk görünür
- Overlap sorunu yok (aynı renk kullanıldığı için)
- Duvar uçları, kolon altındaki çizgiler vs görünmez