### PR TITLE
Boru ölçü gösterimi düzeltmeleri

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -498,7 +498,7 @@ export class InteractionManager {
      * Ölçüyü uygula (Enter tuşuna basıldığında)
      */
     applyMeasurement() {
-        if (!this.boruBaslangic || !this.geciciBoruBitis) return;
+        if (!this.boruBaslangic) return;
 
         const measurement = parseFloat(this.measurementInput);
         if (isNaN(measurement) || measurement <= 0) {
@@ -508,8 +508,41 @@ export class InteractionManager {
             return;
         }
 
+        // Eğer geciciBoruBitis yoksa veya geçersizse, yönü hesapla
+        let targetPoint = this.geciciBoruBitis;
+
+        if (!targetPoint) {
+            // Varsayılan yön: sağa doğru (pozitif X ekseni)
+            targetPoint = {
+                x: this.boruBaslangic.nokta.x + measurement,
+                y: this.boruBaslangic.nokta.y
+            };
+        } else {
+            // Mevcut yönü kullanarak ölçüyü uygula
+            const dx = targetPoint.x - this.boruBaslangic.nokta.x;
+            const dy = targetPoint.y - this.boruBaslangic.nokta.y;
+            const currentLength = Math.hypot(dx, dy);
+
+            if (currentLength > 0.1) {
+                // Yönü normalize et ve ölçü kadar uzat
+                const dirX = dx / currentLength;
+                const dirY = dy / currentLength;
+
+                targetPoint = {
+                    x: this.boruBaslangic.nokta.x + dirX * measurement,
+                    y: this.boruBaslangic.nokta.y + dirY * measurement
+                };
+            } else {
+                // Çok kısa mesafe, varsayılan yön kullan
+                targetPoint = {
+                    x: this.boruBaslangic.nokta.x + measurement,
+                    y: this.boruBaslangic.nokta.y
+                };
+            }
+        }
+
         // Boruyu oluştur
-        this.handleBoruClick(this.geciciBoruBitis);
+        this.handleBoruClick(targetPoint);
 
         // Ölçü girişini sıfırla
         this.measurementInput = '';

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -586,8 +586,8 @@ export class PlumbingRenderer {
             const config = BORU_TIPLERI[pipe.boruTipi] || BORU_TIPLERI.STANDART;
             const width = config.lineWidth;
 
-            // Ölçü offset (boruya temas etmeden, biraz yukarıda)
-            const offset = width / 2 + 3; // 3cm yukarı
+            // Ölçü offset (boruya temas etmeden, en yakınına)
+            const offset = width / 2 + 1; // 1cm yukarı
 
             // Normal vektör (boruya dik)
             const normalX = -Math.sin(angle);
@@ -614,21 +614,7 @@ export class PlumbingRenderer {
             const roundedLength = Math.round(length);
             const displayText = roundedLength.toString();
 
-            // Yazı genişliğini ölç
-            const metrics = ctx.measureText(displayText);
-            const textWidth = metrics.width;
-            const padding = 2;
-
-            // Transparent arka plan
-            ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
-            ctx.fillRect(
-                -textWidth / 2 - padding,
-                -actualFontSize / 2 - padding,
-                textWidth + padding * 2,
-                actualFontSize + padding * 2
-            );
-
-            // Yazıyı çiz
+            // Yazıyı çiz (arka plan yok)
             const adjustedTextColor = getAdjustedColor('#000', 'boru');
             ctx.fillStyle = adjustedTextColor;
             ctx.textAlign = "center";
@@ -666,7 +652,7 @@ export class PlumbingRenderer {
 
         // Ölçü offset
         const width = 4; // geçici boru genişliği
-        const offset = width / 2 + 3;
+        const offset = width / 2 + 1;
 
         // Normal vektör
         const normalX = -Math.sin(angle);
@@ -693,21 +679,7 @@ export class PlumbingRenderer {
         const roundedLength = Math.round(length);
         const displayText = roundedLength.toString();
 
-        // Yazı genişliğini ölç
-        const metrics = ctx.measureText(displayText);
-        const textWidth = metrics.width;
-        const padding = 2;
-
-        // Transparent arka plan (geçici için biraz daha açık)
-        ctx.fillStyle = 'rgba(255, 255, 200, 0.9)';
-        ctx.fillRect(
-            -textWidth / 2 - padding,
-            -actualFontSize / 2 - padding,
-            textWidth + padding * 2,
-            actualFontSize + padding * 2
-        );
-
-        // Yazıyı çiz (geçici için farklı renk)
+        // Yazıyı çiz (geçici için farklı renk, arka plan yok)
         const adjustedTextColor = getAdjustedColor('#FF6600', 'boru');
         ctx.fillStyle = adjustedTextColor;
         ctx.textAlign = "center";


### PR DESCRIPTION
Düzeltmeler:
- Ölçü arka planı tamamen kaldırıldı (transparent yerine hiç arka plan yok)
- Ölçü konumu boruya daha yakın yapıldı (3cm -> 1cm offset)
- Klavyeden ölçü girişi ile çizim hatası düzeltildi
  - Enter'a basıldığında mouse hareket etmese bile doğru yöne çiziyor
  - Mevcut mouse yönü kullanılarak ölçü uygulanıyor
  - Mouse hareket etmediyse varsayılan yön (sağa) kullanılıyor

Teknik detaylar:
- applyMeasurement() fonksiyonu yön hesaplama ile güncellendi
- Arka plan render kodu kaldırıldı
- Offset değerleri optimize edildi