### PR TITLE
Mod bazlı interaksiyon iyileştirmeleri

### DIFF
--- a/draw/draw-rooms.js
+++ b/draw/draw-rooms.js
@@ -1,4 +1,4 @@
-import { state, dom, getAdjustedColor } from '../general-files/main.js';
+import { state, dom, getAdjustedColor, isObjectInteractable } from '../general-files/main.js';
 import { getObjectAtPoint } from '../general-files/actions.js';
 
 // --- EKSİK SABİTİ EKLEYİN ---
@@ -37,7 +37,11 @@ export function drawRoomPolygons(ctx2d, state) {
 
     // Fare sürüklenmiyorsa ve seçim modundaysa, üzerine gelinen nesneyi bul
     const hoveredObject = (!isDragging && currentMode === 'select') ? getObjectAtPoint(mousePos) : null;
-    const hoveredRoom = (hoveredObject?.type === 'roomName' || hoveredObject?.type === 'roomArea') ? hoveredObject.object : null;
+    // Sadece interaktif nesneler için hover göster (roomName modda interaktif olmalı)
+    const hoveredRoom = (hoveredObject?.type === 'roomName' || hoveredObject?.type === 'roomArea')
+        && isObjectInteractable('roomName')
+        ? hoveredObject.object
+        : null;
 
     // Sürüklenen geçici mahal poligonlarını çiz (duvar sürükleme için)
     if (isDragging && draggedRoomInfo && draggedRoomInfo.length > 0) {
@@ -126,7 +130,11 @@ export function drawRoomNames(ctx2d, state, getObjectAtPoint) {
 
     // Fare sürüklenmiyorsa ve seçim modundaysa üzerine gelinen nesneyi bul
     const hoveredObject = (!isDragging && currentMode === 'select' && mousePos) ? getObjectAtPoint(mousePos) : null;
-    const hoveredRoom = (hoveredObject?.type === 'roomName' || hoveredObject?.type === 'roomArea') ? hoveredObject.object : null;
+    // Sadece interaktif nesneler için hover göster (roomName modda interaktif olmalı)
+    const hoveredRoom = (hoveredObject?.type === 'roomName' || hoveredObject?.type === 'roomArea')
+        && isObjectInteractable('roomName')
+        ? hoveredObject.object
+        : null;
 
     // Sürüklenen odaların kümesini oluştur (duvar sürükleme için)
     const draggedRooms = (isDragging && draggedRoomInfo && draggedRoomInfo.length > 0)

--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -8,7 +8,7 @@ import { plumbingManager } from '../plumbing_v2/plumbing-manager.js';
 import { calculateSymmetryPreview, calculateCopyPreview } from '../draw/symmetry.js'; // <-- DÜZELTME: Bu import eklendi
 import { screenToWorld, distToSegmentSquared, findNodeAt } from '../draw/geometry.js';
 import { getObjectAtPoint } from '../general-files/actions.js'; // getObjectAtPoint eklendi
-import { state, dom, setState } from '../general-files/main.js';
+import { state, dom, setState, isObjectInteractable } from '../general-files/main.js';
 import { getSmartSnapPoint } from '../general-files/snap.js';
 import { positionLengthInput } from '../general-files/ui.js';
 import { currentModifierKeys } from '../general-files/input.js';
@@ -598,6 +598,15 @@ function updateMouseCursor() {
         const hoveredObject = getObjectAtPoint(mousePos);
 
         if (hoveredObject) {
+            // İlk olarak nesnenin interaktif olup olmadığını kontrol et
+            const objectType = hoveredObject.type;
+            const isInteractive = isObjectInteractable(objectType);
+
+            // Eğer nesne interaktif değilse, cursor değiştirme
+            if (!isInteractive) {
+                c2d.style.cursor = 'default';
+                return;
+            }
 
            // --- YENİ ÖNCELİKLİ KONTROL ---
            // 1. Mahal Adı/Alanı Hover (Handle'dan bağımsız)


### PR DESCRIPTION
1. Mahal isimleri hover kontrolü:
   - Tesisat modunda mahal isimleri artık hover efekti almıyor
   - Sadece ilgili modda (mimari/karma) mahal isimleri interaktif

2. Mouse cursor kontrolü:
   - Mimari modda tesisat öğeleri (borular, vs.) üzerine gelince cursor değişmiyor
   - Tesisat modunda mimari öğeler üzerine gelince cursor değişmiyor
   - isObjectInteractable kontrolü eklendi

3. Servis kutusu:
   - Zaten getAdjustedColor kullanıyor, mimari modda soluk görünüyor

Değişiklikler:
- draw-rooms.js: Hover kontrolüne isObjectInteractable eklendi
- pointer-move.js: updateMouseCursor fonksiyonuna interaksiyon kontrolü eklendi