### PR TITLE
SVG cursor scale(4) ile daha da büyütüldü

### DIFF
--- a/general-files/cursors/pipe_cursor.svg
+++ b/general-files/cursors/pipe_cursor.svg
@@ -1,5 +1,5 @@
 <svg width="48px" height="48px" viewBox="0 0 512 512" data-name="Camada 1" id="Camada_1" xmlns="http://www.w3.org/2000/svg" fill="#000000">
-<g transform="scale(2)">
+<g transform="scale(4)">
 <g id="SVGRepo_bgCarrier" stroke-width="0"/>
 <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
 <g id="SVGRepo_iconCarrier" transform="rotate(225, 256, 256)">


### PR DESCRIPTION
scale(2) yeterli olmadı, scale(4) deniyoruz.
NOT: Tarayıcı cache'ini temizleyin (Ctrl+Shift+R)