### PR TITLE
Boru cursor hot spot düzeltildi - kalemin ucu tam aktif noktaya geldi

### DIFF
--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -570,8 +570,8 @@ function updateMouseCursor() {
         case 'plumbingV2':
             // Boru aracı seçiliyse veya boru çizim modu aktifse özel cursor göster
             if (plumbingManager.activeTool === 'boru' || plumbingManager.interactionManager?.boruCizimAktif) {
-                // Custom SVG cursor for pipe drawing
-                modeCursorStyle = "url('general-files/pipe-cursor.svg') 4 20, crosshair";
+                // Custom SVG cursor for pipe drawing - hot spot kalemin ucunda (4, 22)
+                modeCursorStyle = "url('general-files/pipe-cursor.svg') 4 22, crosshair";
             } else {
                 modeCursorStyle = 'crosshair';
             }


### PR DESCRIPTION
Boru çizerken kalemin uç noktası tam çizimin aktif noktasına gelmiyor, biraz yukarıda kalıyordu.

Cursor hot spot koordinatı (4, 20)'den (4, 22)'ye değiştirildi. Artık kalemin ucu tam tıklama/çizim noktasına geliyor.

SVG: 24x24px, 225° döndürülmüş kalem
Hot spot: Kalemin ucu (sol alt köşe yakınında)