### PR TITLE
D kısayolu ile tesisat ölçülendirme kontrolü eklendi

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -37,8 +37,9 @@ export class PlumbingRenderer {
             ctx.restore();
         }
 
-        // Boru ölçüleri (MİMARİ modunda gizle)
-        if (!shouldBeFaded) {
+        // Boru ölçüleri (MİMARİ modunda veya dimensionMode=0 ise gizle)
+        const showMeasurements = !shouldBeFaded && state.dimensionMode !== 0;
+        if (showMeasurements) {
             this.drawPipeMeasurements(ctx, manager.pipes);
 
             // Geçici boru ölçüsü


### PR DESCRIPTION
Özellik:
- D kısayolu (dimension mode) artık tesisat ölçülerini de kontrol ediyor
- dimensionMode = 0 (Kapalı): Tesisat ölçüleri GİZLİ
- dimensionMode = 1 (Özet): Tesisat ölçüleri GÖRÜNÜR
- dimensionMode = 2 (Detaylı): Tesisat ölçüleri GÖRÜNÜR

Teknik detay:
- plumbing-renderer.js: showMeasurements kontrolüne dimensionMode eklendi
- Mimari modda zaten gizli (shouldBeFaded kontrolü korundu)