### PR TITLE
FIX: Fleks bitiş noktası cihazın İÇİNE uzanıyor - rotate'de kopmuyor

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -580,8 +580,8 @@ export class InteractionManager {
                 ghost.rotation = 0;
 
                 // Fleks uzunluğu + cihaz yarı genişliği = toplam mesafe
-                // Fleks 5 cm - rotate olunca borudan kopmaması ve cihaz içine daha fazla uzanması için
-                const fleksUzunluk = 5; // cm
+                // Fleks bitiş noktası artık cihazın içine doğru uzandığı için 20 cm yeterli
+                const fleksUzunluk = 20; // cm
                 const cihazYariGenislik = ghost.config.width / 2;
                 const toplamMesafe = fleksUzunluk + cihazYariGenislik;
 
@@ -1048,8 +1048,8 @@ export class InteractionManager {
         const length = Math.hypot(dx, dy);
 
         // Fleks uzunluğu + cihaz yarı genişliği = toplam mesafe
-        // Fleks 5 cm - rotate olunca borudan kopmaması ve cihaz içine daha fazla uzanması için
-        const fleksUzunluk = 5; // cm
+        // Fleks bitiş noktası artık cihazın içine doğru uzandığı için 20 cm yeterli
+        const fleksUzunluk = 20; // cm
         const cihazYariGenislik = cihaz.config.width / 2;
         const toplamMesafe = fleksUzunluk + cihazYariGenislik;
 

--- a/plumbing_v2/objects/device.js
+++ b/plumbing_v2/objects/device.js
@@ -280,13 +280,37 @@ export class Cihaz {
 
     /**
      * Fleks çizgi noktaları
+     * KRITIK: Fleks bitiş noktası cihazın en yakın kenarından MERKEZINE doğru uzanır
      */
     getFleksCizgi() {
         if (!this.fleksBaglanti.baglantiNoktasi) return null;
 
+        const girisNoktasi = this.getGirisNoktasi();
+        const merkez = { x: this.x, y: this.y };
+
+        // Girişten merkeze doğru vektör
+        const dx = merkez.x - girisNoktasi.x;
+        const dy = merkez.y - girisNoktasi.y;
+        const uzunluk = Math.hypot(dx, dy);
+
+        // İçeri margin - fleks bitiş noktası cihazın içine doğru uzansın
+        const iceriMargin = 10; // cm
+
+        let bitis;
+        if (uzunluk > iceriMargin) {
+            // Girişten merkeze doğru iceriMargin kadar git
+            bitis = {
+                x: girisNoktasi.x + (dx / uzunluk) * iceriMargin,
+                y: girisNoktasi.y + (dy / uzunluk) * iceriMargin
+            };
+        } else {
+            // Eğer giriş zaten merkeze çok yakınsa, merkezi kullan
+            bitis = merkez;
+        }
+
         return {
             baslangic: this.fleksBaglanti.baglantiNoktasi,
-            bitis: this.getGirisNoktasi()
+            bitis: bitis
         };
     }
 


### PR DESCRIPTION
SORUN:
1. Fleks bitiş noktası sadece en yakın kenardaydı (kopuk görünüyordu)
2. Rotate yaparken fleks bağlantısı kopuyordu
3. Önceki çözüm aptalcaydı (sadece kısaltmıştım)

ÇÖZÜM:
1. device.js getFleksCizgi():
   - Fleks bitiş = en yakın kenar + (merkeze doğru 10 cm)
   - Artık cihazın İÇİNE doğru uzanıyor ✓

2. Fleks uzunluğu tekrar 20 cm (normal mesafe)
   - toplamMesafe = 20 + 15 = 35 cm

3. Rotate yaparken:
   - yenidenHesaplaGirisOffset() en yakın kenarı buluyor
   - Fleks bağlantısı güncelleniyor
   - Ama fleks BORUDAN ASLA kopmuyor! ✓

SONUÇ: Fleks artık cihazın içine doğru uzanıyor ve rotate kopmuyor!