### PR TITLE
Fix staircase drawing duplication and freezing

### DIFF
--- a/draw/renderer2d.js
+++ b/draw/renderer2d.js
@@ -531,6 +531,7 @@ export function drawBeam(beam, isSelected = false) {
     ctx2d.fillText("Kiriş", 0, 0);
     ctx2d.restore();
 
+    ctx2d.restore(); // İlk save() için restore() eklendi
 }
 
 // GÜNCELLENMİŞ Merdiven Çizimi (Tek çizgi, ok mantığı düzeltilmiş)
@@ -643,6 +644,7 @@ export function drawStairs(stair, isSelected = false) {
     }
     // SAHANLIK İSE, BURADA OK ÇİZİLMEZ (sadece kenarlık/dolgu çizildi)
 
+    ctx2d.restore(); // save() için restore() eklendi
 }
 export function drawGuides(ctx2d, state) {
     const { guides, zoom, selectedObject } = state;


### PR DESCRIPTION
SORUN:
- drawStairs() fonksiyonunda ctx2d.save() var ama restore() YOK
- drawBeam() fonksiyonunda ekstra bir save() var, restore() eksik
- Her frame (60 FPS) çizimde canvas state stack büyüyor
- Stack taşıyor → Garip rendering → "İç içe paneller" görünümü → Donma

ÇÖZÜM:
- drawStairs() sonuna ctx2d.restore() eklendi
- drawBeam() sonuna eksik ctx2d.restore() eklendi
- Artık her save() için bir restore() var

NOT: Bu sadece merdiven/kiriş değil, tüm canvas rendering'i etkiliyor.