### PR TITLE
feat: Update T shortcut to use plumbingV2 mode

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -842,7 +842,10 @@ function onKeyDown(e) {
     if (e.key.toLowerCase() === "c" && !e.ctrlKey && !e.altKey && !e.shiftKey) setMode("drawColumn");
     if (e.key.toLowerCase() === "b" && !e.ctrlKey && !e.altKey && !e.shiftKey) setMode("drawBeam");
     if (e.key.toLowerCase() === "m" && !e.ctrlKey && !e.altKey && !e.shiftKey) setMode("drawStairs");
-    if (e.key.toLowerCase() === "t" && !e.ctrlKey && !e.altKey && !e.shiftKey) setMode("drawPlumbingPipe"); // Tesisat borusu
+    if (e.key.toLowerCase() === "t" && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+        plumbingManager.startPipeMode(); // Boru çizim aracını başlat
+        setMode("plumbingV2", true); // UI'yı güncelle (ikonu aktif et)
+    }
     if (e.key.toLowerCase() === "s" && !e.ctrlKey && !e.altKey && !e.shiftKey && !inFPSMode) setMode("drawSymmetry"); // YENİ SATIR
 
 }


### PR DESCRIPTION
T shortcut now properly activates pipe drawing mode using plumbingManager.startPipeMode() and setMode("plumbingV2", true) to match the behavior of the pipe button in the UI.

Note: K/O shortcuts were already working correctly with ESCAPE logic and direct device placement.