### PR TITLE
Boru cursor ikonu 2x büyütüldü

### DIFF
--- a/general-files/cursors/pipe_cursor.svg
+++ b/general-files/cursors/pipe_cursor.svg
@@ -1,4 +1,4 @@
-<svg width="24px" height="24px" viewBox="0 0 512 512" data-name="Camada 1" id="Camada_1" xmlns="http://www.w3.org/2000/svg" fill="#000000">
+<svg width="48px" height="48px" viewBox="0 0 512 512" data-name="Camada 1" id="Camada_1" xmlns="http://www.w3.org/2000/svg" fill="#000000">
 <g id="SVGRepo_bgCarrier" stroke-width="0"/>
 <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
 <g id="SVGRepo_iconCarrier" transform="rotate(225, 256, 256)">

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -333,7 +333,7 @@ canvas {
 }
 
 .panel.tool-boru {
-    cursor: url('cursors/pipe_cursor.svg') 0 24, auto !important;
+    cursor: url('cursors/pipe_cursor.svg') 0 48, auto !important;
 }
 
 #length-input {


### PR DESCRIPTION
Değişiklikler:
- pipe_cursor.svg: 24px -> 48px
- style.css: Cursor hotspot 0 24 -> 0 48

Artık boru çizim modunda mouse ikonu (kalem) 2 kat daha büyük.