### PR TITLE
Mod izolasyonu: Mimari ve tesisat modları arasında tam izolasyon sağl…

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -691,36 +691,55 @@ export function getObjectOpacity_OLD(objectType) {
     return 1.0;
 }
 
+// Tesisat modunda mı kontrol eder
+export function isInPlumbingMode() {
+    const mode = state.currentMode;
+    return mode === 'plumbingV2' ||
+           mode === 'drawPlumbingPipe' ||
+           mode === 'drawPlumbingBlock';
+}
+
+// Mimari modunda mı kontrol eder
+export function isInArchitecturalMode() {
+    const mode = state.currentMode;
+    // Tesisat modları dışında kalan tüm modlar mimari modlarıdır
+    return !isInPlumbingMode() && mode !== 'MİMARİ-TESİSAT';
+}
+
+// Karma modda mı kontrol eder (hem tesisat hem mimari)
+export function isInMixedMode() {
+    return state.currentMode === 'MİMARİ-TESİSAT';
+}
+
 // Nesne tipine göre aktif modda dokunulabilir mi kontrol eder
 export function isObjectInteractable(objectType) {
-    const mode = state.currentDrawingMode;
-
-    // KARMA modunda her şeye dokunulabilir
-    if (mode === "KARMA") {
+    // Karma modunda her şeye dokunulabilir
+    if (isInMixedMode()) {
         return true;
     }
 
     // Mimari nesneler listesi
     const architecturalObjects = [
-        'wall', 'door', 'window', 'room', 'roomName', 'roomArea', 'column', 'beam', 'stair', 'stairs', 'arcControl'
+        'wall', 'door', 'window', 'room', 'roomName', 'roomArea', 'column', 'beam', 'stair', 'stairs', 'arcControl', 'vent'
     ];
 
     // Tesisat nesneleri listesi
     const plumbingObjects = [
-        'plumbing', 'pipe', 'boru', 'servis_kutusu', 'sayac', 'vana', 'cihaz', 'plumbingPipe', 'plumbingComponent'
+        'plumbing', 'pipe', 'boru', 'servis_kutusu', 'sayac', 'vana', 'cihaz',
+        'plumbingPipe', 'plumbingComponent', 'plumbingBlock'
     ];
 
-    const isArchitectural = architecturalObjects.includes(objectType);
-    const isPlumbing = plumbingObjects.includes(objectType);
+    const isArchitecturalObject = architecturalObjects.includes(objectType);
+    const isPlumbingObject = plumbingObjects.includes(objectType);
 
-    // MİMARİ modunda sadece mimari nesnelere dokunulabilir
-    if (mode === "MİMARİ") {
-        return isArchitectural;
+    // Tesisat modunda sadece tesisat nesnelerine dokunulabilir
+    if (isInPlumbingMode()) {
+        return isPlumbingObject;
     }
 
-    // TESİSAT modunda sadece tesisat nesnelerine dokunulabilir
-    if (mode === "TESİSAT") {
-        return isPlumbing;
+    // Mimari modunda sadece mimari nesnelere dokunulabilir
+    if (isInArchitecturalMode()) {
+        return isArchitecturalObject;
     }
 
     // Varsayılan: dokunulabilir

--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -11,7 +11,7 @@ import { onPointerDownDraw as onPointerDownDrawWindow, onPointerDownSelect as on
 import { hideGuideContextMenu } from '../menu/guide-menu.js';
 import { screenToWorld, findNodeAt, getOrCreateNode, isPointOnWallBody, distToSegmentSquared, snapTo15DegreeAngle } from '../draw/geometry.js';
 import { applySymmetry, applyCopy } from '../draw/symmetry.js';
-import { state, dom, setState, setMode } from '../general-files/main.js';
+import { state, dom, setState, setMode, isObjectInteractable } from '../general-files/main.js';
 import { getSmartSnapPoint } from '../general-files/snap.js';
 import { currentModifierKeys } from '../general-files/input.js';
 import { saveState } from '../general-files/history.js';
@@ -121,7 +121,8 @@ export function onPointerDown(e) {
         // CTRL ile multi-select modu (sadece CTRL basılıyken, body'ye tıklandığında)
         if (currentModifierKeys.ctrl && !currentModifierKeys.alt && !currentModifierKeys.shift && clickedObject &&
             ['column', 'beam', 'stairs', 'door', 'window', 'plumbingBlock', 'plumbingPipe'].includes(clickedObject.type) &&
-            clickedObject.handle === 'body') {
+            clickedObject.handle === 'body' &&
+            isObjectInteractable(clickedObject.type)) {
 
             let currentGroup = [...state.selectedGroup];
             if (currentGroup.length === 0 && state.selectedObject &&
@@ -148,6 +149,7 @@ export function onPointerDown(e) {
 
         if (!currentModifierKeys.ctrl && clickedObject &&
             ['column', 'beam', 'stairs', 'door', 'window', 'plumbingBlock', 'plumbingPipe'].includes(clickedObject.type) &&
+            isObjectInteractable(clickedObject.type) &&
             state.selectedGroup.length > 0) {
             // (selectedGroup'u temizle - aşağıda yapılıyor)
         }
@@ -181,6 +183,12 @@ export function onPointerDown(e) {
 
         // Tıklanan nesne varsa seçili yap ve sürüklemeyi başlat
         if (clickedObject) {
+            // Mod izolasyonu: nesne aktif modda dokunulabilir mi kontrol et
+            if (!isObjectInteractable(clickedObject.type)) {
+                console.log('🚫 Object not interactable in current mode:', clickedObject.type);
+                return;
+            }
+
             console.log('🎯 Object clicked:', clickedObject.type, 'handle:', clickedObject.handle);
             if (clickedObject.type === 'room') {
                 setState({ selectedRoom: clickedObject.object, selectedObject: null });


### PR DESCRIPTION
…andı

Sorunlar:
1. Mimari modda tesisat elemanları (servis kutusu, boru) seçilebiliyor ve taşınabiliyordu
2. Tesisat modunda mimari nesnelere (duvar, oda) sağ tıklanabiliyordu
3. Tesisat modunda mimari kısayollar (K, P, C, B, M) çalışıyordu

Düzeltmeler:

1. main.js:
   - isObjectInteractable() fonksiyonu yeniden yazıldı
   - Yeni helper fonksiyonlar eklendi: isInPlumbingMode(), isInArchitecturalMode(), isInMixedMode()
   - 'plumbingBlock' tesisat nesneleri listesine eklendi
   - state.currentMode kullanılarak doğru mod kontrolü yapılıyor

2. pointer-down.js:
   - Select modunda nesne seçiminde isObjectInteractable() kontrolü eklendi
   - Multi-select (CTRL) modunda da aynı kontrol eklendi
   - Artık mimari modda tesisat nesneleri seçilemiyor

3. input.js:
   - Context menu (sağ tık) handler'ına mod kontrolü eklendi
   - Tesisat modunda mimari nesnelere sağ tıklama engellendi
   - Klavye kısayolları mod kontrolü ile ayrıldı:
     * Mimari kısayollar (W, R, K, P, C, B, M, S) tesisat modunda çalışmaz
     * Tesisat kısayolu (T) mimari modunda çalışmaz

Sonuç: Artık her mod sadece kendi nesneleriyle etkileşime geçiyor.