### PR TITLE
FIX: Boru seçimi sonrası Delete tuşu çalışmıyor sorunu düzeltildi

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -484,9 +484,28 @@ export class InteractionManager {
         }
 
         // Delete - seçili nesneyi sil
-        if (e.key === 'Delete' && this.selectedObject) {
-            this.deleteSelectedObject();
-            return true;
+        if (e.key === 'Delete') {
+            // Hem this.selectedObject hem de state.selectedObject'i kontrol et
+            if (this.selectedObject) {
+                this.deleteSelectedObject();
+                return true;
+            }
+            // Eğer this.selectedObject null ama state.selectedObject varsa, önce seç sonra sil
+            if (!this.selectedObject && state.selectedObject) {
+                const stateObj = state.selectedObject;
+                // V2 plumbing nesnesi mi kontrol et
+                if (stateObj && ['pipe', 'boru', 'servis_kutusu', 'sayac', 'vana', 'cihaz'].includes(stateObj.type)) {
+                    // Nesneyi bul ve seç
+                    const obj = stateObj.object;
+                    if (obj) {
+                        // this.selectedObject'i senkronize et
+                        this.selectedObject = obj;
+                        // Şimdi sil
+                        this.deleteSelectedObject();
+                        return true;
+                    }
+                }
+            }
         }
 
         // Ok tuşları - seçili boru navigasyonu


### PR DESCRIPTION
Problem: Kullanıcı 1. hattı (boruyu) seçtiğinde Delete tuşu çalışmıyordu. Ancak 2. hattı seçip ok tuşları ile geri geldiğinde Delete çalışıyordu.

Sebep: interaction-manager.js içindeki handleKeyDown fonksiyonu Delete kontrolünde sadece this.selectedObject'i kontrol ediyordu. Bazı durumlarda state.selectedObject set edilmiş olabilir ama this.selectedObject set edilmemiş olabilir.

Çözüm: Delete tuşu kontrolüne ek mantık eklendi. Eğer this.selectedObject null ama state.selectedObject varsa, önce nesne senkronize edilip sonra siliniyor.