### PR TITLE
Boru undo bug'ı düzeltildi: Sürükleme işlemleri artık undo history'ye…

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -224,6 +224,7 @@ export function handleDelete() {
 
     let deleted = false;
     let isGuideDeleted = false;
+    let isPlumbingV2Deleted = false; // Flag for v2 plumbing objects
 
     // Önce selectedGroup'u kontrol et (toplu silme)
     if (selectedGroupSnapshot.length > 0) {
@@ -275,6 +276,7 @@ export function handleDelete() {
             if (plumbingManager && plumbingManager.interactionManager) {
                 plumbingManager.interactionManager.deleteSelectedObject();
                 deleted = true;
+                isPlumbingV2Deleted = true; // v2 already called saveState()
             }
         }
         else if (objType === 'column') {
@@ -443,7 +445,10 @@ export function handleDelete() {
         if (!isGuideDeleted) {
             processWalls();
         }
-        saveState();
+        // V2 plumbing objects already called saveState() in their delete handler
+        if (!isPlumbingV2Deleted) {
+            saveState();
+        }
         update3DScene();
     } else {
         console.warn('❌ Delete failed - nothing was deleted');

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -1043,6 +1043,7 @@ export class InteractionManager {
         this.pipeEndpointSnapLock = null; // Snap lock'u temizle
         this.pipeSnapMouseStart = null; // Mouse start pozisyonunu temizle
         this.manager.saveToState();
+        saveState(); // Save to undo history
     }
 
     /**
@@ -1146,6 +1147,7 @@ export class InteractionManager {
         this.dragObject = null;
         this.rotationOffset = 0;
         this.manager.saveToState();
+        saveState(); // Save to undo history
     }
 
     updateConnectedPipe(result) {


### PR DESCRIPTION
… kaydediliyor

Ana Sorun:
- Boru/tesisat elemanları sürüklenirken (drag/rotate) işlemler undo history'sine kaydedilmiyordu
- Undo yapıldığında elemanlar en son kaydedilen hale dönüyor ve kaybolmuş gibi görünüyordu

Düzeltmeler:
1. interaction-manager.js: endDrag() fonksiyonuna saveState() eklendi
2. interaction-manager.js: endRotation() fonksiyonuna saveState() eklendi
3. input.js: V2 tesisat nesneleri için gereksiz duplicate saveState() çağrısı engellendi

Şimdi sürükleme, döndürme ve silme işlemlerinin hepsi undo history'ye doğru şekilde kaydediliyor.