### PR TITLE
3 kritik düzeltme: Servis kutusu silme, sürekli snap, boru kalınlığı

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -91,10 +91,21 @@ export class PlumbingRenderer {
             const length = Math.hypot(dx, dy);
             const angle = Math.atan2(dy, dx);
 
-            // Zoom kompenzasyonu - uzaklaştıkça çok hızlı incelmesin
+            // Zoom kompenzasyonu - 5x zoom'a kadar sabit, sonra incelmeye başla
             const zoom = state.zoom || 1;
-            const zoomCompensation = Math.pow(zoom, 0.6); // 0.6: incelme oranı (küçültülürse daha yavaş incelir)
-            const width = config.lineWidth ;
+            const ZOOM_THRESHOLD = 5.0; // 5x zoom'a kadar sabit kalınlık
+            let effectiveZoom = zoom;
+
+            if (zoom < ZOOM_THRESHOLD) {
+                // 5x'e kadar zoom faktörü 1 (sabit kalınlık)
+                effectiveZoom = 1;
+            } else {
+                // 5x'ten sonra zoom faktörünü normalize et (5x = 1 olacak şekilde)
+                effectiveZoom = zoom / ZOOM_THRESHOLD;
+            }
+
+            const zoomCompensation = Math.pow(effectiveZoom, 0.4); // 0.4: incelme oranı
+            const width = config.lineWidth / zoomCompensation;
 
             ctx.save();
 


### PR DESCRIPTION
1. SERVİS KUTUSU SİLME DÜZELTİLDİ: Sorun: Servis kutusu silinince tesisat duruyor, borular kalıyor

   Çözüm:
   - removeObject'te servis_kutusu kontrolü eklendi
   - Bağlı boruId bulunuyor (bagliBoruId)
   - findConnectedPipesChain ile tüm boru zinciri bulunuyor
   - Tüm zincir siliniyor

   Sonuç: Servis kutusu silinince bağlı tüm borular da siliniyor ✅

2. SÜREKLI SNAP SİSTEMİ: Sorun: Snap sadece ilk anda yakalayıp bırakıyor, mouse hareket ederken yeni snap aramıyor

   Çözüm:
   - Sticky lock mekanizması kaldırıldı (125+ satır gereksiz kod silindi)
   - Her handleDrag çağrısında yeni snap aranıyor
   - Mouse yakınlıkta olduğu sürece snap aktif
   - Uzaklaşınca otomatik serbest bırakılıyor

   Sonuç: Mouse hareket ettikçe sürekli snap pozisyonları yakalıyor ✅

3. BORU KALINLIĞI ZOOM: Sorun: Zoom yapınca boru hemen inciliyor

   Çözüm:
   - ZOOM_THRESHOLD = 5.0 eklendi
   - 1x - 5x arası: effectiveZoom = 1 (sabit kalınlık)
   - 5x üzeri: effectiveZoom = zoom/5 (incelme başlıyor)
   - zoomCompensation üssü 0.4 (yavaş incelme)

   Sonuç: 5x zoom'a kadar boru kalınlığı sabit ✅

BONUS: 125+ satır gereksiz kod (duplicate snap mekanizması) temizlendi