### PR TITLE
DELETE tuşu ile boru silme düzeltildi

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -268,7 +268,16 @@ export function handleDelete() {
         const objType = selectedObjectSnapshot.type;
         console.log('🔍 Deleting single object, type:', objType);
 
-        if (objType === 'column') {
+        // Plumbing v2 nesneleri için (boru, servis kutusu, sayaç, vana, cihaz)
+        if (objType === 'pipe' || objType === 'boru' || objType === 'servis_kutusu' || objType === 'sayac' || objType === 'vana' || objType === 'cihaz') {
+            // plumbingManager v2'nin kendi silme mekanizmasını kullan
+            const plumbingManager = window.plumbingManager;
+            if (plumbingManager && plumbingManager.interactionManager) {
+                plumbingManager.interactionManager.deleteSelectedObject();
+                deleted = true;
+            }
+        }
+        else if (objType === 'column') {
             state.columns = state.columns.filter(c => c !== selectedObjectSnapshot.object);
             deleted = true;
         }

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -10,7 +10,7 @@ import { Sayac, createSayac } from '../objects/meter.js';
 import { Vana, createVana } from '../objects/valve.js';
 import { Cihaz, createCihaz } from '../objects/device.js';
 import { screenToWorld } from '../../draw/geometry.js';
-import { dom, state, setMode } from '../../general-files/main.js';
+import { dom, state, setMode, setState } from '../../general-files/main.js';
 import { saveState } from '../../general-files/history.js';
 
 // Tool modları
@@ -612,6 +612,15 @@ export class InteractionManager {
         }
         this.selectedObject = obj;
         obj.isSelected = true;
+
+        // state.selectedObject'i de set et (DELETE tuşu için)
+        setState({
+            selectedObject: {
+                type: obj.type === 'boru' ? 'pipe' : obj.type,
+                object: obj,
+                handle: 'body'
+            }
+        });
     }
 
     deselectObject() {
@@ -619,6 +628,9 @@ export class InteractionManager {
             this.selectedObject.isSelected = false;
             this.selectedObject = null;
         }
+
+        // state.selectedObject'i de temizle
+        setState({ selectedObject: null });
     }
 
     deleteSelectedObject() {


### PR DESCRIPTION
Sorun:
- Boru seçilip DELETE tuşuna basılınca "Nothing selected to delete" hatası
- interactionManager.selectedObject set ediliyordu ama state.selectedObject değil
- input.js'deki handleDelete, state.selectedObject'e bakıyor

Çözüm:

1. INTERACTION MANAGER:
   - setState import eklendi
   - selectObject: state.selectedObject'i de set ediyor
   - deselectObject: state.selectedObject'i de temizliyor
   - Boru tipi 'pipe' olarak kaydediliyor (input.js uyumu için)

2. INPUT.JS:
   - handleDelete'e plumbing v2 desteği eklendi
   - Eğer tip 'pipe', 'boru', 'servis_kutusu', 'sayac', 'vana', 'cihaz' ise
   - plumbingManager.interactionManager.deleteSelectedObject() çağrılıyor
   - Böylece tüm silme mantığı (zincir güncelleme, vb.) korunuyor

Sonuç:
✅ DELETE tuşu çalışıyor
✅ Borular silinebiliyor
✅ Zincir güncelleme çalışıyor
✅ Tüm plumbing v2 nesneleri DELETE ile silinebiliyor