### PR TITLE
Mod bazlı koşullu öğe görünürlüğü iyileştirmesi

### DIFF
--- a/draw/dimensions.js
+++ b/draw/dimensions.js
@@ -1,5 +1,5 @@
 import { screenToWorld } from './geometry.js';
-import { state, dom } from '../general-files/main.js';
+import { state, dom, getAdjustedColor } from '../general-files/main.js';
 
 // Yazı boyutunun zoom ile nasıl değişeceğini belirleyen üs (-0.7 yaklaşık olarak 10x zoomda yarı boyutu verir)
 const ZOOM_EXPONENT = -0.65;
@@ -65,12 +65,15 @@ export function drawDimension(p1, p2, isPreview = false, mode = 'single') {
     ctx2d.font = `400 ${Math.max(minWorldFontSize, fontSize)}px "Segoe UI", "Roboto", "Helvetica Neue", sans-serif`;
 
     // ---- RENK AYARLAMASI ----
-    // Kolon/Kiriş/Merdiven modu için her zaman dimensionOptions.color kullan
+    // Çizim moduna göre renk ayarla
+    let baseColor;
     if (mode === 'columnBeam') {
-        ctx2d.fillStyle = dimensionOptions.color;
+        baseColor = dimensionOptions.color;
     } else {
-        ctx2d.fillStyle = isPreview ? "#8ab4f8" : dimensionOptions.color;
+        baseColor = isPreview ? "#8ab4f8" : dimensionOptions.color;
     }
+    const adjustedColor = getAdjustedColor(baseColor, 'dimension');
+    ctx2d.fillStyle = adjustedColor;
     // ---- AYARLAMA SONU ----
 
     ctx2d.textAlign = "center";
@@ -94,7 +97,9 @@ export function drawTotalDimensions(filteredWalls = null, filteredRooms = null) 
     const minWorldFontSize = 10; // Özet görünüm için biraz daha büyük minimum
 
     ctx2d.font = `400 ${Math.max(minWorldFontSize, fontSize)}px "Segoe UI", "Roboto", "Helvetica Neue", sans-serif`;
-    ctx2d.fillStyle = dimensionOptions.color;
+    // Çizim moduna göre renk ayarla
+    const adjustedDimensionColor = getAdjustedColor(dimensionOptions.color, 'dimension');
+    ctx2d.fillStyle = adjustedDimensionColor;
 
     const gridSpacing = gridOptions.visible ? gridOptions.spacing : 1;
     const TOLERANCE = 1;
@@ -229,8 +234,10 @@ export function drawOuterDimensions(filteredWalls = null) {
         const extensionOvershoot = 8;
         const extensionLineLength = dimLineOffset + extensionOvershoot;
 
-        ctx2d.strokeStyle = dimensionOptions.color;
-        ctx2d.fillStyle = dimensionOptions.color;
+        // Çizim moduna göre renk ayarla
+        const adjustedOuterDimensionColor = getAdjustedColor(dimensionOptions.color, 'dimension');
+        ctx2d.strokeStyle = adjustedOuterDimensionColor;
+        ctx2d.fillStyle = adjustedOuterDimensionColor;
         ctx2d.lineWidth = 1 / zoom;
 
         const baseFontSize = dimensionOptions.fontSize;
@@ -279,8 +286,9 @@ export function drawOuterDimensions(filteredWalls = null) {
 
         const leftDimX = minX - dimLineOffset;
 
-        ctx2d.strokeStyle = dimensionOptions.color;
-        ctx2d.fillStyle = dimensionOptions.color;
+        // Çizim moduna göre renk ayarla
+        ctx2d.strokeStyle = adjustedOuterDimensionColor;
+        ctx2d.fillStyle = adjustedOuterDimensionColor;
         ctx2d.lineWidth = 1 / zoom;
 
         ctx2d.beginPath();

--- a/draw/draw-rooms.js
+++ b/draw/draw-rooms.js
@@ -165,7 +165,10 @@ export function drawRoomNames(ctx2d, state, getObjectAtPoint) {
             ctx2d.shadowBlur = 8 / zoom; // Gölgeyi zoom'a göre ayarla
         }
 
-        ctx2d.fillStyle = room.name === 'MAHAL' ? '#e57373' : '#8ab4f8';
+        // Çizim moduna göre renk ayarla
+        const baseNameColor = room.name === 'MAHAL' ? '#e57373' : '#8ab4f8';
+        const adjustedNameColor = getAdjustedColor(baseNameColor, 'roomName');
+        ctx2d.fillStyle = adjustedNameColor;
 
         ctx2d.font = `500 ${Math.max(minWorldNameFontSize, nameFontSize)}px "Segoe UI", "Roboto", "Helvetica Neue", sans-serif`;
 
@@ -183,7 +186,9 @@ export function drawRoomNames(ctx2d, state, getObjectAtPoint) {
         }
 
         if (showArea) {
-            ctx2d.fillStyle = '#e57373';
+            // Çizim moduna göre alan metni rengi ayarla
+            const adjustedAreaColor = getAdjustedColor('#e57373', 'roomName');
+            ctx2d.fillStyle = adjustedAreaColor;
             ctx2d.font = `400 ${Math.max(minWorldAreaFontSize, areaFontSize)}px "Segoe UI", "Roboto", "Helvetica Neue", sans-serif`;
             ctx2d.textBaseline = "middle";
             const text = (typeof room.area === 'number') ? `${room.area.toFixed(2)} m²` : '? m²';
@@ -208,7 +213,10 @@ export function drawRoomNames(ctx2d, state, getObjectAtPoint) {
          // room.center geçerli mi kontrol et
         if (room.center && Array.isArray(room.center) && room.center.length >= 2 && typeof room.center[0] === 'number') {
             ctx2d.textAlign = "center";
-            ctx2d.fillStyle = room.name === 'MAHAL' ? '#e57373' : '#8ab4f8';
+            // Çizim moduna göre renk ayarla
+            const baseNameColor = room.name === 'MAHAL' ? '#e57373' : '#8ab4f8';
+            const adjustedNameColor = getAdjustedColor(baseNameColor, 'roomName');
+            ctx2d.fillStyle = adjustedNameColor;
             const baseNameFontSize = 18;
             let nameFontSize = baseNameFontSize * Math.pow(zoom, ZOOM_EXPONENT); // ZOOM_EXPONENT burada tanımlı olmalı
             const minWorldNameFontSize = 3;
@@ -241,7 +249,9 @@ export function drawRoomNames(ctx2d, state, getObjectAtPoint) {
 
              // Alanı da çiz
              if (showArea && typeof room.area === 'number') {
-                 ctx2d.fillStyle = '#e57373';
+                 // Çizim moduna göre alan metni rengi ayarla
+                 const adjustedAreaColor = getAdjustedColor('#e57373', 'roomName');
+                 ctx2d.fillStyle = adjustedAreaColor;
                  const baseAreaFontSize = 14;
                  let areaFontSize = baseAreaFontSize * Math.pow(zoom, ZOOM_EXPONENT); // ZOOM_EXPONENT burada tanımlı olmalı
                  const minWorldAreaFontSize = 2;

--- a/draw/renderer2d.js
+++ b/draw/renderer2d.js
@@ -294,9 +294,13 @@ export function drawColumn(column, isSelected = false) {
 
     const corners = getColumnCorners(column); // Kolonun köşe noktaları
 
+    // Çizim moduna göre renk ayarla
+    const adjustedBorderColor = getAdjustedColor(wallBorderColor, 'column');
+    const adjustedFillColor = getAdjustedColor(BG, 'column');
+
     // Çizim stilleri
-    ctx2d.fillStyle = BG; // İçini arka plan rengiyle doldur
-    ctx2d.strokeStyle = isSelected ? '#8ab4f8' : wallBorderColor; // Kenarlık rengi (seçiliyse mavi)
+    ctx2d.fillStyle = adjustedFillColor; // İçini arka plan rengiyle doldur
+    ctx2d.strokeStyle = isSelected ? '#8ab4f8' : adjustedBorderColor; // Kenarlık rengi (seçiliyse mavi)
     ctx2d.lineWidth = lineThickness / zoom; // Çizgi kalınlığı (zoom'a göre ayarlı)
 
     // Dış kareyi çiz (Önce dolgu, sonra kenarlık)
@@ -477,7 +481,8 @@ export function drawColumn(column, isSelected = false) {
     if (column.hollowWidth && column.hollowHeight) {
         const halfHollowW = column.hollowWidth / 2; const halfHollowH = column.hollowHeight / 2; const cx = column.center.x; const cy = column.center.y; const rot = (column.rotation || 0) * Math.PI / 180; const offsetX = column.hollowOffsetX || 0; const offsetY = column.hollowOffsetY || 0;
         const hollowCorners = [ { x: offsetX - halfHollowW, y: offsetY - halfHollowH }, { x: offsetX + halfHollowW, y: offsetY - halfHollowH }, { x: offsetX + halfHollowW, y: offsetY + halfHollowH }, { x: offsetX - halfHollowW, y: offsetY + halfHollowH } ].map(corner => { const rotatedX = corner.x * Math.cos(rot) - corner.y * Math.sin(rot); const rotatedY = corner.x * Math.sin(rot) + corner.y * Math.cos(rot); return { x: cx + rotatedX, y: cy + rotatedY }; });
-        ctx2d.fillStyle = state.roomFillColor; ctx2d.strokeStyle = isSelected ? '#8ab4f8' : wallBorderColor; ctx2d.lineWidth = lineThickness / zoom;
+        const adjustedRoomFillColor = getAdjustedColor(state.roomFillColor, 'column');
+        ctx2d.fillStyle = adjustedRoomFillColor; ctx2d.strokeStyle = isSelected ? '#8ab4f8' : adjustedBorderColor; ctx2d.lineWidth = lineThickness / zoom;
         ctx2d.beginPath(); ctx2d.moveTo(hollowCorners[0].x, hollowCorners[0].y); for (let i = 1; i < hollowCorners.length; i++) { ctx2d.lineTo(hollowCorners[i].x, hollowCorners[i].y); } ctx2d.closePath(); ctx2d.fill(); ctx2d.stroke();
     }
 
@@ -493,7 +498,9 @@ export function drawBeam(beam, isSelected = false) {
     ctx2d.save();
 
     const corners = getBeamCorners(beam); // Kiriş köşe noktaları
-    const beamColor = isSelected ? '#8ab4f8' : state.wallBorderColor;
+    // Çizim moduna göre renk ayarla
+    const adjustedWallBorderColor = getAdjustedColor(state.wallBorderColor, 'beam');
+    const beamColor = isSelected ? '#8ab4f8' : adjustedWallBorderColor;
     let fillColor;
     if (beamColor.startsWith('#')) {
         const hex = beamColor.slice(1);
@@ -552,8 +559,11 @@ export function drawStairs(stair, isSelected = false) {
     ctx2d.save();
 
     const corners = getStairCorners(stair); // Köşe noktalarını al
-    const stairColor = isSelected ? '#8ab4f8' : wallBorderColor;
-    const backgroundColor = roomFillColor || '#1e1f20';
+    // Çizim moduna göre renk ayarla
+    const adjustedWallBorderColor = getAdjustedColor(wallBorderColor, 'stair');
+    const adjustedRoomFillColor = getAdjustedColor(roomFillColor || '#1e1f20', 'stair');
+    const stairColor = isSelected ? '#8ab4f8' : adjustedWallBorderColor;
+    const backgroundColor = adjustedRoomFillColor;
     const rotRad = (stair.rotation || 0) * Math.PI / 180;
     const dirX = Math.cos(rotRad); // Ok için yön vektörleri
     const dirY = Math.sin(rotRad);

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -478,6 +478,9 @@ function setupModeButtons() {
 export function setDrawingMode(mode) {
     setState({ currentDrawingMode: mode });
 
+    // Mod değiştiğinde otomatik olarak seç moduna geç
+    setMode('select', true);
+
     // Butonların active durumunu güncelle (dinamik olarak query)
     const modeMimari = document.getElementById("mode-mimari");
     const modeTesisat = document.getElementById("mode-tesisat");
@@ -564,7 +567,7 @@ export function getAdjustedColor(originalColor, objectType) {
 
     // Mimari nesneler listesi (TESİSAT modunda soluk olacaklar)
     const architecturalObjects = [
-        'wall', 'door', 'window', 'room'
+        'wall', 'door', 'window', 'room', 'column', 'beam', 'stair', 'dimension', 'roomName'
     ];
 
     // Tesisat nesneleri listesi


### PR DESCRIPTION
- Mimari modda tesisat öğeleri (boru, servis kutusu, sayaç, vana, kombi, ocak) soluk görünüyor
- Tesisat modunda mimari öğeler (kapı, pencere, merdiven, mahal isimleri, kolon, kiriş, ölçüler) soluk görünüyor
- Proje modları tabından mod değiştirildiğinde otomatik olarak seç moduna geçiş eklendi

Değişiklikler:
- getAdjustedColor fonksiyonuna yeni mimari öğe tipleri eklendi: column, beam, stair, dimension, roomName
- Merdiven, kolon, kiriş çizimlerinde renk ayarlaması için getAdjustedColor kullanıldı
- Mahal isimleri çiziminde renk ayarlaması için getAdjustedColor kullanıldı
- Ölçüler (dimensions) çiziminde renk ayarlaması için getAdjustedColor kullanıldı
- setDrawingMode fonksiyonuna mod değiştiğinde otomatik seç moduna geçiş eklendi