### PR TITLE
Boru çizim cursor'ı ve snap göstergeleri düzeltildi

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -403,21 +403,17 @@ export class PlumbingRenderer {
     }
 
     drawSnapIndicator(ctx, snap) {
-        ctx.save();
-
-        // Snap noktası
-        ctx.fillStyle = '#00FF00';
-        ctx.beginPath();
-        ctx.arc(snap.x, snap.y, 5, 0, Math.PI * 2);
-        ctx.fill();
-
-        // Snap tipi yazısı
-        ctx.fillStyle = '#00FF00';
-        ctx.font = '10px Arial';
-        ctx.textAlign = 'left';
-        ctx.fillText(snap.type.name, snap.x + 8, snap.y - 8);
-
-        ctx.restore();
+        // Snap göstergesi kaldırıldı - kullanıcı istemiyor
+        // ctx.save();
+        // ctx.fillStyle = '#00FF00';
+        // ctx.beginPath();
+        // ctx.arc(snap.x, snap.y, 5, 0, Math.PI * 2);
+        // ctx.fill();
+        // ctx.fillStyle = '#00FF00';
+        // ctx.font = '10px Arial';
+        // ctx.textAlign = 'left';
+        // ctx.fillText(snap.type.name, snap.x + 8, snap.y - 8);
+        // ctx.restore();
     }
 
     hexToRgba(hex, alpha) {

--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -572,7 +572,7 @@ function updateMouseCursor() {
         case 'plumbingV2':
             // Boru çizim modu aktifse özel cursor göster
             if (plumbingManager.interactionManager?.boruCizimAktif) {
-                modeCursorStyle = "url('data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"32\" height=\"32\" viewBox=\"0 0 32 32\"><path fill=\"white\" transform=\"translate(4 4) scale(0.8)\" d=\"M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zm17.71-10.21c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z\"/><g transform=\"translate(19, 5) scale(0.5)\"><line x1=\"4\" y1=\"12\" x2=\"20\" y2=\"12\" stroke=\"%234885e8\" stroke-width=\"3\" stroke-linecap=\"round\"/><line x1=\"20\" y1=\"12\" x2=\"20\" y2=\"18\" stroke=\"%234885e8\" stroke-width=\"3\" stroke-linecap=\"round\"/><circle cx=\"4\" cy=\"12\" r=\"1.5\" fill=\"%234885e8\"/><circle cx=\"20\" cy=\"12\" r=\"1.5\" fill=\"%234885e8\"/></g></svg>') 5 5, crosshair";
+                modeCursorStyle = "url('data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"32\" height=\"32\" viewBox=\"0 0 32 32\"><polygon fill=\"white\" points=\"2,2 8,2 5,8\"/><rect fill=\"white\" x=\"4\" y=\"8\" width=\"2\" height=\"10\"/><g transform=\"translate(7, 3) scale(0.5)\"><line x1=\"4\" y1=\"12\" x2=\"20\" y2=\"12\" stroke=\"%234885e8\" stroke-width=\"3\" stroke-linecap=\"round\"/><line x1=\"20\" y1=\"12\" x2=\"20\" y2=\"18\" stroke=\"%234885e8\" stroke-width=\"3\" stroke-linecap=\"round\"/><circle cx=\"4\" cy=\"12\" r=\"1.5\" fill=\"%234885e8\"/><circle cx=\"20\" cy=\"12\" r=\"1.5\" fill=\"%234885e8\"/></g></svg>') 5 5, crosshair";
             } else {
                 modeCursorStyle = 'crosshair';
             }


### PR DESCRIPTION
1. Snap göstergeleri kaldırıldı:
   - Yeşil nokta kaldırıldı
   - "90derece açı" gibi yazılar kaldırıldı

2. Kalem ikonu basitleştirildi:
   - Material Design ikonu yerine basit kalem (üçgen uç + dikdörtgen gövde)
   - Takma kulp kaldırıldı

3. Boru ikonu pozisyonu ayarlandı:
   - Hot spot: (5, 5) - kalem ucu
   - Boru ikonu: noktanın x+2, y-2 pozisyonunda (translate(7, 3))

Dosyalar:
- pointer/pointer-move.js: Cursor SVG güncellendi
- plumbing_v2/plumbing-renderer.js: drawSnapIndicator() devre dışı