### PR TITLE
FIX: Rotate ederken fleks KOPMUYOR artık!

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -2218,7 +2218,13 @@ export class InteractionManager {
         } else if (obj.type === 'cihaz') {
             // Cihaz: Merkez sabit, sadece rotation değişir
             obj.rotation = newRotationDeg;
-            // Fleks bağlantısını güncelle
+
+            // KRITIK: En yakın kenarı yeniden hesapla (fleks kopmaması için)
+            if (obj.yenidenHesaplaGirisOffset) {
+                obj.yenidenHesaplaGirisOffset();
+            }
+
+            // Fleks uzunluğunu güncelle
             if (obj.fleksGuncelle) {
                 obj.fleksGuncelle();
             }


### PR DESCRIPTION
SORUN:
- Cihaz rotate edildiğinde fleks KOPUYORDU
- handleRotation() sadece obj.rotation değiştiriyordu
- yenidenHesaplaGirisOffset() ÇAĞRILMIYORDU! ✗

NEDEN KOPUYORDU:
- Rotation değişince en yakın kenar değişiyor
- Ama girisOffset güncellenmiyordu
- Fleks eski kenardan çizilmeye çalışıyordu → KOPMA!

ÇÖZÜM:
interaction-manager.js handleRotation():

ÖNCEKI:
```javascript
obj.rotation = newRotationDeg;
if (obj.fleksGuncelle) {
    obj.fleksGuncelle();  // Sadece uzunluk
}
```

YENİ:
```javascript
obj.rotation = newRotationDeg;

// KRITIK: En yakın kenarı yeniden hesapla
if (obj.yenidenHesaplaGirisOffset) {
    obj.yenidenHesaplaGirisOffset();  // Kenar güncelle ✓
}

// Fleks uzunluğunu güncelle
if (obj.fleksGuncelle) {
    obj.fleksGuncelle();  // Uzunluk güncelle ✓
}
```

SONUÇ: Rotate ederken fleks ASLA kopmuyor! ✓