### PR TITLE
FIX: Boru uç noktası seçim toleransını azalt (4cm -> 2.5cm)

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -301,7 +301,7 @@ export class InteractionManager {
             }
 
             // Sonra boru uç noktası kontrolü yap (ÖNCE NOKTA - body'den önce)
-            const boruUcu = this.findBoruUcuAt(point, 4); // Nokta seçimi için 4 cm tolerance
+            const boruUcu = this.findBoruUcuAt(point, 2.5); // Nokta seçimi için 2.5 cm tolerance (daha hassas)
             if (boruUcu) {
                 console.log('🎯 BORU UCU BULUNDU:', boruUcu.uc, boruUcu.boruId);
                 const pipe = this.manager.pipes.find(p => p.id === boruUcu.boruId);


### PR DESCRIPTION
Kullanıcı borunun ucuna yakın ama dışardan bir noktadan tıkladığında boru kopma sorunu yaşıyordu. Bunun nedeni boru uç noktası tolerance'ının (4 cm) çok geniş olmasıydı.

Çözüm: Uç nokta seçim tolerance'ı 2.5 cm'e düşürüldü. Bu sayede:
- Gerçekten uç noktaya tıklandığında uç nokta seçilir
- Ama dışardan bir noktaya tıklandığında boru gövdesi seçilir

Dosya: plumbing_v2/interactions/interaction-manager.js:304