### PR TITLE
FIX: Ghost'ta fleks GÖRÜNÜYor + Fleks 15cm içeri - kopmuyor!

### DIFF
--- a/plumbing_v2/objects/device.js
+++ b/plumbing_v2/objects/device.js
@@ -294,7 +294,8 @@ export class Cihaz {
         const uzunluk = Math.hypot(dx, dy);
 
         // İçeri margin - fleks bitiş noktası cihazın içine doğru uzansın
-        const iceriMargin = 10; // cm
+        // 15 cm - rotate ederken kopmaması için daha fazla içeri uzatıldı
+        const iceriMargin = 15; // cm
 
         let bitis;
         if (uzunluk > iceriMargin) {

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1590,7 +1590,31 @@ export class PlumbingRenderer {
             ctx.restore();
         }
 
-        // 2. Fleks çizgisi (boru ucundan cihaz giriş noktasına)
+        // 2. Fleks çizgisi (boru ucundan cihazın içine doğru)
+        // Cihazın en yakın kenarını ve merkeze doğru bitiş noktasını hesapla
+        const girisNoktasi_cihaz = ghost.getGirisNoktasi();
+        const merkez = { x: ghost.x, y: ghost.y };
+
+        // Girişten merkeze doğru vektör
+        const dx_flex = merkez.x - girisNoktasi_cihaz.x;
+        const dy_flex = merkez.y - girisNoktasi_cihaz.y;
+        const uzunluk_flex = Math.hypot(dx_flex, dy_flex);
+
+        // İçeri margin - fleks bitiş noktası cihazın içine doğru uzansın
+        const iceriMargin = 15; // cm - ghost için daha belirgin olsun
+
+        let fleksBitis;
+        if (uzunluk_flex > iceriMargin) {
+            // Girişten merkeze doğru iceriMargin kadar git
+            fleksBitis = {
+                x: girisNoktasi_cihaz.x + (dx_flex / uzunluk_flex) * iceriMargin,
+                y: girisNoktasi_cihaz.y + (dy_flex / uzunluk_flex) * iceriMargin
+            };
+        } else {
+            // Eğer giriş zaten merkeze çok yakınsa, merkezi kullan
+            fleksBitis = merkez;
+        }
+
         ctx.globalAlpha = 0.6;
         ctx.strokeStyle = '#FFD700'; // Sarı
         ctx.lineWidth = 2;
@@ -1598,7 +1622,7 @@ export class PlumbingRenderer {
 
         ctx.beginPath();
         ctx.moveTo(boruUcu.nokta.x, boruUcu.nokta.y);
-        ctx.lineTo(girisNoktasi.x, girisNoktasi.y);
+        ctx.lineTo(fleksBitis.x, fleksBitis.y);
         ctx.stroke();
 
         ctx.setLineDash([]); // Reset dash


### PR DESCRIPTION
SORUNLAR:
1. Ghost'ta fleks görünmüyordu (başlangıç=bitiş=boru ucu)
2. Fleks kısa kalıyordu, kopuyordu
3. Rotate'de hala sorun vardı

ÇÖZÜMLER:

1. plumbing-renderer.js drawCihazGhostConnection():
   - Fleks başlangıcı: boru ucu ✓
   - Fleks bitişi: cihazın giriş noktası + 15cm merkeze doğru ✓
   - Artık ghost'ta SARΙ fleks GÖRÜNÜYOR! ✓

2. device.js getFleksCizgi():
   - iceriMargin: 10cm → 15cm
   - Fleks cihazın DAHA İÇİNE uzanıyor ✓
   - Rotate ederken KOPMUYOR! ✓

3. Her iki yerde de aynı mantık (15cm içeri):
   - Ghost ve gerçek render tutarlı ✓
   - Fleks boru ucundan cihaz merkezine doğru uzanıyor ✓

SONUÇ: Ghost'ta fleks görünüyor, 15cm içeri uzanıyor, rotate'de kopmuyor!