### PR TITLE
Servis kutusuna bağlı ilk boru silme engellendi

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -636,10 +636,20 @@ export class InteractionManager {
     deleteSelectedObject() {
         if (!this.selectedObject) return;
 
+        const obj = this.selectedObject;
+
+        // Servis kutusuna bağlı ilk boru silinemesin
+        if (obj.type === 'boru') {
+            const pipe = obj;
+            // Başlangıcı servis kutusuna bağlı mı kontrol et
+            if (pipe.baslangicBaglanti && pipe.baslangicBaglanti.tip === BAGLANTI_TIPLERI.SERVIS_KUTUSU) {
+                alert('⚠️ Servis kutusuna bağlı ilk boru silinemez!\n\nÖnce servis kutusunu silin veya başka bir boru ekleyin.');
+                return;
+            }
+        }
+
         // Undo için state kaydet
         saveState();
-
-        const obj = this.selectedObject;
 
         if (obj.type === 'servis_kutusu') {
             if (confirm(obj.getDeleteInfo().uyari)) {


### PR DESCRIPTION
Servis kutusuna bağlı ilk boru artık silinemez:

- deleteSelectedObject'te kontrol eklendi
- Eğer boru.baslangicBaglanti.tip === SERVIS_KUTUSU ise
- Alert gösteriliyor: "Servis kutusuna bağlı ilk boru silinemez!"
- Silme işlemi iptal ediliyor (saveState çağrılmıyor)
- Kullanıcıya servis kutusunu silmesi veya başka boru eklemesi öneriliyor

Neden:
- Servis kutusu her zaman bir boruya bağlı olmalı
- İlk boru silinirse servis kutusu bağlantısız kalır
- Bu tesisat mantığına aykırı

Çözüm:
✅ İlk boru korunuyor
✅ Diğer borular silinebiliyor
✅ Servis kutusu silinirse tüm bağlı borular da silinir