### PR TITLE
JavaScript ile custom cursor elementi (80x80px)

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -1345,6 +1345,18 @@ function initialize() {
     // Sürüklenebilir gruplar için drag & drop
     initializeDraggableGroups();
 
+    // Custom Pipe Cursor - Mouse tracking
+    const customCursor = document.getElementById('custom-pipe-cursor');
+    document.addEventListener('mousemove', (e) => {
+        if (state.currentMode === 'plumbingV2' && plumbingManager?.activeTool === 'boru') {
+            customCursor.style.display = 'block';
+            customCursor.style.left = e.clientX + 'px';
+            customCursor.style.top = e.clientY + 'px';
+        } else {
+            customCursor.style.display = 'none';
+        }
+    });
+
     resize();
     animate();
     setTimeout(fitDrawingToScreen, 100); // 100ms sonra fitDrawingToScreen'i çağır

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -333,7 +333,21 @@ canvas {
 }
 
 .panel.tool-boru {
-    cursor: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><line x1="32" y1="8" x2="32" y2="56" stroke="white" stroke-width="3"/><line x1="8" y1="32" x2="56" y2="32" stroke="white" stroke-width="3"/><circle cx="32" cy="32" r="12" fill="none" stroke="cyan" stroke-width="2"/></svg>') 32 32, crosshair !important;
+    cursor: none !important;
+}
+
+/* Custom Pipe Cursor */
+#custom-pipe-cursor {
+    position: fixed;
+    width: 80px;
+    height: 80px;
+    pointer-events: none;
+    z-index: 10000;
+    background-image: url('cursors/pipe_cursor.svg');
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+    transform: translate(-50%, -50%);
 }
 
 #length-input {

--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
     <button class="mode-btn active" id="mode-karma" title="Karma Mod">KARMA</button>
   </div>
 
+  <!-- Custom Cursor Element -->
+  <div id="custom-pipe-cursor" style="display: none;"></div>
+
   <div class="main" id="main-container">
     <div id="p2d" class="panel">
       <div id="ui">


### PR DESCRIPTION
CSS cursor boyut sınırlamaları yüzünden çalışmadı. Çözüm: JavaScript ile mouse'u takip eden DOM element:

- index.html: custom-pipe-cursor elementi eklendi
- style.css: 80x80px cursor elementi stili, tool-boru için cursor: none
- main.js: mousemove event listener ile cursor takibi

Artık boru modunda büyük cursor görünecek!