### PR TITLE
Canvas transform matrix düzeltildi - setTransform kullanımı

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -258,19 +258,22 @@ export function draw2D() {
     });
     const nodes = Array.from(nodesSet);
 
-    // Apply DPR scaling to use all physical pixels
+    // Get device pixel ratio for crisp rendering
     const dpr = window.devicePixelRatio || 1;
 
     ctx2d.fillStyle = BG;
     ctx2d.fillRect(0, 0, c2d.width, c2d.height);
     ctx2d.save();
 
-    // Scale context to device pixel ratio first
-    ctx2d.scale(dpr, dpr);
+    // Apply combined transform matrix for DPR, zoom, and pan
+    // This is equivalent to: scale(dpr) -> translate(panOffset) -> scale(zoom)
+    // But done correctly so mouse coordinates work properly
+    ctx2d.setTransform(
+        dpr * zoom, 0,
+        0, dpr * zoom,
+        dpr * panOffset.x, dpr * panOffset.y
+    );
 
-    // Then apply pan and zoom (these work in CSS pixels)
-    ctx2d.translate(panOffset.x, panOffset.y);
-    ctx2d.scale(zoom, zoom);
     ctx2d.lineWidth = 1 / zoom;
 
     // 1. Grid


### PR DESCRIPTION
- ctx.scale() + translate() yerine setTransform() kullanıldı
- Transform matrix doğrudan hesaplanarak uygulandı
- Mouse koordinatları artık doğru eşleşiyor
- Merdiven ve diğer nesneler artık düzgün seçilebilir
- Çizgiler hala keskin ve net