### PR TITLE
4 önemli düzeltme yapıldı

### DIFF
--- a/plumbing_v2/objects/service-box.js
+++ b/plumbing_v2/objects/service-box.js
@@ -193,12 +193,12 @@ export class ServisKutusu {
     }
 
     /**
-     * Serbest yerleştir (duvar dışı - yatay)
+     * Serbest yerleştir (duvar dışı - mevcut rotation korunur)
      */
     placeFree(point) {
         this.x = point.x;
         this.y = point.y;
-        this.rotation = 0; // Yatay
+        // Rotation'ı koru (kullanıcı manuel döndürdüyse kaybolmasın)
         this.snapliDuvar = null;
     }
 

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -575,29 +575,29 @@ export class PlumbingRenderer {
     }
 
     /**
-     * Döndürme tutamacı (servis kutusu için) - Merkezden çubuk çıkar
+     * Döndürme tutamacı (servis kutusu için) - Merkezden yukarı çubuk çıkar
      */
     drawRotationHandles(ctx, comp) {
-        const { width } = SERVIS_KUTUSU_CONFIG;
+        const { height } = SERVIS_KUTUSU_CONFIG;
 
-        // Döndürme çubuğu uzunluğu (kutu genişliğinden biraz daha uzun)
-        const handleLength = width / 2 + 15; // 15cm dışarıda
+        // Döndürme çubuğu uzunluğu (daha küçük - 10cm)
+        const handleLength = height / 2 + 10; // 10cm dışarıda
 
-        // Çubuğu çiz (merkezden sağa doğru, local koordinatlarda)
+        // Çubuğu çiz (merkezden yukarı doğru, local koordinatlarda)
         ctx.strokeStyle = this.secilenRenk;
-        ctx.lineWidth = 2;
+        ctx.lineWidth = 1.5;
         ctx.setLineDash([]);
         ctx.beginPath();
         ctx.moveTo(0, 0); // Merkezden başla
-        ctx.lineTo(handleLength, 0); // Sağa doğru
+        ctx.lineTo(0, -handleLength); // Yukarı doğru (negatif Y)
         ctx.stroke();
 
-        // Ucunda tutamaç (daire)
+        // Ucunda tutamaç (daire) - biraz daha küçük
         ctx.fillStyle = this.secilenRenk;
         ctx.strokeStyle = '#fff';
-        ctx.lineWidth = 2;
+        ctx.lineWidth = 1.5;
         ctx.beginPath();
-        ctx.arc(handleLength, 0, 5, 0, Math.PI * 2);
+        ctx.arc(0, -handleLength, 4, 0, Math.PI * 2);
         ctx.fill();
         ctx.stroke();
     }


### PR DESCRIPTION
1. Kutuya bağlı ilk boru gövdeden taşınamaz
   - startBodyDrag'den önce servis kutusu bağlantısı kontrol ediliyor

2. Döndürme tutamacı yukarı yönde ve küçük
   - Tutamaç merkezden yukarı çıkıyor (0, -handleLength)
   - Boyut küçültüldü (10cm)
   - findRotationHandleAt güncellenedi

3. Döndürülmüş kutu rotation'ını koruyor
   - placeFree artık rotation'ı sıfırlamıyor
   - Manuel döndürülmüş kutu taşınınca rotation korunuyor

4. Boru ikonu aktifken boru ucuna tıklayınca çizim başlıyor
   - Tool priority düzeltildi
   - activeTool === 'boru' ise uç sürükleme yerine çizim başlıyor