### PR TITLE
KARMA moduna geçişte çizim modu korunması

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -474,16 +474,32 @@ function setupModeButtons() {
     });
 }
 
+// KARMA modundan ayrılırken çizim modunu kaydetmek için
+let karmaLastDrawingMode = null;
+
 // Çizim modu değiştirme fonksiyonu (MİMARİ, TESİSAT, KARMA)
 export function setDrawingMode(mode) {
+    // KARMA modundan ayrılırken, mevcut çizim modunu kaydet (eğer select değilse)
+    if (state.currentDrawingMode === 'KARMA' && mode !== 'KARMA') {
+        if (state.currentMode !== 'select') {
+            karmaLastDrawingMode = state.currentMode;
+        }
+    }
+
     setState({ currentDrawingMode: mode });
 
-    // KARMA moduna geçildiğinde mevcut ikon korunmalı (hiç setMode çağrılmaz)
+    // KARMA moduna geçildiğinde önceki çizim modu geri yüklenir
     // MİMARİ ve TESİSAT modlarında otomatik olarak seç moduna geç
     if (mode !== 'KARMA') {
         setMode('select', true);
+    } else {
+        // KARMA moduna geçildiğinde, kaydedilmiş çizim modunu geri yükle
+        if (karmaLastDrawingMode) {
+            setMode(karmaLastDrawingMode, true);
+            karmaLastDrawingMode = null; // Geri yüklendikten sonra temizle
+        }
     }
-    // KARMA modunda: mevcut mod (drawWall, select, vb.) korunur
+    // KARMA modunda: önceki çizim modu korunur veya geri yüklenir
 
     // Butonların active durumunu güncelle (dinamik olarak query)
     const modeMimari = document.getElementById("mode-mimari");


### PR DESCRIPTION
KARMA modundan başka bir proje görüntüleme moduna (MİMARİ/TESİSAT) geçilip tekrar KARMA'ya dönüldüğünde, önceki çizim modu (duvar çizme, kapı çizme, vb.) otomatik olarak geri yükleniyor.

Bu sayede kullanıcı KARMA modundaki aktif çizim aracından çıkmamış oluyor.