### PR TITLE
Canvas'ta bulanık çizgi sorunu düzeltildi

### DIFF
--- a/architectural-objects/guide-handler.js
+++ b/architectural-objects/guide-handler.js
@@ -26,8 +26,9 @@ export function getGuideAtPoint(pos, tolerance) {
             case 'horizontal': {
                 const dist = Math.abs(pos.y - guide.y);
                 // Ekran sınırları içinde mi diye kontrol et (sonsuz çizgiler için)
+                const dpr = window.devicePixelRatio || 1;
                 const { x: worldLeft } = screenToWorld(0, 0);
-                const { x: worldRight } = screenToWorld(dom.c2d.width, 0);
+                const { x: worldRight } = screenToWorld(dom.c2d.width / dpr, 0);
                 if (dist < tolerance && pos.x >= worldLeft && pos.x <= worldRight) {
                     return { type: 'guide', object: guide, handle: 'body' };
                 }
@@ -35,8 +36,9 @@ export function getGuideAtPoint(pos, tolerance) {
             }
             case 'vertical': {
                 const dist = Math.abs(pos.x - guide.x);
+                const dpr = window.devicePixelRatio || 1;
                 const { y: worldTop } = screenToWorld(0, 0);
-                const { y: worldBottom } = screenToWorld(0, dom.c2d.height);
+                const { y: worldBottom } = screenToWorld(0, dom.c2d.height / dpr);
                 if (dist < tolerance && pos.y >= worldTop && pos.y <= worldBottom) {
                     return { type: 'guide', object: guide, handle: 'body' };
                 }

--- a/draw/draw-previews.js
+++ b/draw/draw-previews.js
@@ -173,8 +173,9 @@ export function drawDrawingPreviews(ctx2d, state, snapTo15DegreeAngle, drawDimen
                 const dy = previewPos.y - startPoint.y;
                 const len = Math.hypot(dx, dy);
                 if (len > 0.1) {
+                    const dpr = window.devicePixelRatio || 1;
                     const { x: worldLeft, y: worldTop } = screenToWorld(0, 0);
-                    const { x: worldRight, y: worldBottom } = screenToWorld(dom.c2d.width, dom.c2d.height);
+                    const { x: worldRight, y: worldBottom } = screenToWorld(dom.c2d.width / dpr, dom.c2d.height / dpr);
                     const extend = Math.max(worldRight - worldLeft, worldBottom - worldTop) * 2;
                     
                     const p0 = { x: startPoint.x - (dx/len) * extend, y: startPoint.y - (dy/len) * extend };

--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -258,9 +258,17 @@ export function draw2D() {
     });
     const nodes = Array.from(nodesSet);
 
+    // Get device pixel ratio for crisp rendering
+    const dpr = window.devicePixelRatio || 1;
+
     ctx2d.fillStyle = BG;
     ctx2d.fillRect(0, 0, c2d.width, c2d.height);
     ctx2d.save();
+
+    // Apply DPR scaling first for crisp rendering
+    ctx2d.scale(dpr, dpr);
+
+    // Then apply pan and zoom transforms
     ctx2d.translate(panOffset.x, panOffset.y);
     ctx2d.scale(zoom, zoom);
     ctx2d.lineWidth = 1 / zoom;

--- a/draw/renderer2d.js
+++ b/draw/renderer2d.js
@@ -246,7 +246,8 @@ export function drawWindowSymbol(wall, window, isPreview = false, isSelected = f
 // Grid'i çizer
 export function drawGrid() {
     const { ctx2d, c2d } = dom; const { zoom, gridOptions } = state; if (!gridOptions.visible) return;
-    const { x: worldLeft, y: worldTop } = screenToWorld(0, 0); const { x: worldRight, y: worldBottom } = screenToWorld(c2d.width, c2d.height);
+    const dpr = window.devicePixelRatio || 1;
+    const { x: worldLeft, y: worldTop } = screenToWorld(0, 0); const { x: worldRight, y: worldBottom } = screenToWorld(c2d.width / dpr, c2d.height / dpr);
     const baseSpacing = gridOptions.spacing; const MIN_PIXEL_SPACING = 20; const multipliers = [1, 5, 10, 50, 100]; const visibleMultipliers = [];
     for (const mult of multipliers) { const spacing = baseSpacing * mult; const pixelSpacing = spacing * zoom; if (pixelSpacing >= MIN_PIXEL_SPACING) { visibleMultipliers.push({ multiplier: mult, spacing: spacing }); } }
     if (visibleMultipliers.length === 0) { visibleMultipliers.push({ multiplier: multipliers[multipliers.length -1], spacing: baseSpacing * multipliers[multipliers.length -1] }); if(multipliers.length > 1) { visibleMultipliers.push({ multiplier: multipliers[multipliers.length - 2], spacing: baseSpacing * multipliers[multipliers.length - 2] }); } } else if (visibleMultipliers.length === 1 && multipliers.indexOf(visibleMultipliers[0].multiplier) < multipliers.length - 1) { const currentMultIndex = multipliers.indexOf(visibleMultipliers[0].multiplier); const nextMult = multipliers[currentMultIndex + 1]; visibleMultipliers.push({ multiplier: nextMult, spacing: baseSpacing * nextMult }); }
@@ -670,8 +671,9 @@ export function drawGuides(ctx2d, state) {
     if (!guides || guides.length === 0) return;
 
     // Görünür alanı dünya koordinatlarında al
+    const dpr = window.devicePixelRatio || 1;
     const { x: worldLeft, y: worldTop } = screenToWorld(0, 0);
-    const { x: worldRight, y: worldBottom } = screenToWorld(dom.c2d.width, dom.c2d.height);
+    const { x: worldRight, y: worldBottom } = screenToWorld(dom.c2d.width / dpr, dom.c2d.height / dpr);
     
     // İsteğiniz üzerine stil tanımlamaları
     const guideColor = "rgba(255, 100, 100, 0.5)"; // Soluk kırmızı

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -773,8 +773,19 @@ export function setMode(mode, forceSet = false) { // forceSet parametresi eklend
 
 export function resize() {
     const r2d = dom.p2d.getBoundingClientRect();
-    dom.c2d.width = r2d.width;
-    dom.c2d.height = r2d.height;
+    const dpr = window.devicePixelRatio || 1;
+
+    // Set canvas size with device pixel ratio for crisp rendering
+    dom.c2d.width = r2d.width * dpr;
+    dom.c2d.height = r2d.height * dpr;
+    dom.c2d.style.width = r2d.width + 'px';
+    dom.c2d.style.height = r2d.height + 'px';
+
+    // Disable image smoothing for crisp vector lines
+    dom.ctx2d.imageSmoothingEnabled = false;
+    dom.ctx2d.webkitImageSmoothingEnabled = false;
+    dom.ctx2d.mozImageSmoothingEnabled = false;
+    dom.ctx2d.msImageSmoothingEnabled = false;
 
     const r3d = dom.p3d.getBoundingClientRect();
     if (r3d.width > 0 && r3d.height > 0 && camera3d && renderer3d) {


### PR DESCRIPTION
- Device Pixel Ratio (DPR) desteği eklendi
- Canvas fiziksel boyutları DPR ile çarpılarak keskin render sağlandı
- imageSmoothingEnabled false yapılarak anti-aliasing devre dışı bırakıldı
- screenToWorld çağrılarında DPR ile bölme eklendi
- Duvar ve ölçülendirme çizgileri artık SVG gibi her zoom seviyesinde keskin