### PR TITLE
Servis kutusu boru bağlantısı ve duvar sürükleme düzeltmeleri

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -347,7 +347,7 @@ export class InteractionManager {
         // Servis kutusu - duvara snap (yerleştirme için useBoxPosition=false)
         if (ghost.type === 'servis_kutusu') {
             const walls = state.walls;
-            const snapDistance = 30; // 30cm içinde snap yap
+            const snapDistance = 15; // 15cm içinde snap yap
 
             // En yakın duvarı bul
             let closestWall = null;
@@ -795,7 +795,7 @@ export class InteractionManager {
 
             // Sticky snap: Eğer kutu zaten snaplıysa, daha geniş threshold kullan
             const isCurrentlySnapped = this.dragObject.snapliDuvar !== null;
-            const snapDistance = isCurrentlySnapped ? 80 : 40; // Snaplıysa 80cm, değilse 40cm
+            const snapDistance = isCurrentlySnapped ? 30 : 15; // Snaplıysa 30cm, değilse 15cm
 
             // En yakın duvarı bul
             let closestWall = null;

--- a/plumbing_v2/objects/service-box.js
+++ b/plumbing_v2/objects/service-box.js
@@ -145,19 +145,19 @@ export class ServisKutusu {
             const dy = wall.p2.y - wall.p1.y;
             const len = Math.hypot(dx, dy);
 
-            // Taşıma sırasında mevcut kutu pozisyonunu kullan, yoksa mouse pozisyonunu
-            const referencePoint = useBoxPosition ? { x: this.x, y: this.y } : point;
+            // PROJEKSİYON için her zaman MOUSE pozisyonunu kullan (duvar boyunca hareket için)
+            const projectionPoint = point;
 
-            // Noktayı duvar merkez çizgisine projeksiyon yap (referencePoint kullan)
+            // Noktayı duvar merkez çizgisine projeksiyon yap
             // t değerini 0-1 arası sınırla (duvar segmenti içinde kalsın)
             const t = Math.max(0, Math.min(1,
-                ((referencePoint.x - wall.p1.x) * dx + (referencePoint.y - wall.p1.y) * dy) / (len * len)
+                ((projectionPoint.x - wall.p1.x) * dx + (projectionPoint.y - wall.p1.y) * dy) / (len * len)
             ));
             const projX = wall.p1.x + t * dx;
             const projY = wall.p1.y + t * dy;
 
-            // Referans noktanın duvarın hangi tarafında olduğunu bul (cross product)
-            // Taşıma sırasında kutu pozisyonuna göre taraf belirlenir, böylece taraf değişmez
+            // TARAF BELİRLEME için: Taşıma sırasında kutu pozisyonunu, ilk yerleştirmede mouse kullan
+            const referencePoint = useBoxPosition ? { x: this.x, y: this.y } : point;
             const toPointX = referencePoint.x - wall.p1.x;
             const toPointY = referencePoint.y - wall.p1.y;
             const cross = dx * toPointY - dy * toPointX;


### PR DESCRIPTION
4 önemli düzeltme yapıldı:

1. Boru ucu taşıma kontrolü:
   - Servis kutusuna bağlı boru ucu artık taşınamaz
   - Sadece seçilebilir, kutu ile birlikte hareket eder

2. Duvar boyunca sürükleme düzeltildi:
   - snapToWall() projeksiyon için mouse pozisyonunu kullanıyor
   - Taraf belirleme için kutu pozisyonunu kullanıyor
   - Kutu artık duvar boyunca rahatça sürüklenebiliyor

3. Snap mesafesi optimize edildi:
   - Ghost yerleştirme: 15cm
   - İlk snap: 15cm
   - Sticky snap (snaplıyken): 30cm
   - Daha az agresif, daha kontrollü

4. Sticky snap mekanizması korundu:
   - Snaplıyken 30cm threshold ile kolay kopmaz
   - Snap yokken 15cm ile daha hassas