### PR TITLE
MİMARİ modunda tesisat görünürlüğü artırıldı ve renk sorunu düzeltildi

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -628,8 +628,9 @@ export function getAdjustedColor(originalColor, objectType) {
     // MİMARİ modunda
     if (mode === "MİMARİ") {
         if (isPlumbing) {
-            // Tesisat nesneleri soluk (85% background'a blend)
-            return blendColorWithBackground(originalColor, 0.85);
+            // Tesisat nesneleri - renk blend YAPMA, sadece globalAlpha ile soluklaştır
+            // (plumbing-renderer.js'de globalAlpha kullanılıyor)
+            return normalizeColor(originalColor);
         }
         return normalizeColor(originalColor); // Mimari nesneler normal
     }

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -23,7 +23,7 @@ export class PlumbingRenderer {
 
         if (shouldBeFaded) {
             ctx.save();
-            ctx.globalAlpha = 0.15; // Çok soluk (85% blend'e karşılık gelir)
+            ctx.globalAlpha = 0.35; // Biraz daha görünür (önceden 0.15)
         }
 
         // Borular


### PR DESCRIPTION
SORUN:
- globalAlpha = 0.15 ile tesisat nesneleri çok soluktu
- globalAlpha artırılınca servis kutusunun içi renkli oluyordu
- Çünkü hem renk blend (0.85) hem de globalAlpha (0.15) yapılıyordu

ÇÖZÜM:
1. MİMARİ modunda tesisat için renk blend KALDIRILDI
   - getAdjustedColor'da blend yerine orijinal renk kullanılıyor
   - Bu sayede renk korunuyor

2. globalAlpha 0.15'ten 0.35'e ÇIKARILDI
   - Sadece opacity ile soluklaştırma yapılıyor
   - Çift soluklaştırma kaldırıldı

SONUÇ:
- Tesisat nesneleri MİMARİ modunda daha görünür (0.35 opacity)
- Renkler korunuyor, renkli olmuyor
- Servis kutusu gri kalıyor (#ccc)