### PR TITLE
Servis kutusu seçim gösterimi ve boru gövde taşıma düzeltildi

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -829,16 +829,18 @@ export class InteractionManager {
                 offsetY = dy;
             }
 
-            // Her iki ucu da taşı
-            const oldP1 = { ...this.bodyDragInitialP1 };
-            const oldP2 = { ...this.bodyDragInitialP2 };
+            // ŞU ANKİ pozisyonları kaydet (henüz güncellenmeden önce)
+            const oldP1 = { x: pipe.p1.x, y: pipe.p1.y };
+            const oldP2 = { x: pipe.p2.x, y: pipe.p2.y };
 
+            // Her iki ucu da yeni pozisyona taşı
             pipe.p1.x = this.bodyDragInitialP1.x + offsetX;
             pipe.p1.y = this.bodyDragInitialP1.y + offsetY;
             pipe.p2.x = this.bodyDragInitialP2.x + offsetX;
             pipe.p2.y = this.bodyDragInitialP2.y + offsetY;
 
             // Bağlı boruları güncelle (her iki uç için)
+            // oldPoint = şu anki pozisyon, newPoint = yeni pozisyon
             this.updateConnectedPipesChain(oldP1, pipe.p1);
             this.updateConnectedPipesChain(oldP2, pipe.p2);
             return;

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -289,7 +289,10 @@ export class PlumbingRenderer {
 
         // Seçim göstergesi
         if (comp.isSelected) {
-            this.drawSelectionBox(ctx, comp);
+            // Servis kutusu için kesikli çizgi gösterme, renk değişimi yeterli
+            if (comp.type !== 'servis_kutusu') {
+                this.drawSelectionBox(ctx, comp);
+            }
             // Servis kutusu için döndürme tutamacı
             if (comp.type === 'servis_kutusu') {
                 this.drawRotationHandles(ctx, comp);
@@ -308,11 +311,12 @@ export class PlumbingRenderer {
         ctx.shadowOffsetY = 0;
 
         // Ana kutu
-        const adjustedColor = getAdjustedColor("rgba(206, 206, 206, 1)", 'servis_kutusu');
-        //const adjustedColor = getAdjustedColor("#0390a3", 'servis_kutusu');
+        const baseColor = "rgba(206, 206, 206, 1)";
+        const adjustedColor = getAdjustedColor(baseColor, 'servis_kutusu');
         const adjustedStroke = getAdjustedColor('#fff', 'servis_kutusu');
-       
-        ctx.fillStyle = adjustedColor;
+
+        // Seçiliyse renk değişsin
+        ctx.fillStyle = comp.isSelected ? this.secilenRenk : adjustedColor;
         ctx.strokeStyle = comp.isSelected ? this.secilenRenk : adjustedStroke;
         ctx.lineWidth = 2;
  


### PR DESCRIPTION
1. Servis kutusu seçilince:
   - Kesikli çizgi gösterilmiyor
   - Kutunun rengi mavi (#00BFFF) oluyor
   - Döndürme tutamacı görünüyor

2. Boru gövdesi taşırken:
   - Bağlı borular artık kopmuyor
   - Her frame'de şu anki pozisyondan yeni pozisyona geçiş yapılıyor
   - updateConnectedPipesChain doğru parametrelerle çağrılıyor