### PR TITLE
fix: Correct K/O shortcut behavior for device placement

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -807,34 +807,6 @@ function onKeyDown(e) {
         }
     }
 
-    // YENİ: Kombi/Ocak hızlı ekleme kısayolu
-    if ((e.key.toLowerCase() === 'k' || e.key.toLowerCase() === 'o') && !inFPSMode && !e.ctrlKey && !e.altKey && !e.shiftKey) {
-        e.preventDefault();
-
-        // 1. Mevcut eylemleri doğrudan iptal et (Escape tuşu gibi)
-        if (state.isEditingLength) cancelLengthEdit();
-        setState({ selectedObject: null, selectedGroup: [] });
-        setState({ startPoint: null });
-        if (plumbingManager.interactionManager) {
-            // Bu fonksiyon hayalet boru gibi önizlemeleri iptal eder.
-            plumbingManager.interactionManager.cancelCurrentAction();
-        }
-        setMode("select");
-
-        // 2. Cihaz tipini belirle
-        const deviceType = e.key.toLowerCase() === 'k' ? 'KOMBI' : 'OCAK';
-
-        // 3. Cihazı yerleştir. State güncellemelerinin tamamlanması için kısa bir gecikme ekleyelim.
-        setTimeout(() => {
-            if (plumbingManager.placeDeviceAtOpenEnd(deviceType)) {
-                saveState();
-                update3DScene();
-            }
-        }, 0); // 0ms timeout, işlemi bir sonraki event loop'a erteler.
-
-        return; // Diğer kısayollarla çakışmaması için
-    }
-
     if (e.key.toLowerCase() === "d" && !inFPSMode) { const newMode = (state.dimensionMode + 1) % 3; setState({ dimensionMode: newMode }); state.dimensionOptions.defaultView = newMode; dom.dimensionDefaultViewSelect.value = newMode; }
     if (e.key.toLowerCase() === "w" && !e.ctrlKey && !e.altKey && !e.shiftKey && !inFPSMode) setMode("drawWall");
     if (e.key.toLowerCase() === "r" && !e.ctrlKey && !e.altKey && !e.shiftKey) setMode("drawRoom");

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -10,8 +10,9 @@ import { Sayac, createSayac } from '../objects/meter.js';
 import { Vana, createVana } from '../objects/valve.js';
 import { Cihaz, createCihaz } from '../objects/device.js';
 import { screenToWorld } from '../../draw/geometry.js';
-import { dom, state, setMode, setState } from '../../general-files/main.js';
+import { dom, state, setMode, setState, setDrawingMode } from '../../general-files/main.js';
 import { saveState } from '../../general-files/history.js';
+import { update3DScene } from '../../scene3d/scene3d-update.js';
 import { canPlaceValveOnPipe, getObjectsOnPipe } from '../utils/placement-utils.js';
 
 // Tool modları
@@ -446,47 +447,41 @@ handleKeyDown(e) {
 
     // K - Kombi ekle
     if (e.key === 'k' || e.key === 'K') {
-        // Eğer boru çiziyorsak, aktif noktaya cihaz ekle
-        if (this.boruCizimAktif && this.geciciBoruBitis) {
-            // Önce mevcut boruyu tamamla
-            this.handleBoruClick(this.geciciBoruBitis);
-            // Boru çizimini sonlandır
-            this.cancelCurrentAction();
-        }
+        // Mevcut eylemleri iptal et (ghost boruyu iptal et, onaylama)
+        this.cancelCurrentAction();
+        setMode("select");
 
         // TESİSAT moduna geç
         if (state.currentDrawingMode !== "KARMA") {
             setDrawingMode("TESİSAT");
         }
-        
-        // Kombi yerleştirme modunu başlat
-        this.manager.startPlacement(TESISAT_MODLARI.CIHAZ, { cihazTipi: 'KOMBI' });
-        
-        // UI ikonunu güncelle
-        setMode("plumbingV2", true);
+
+        // Boş uca direkt kombi ekle
+        if (this.manager.placeDeviceAtOpenEnd('KOMBI')) {
+            saveState();
+            update3DScene();
+        }
+
         return true;
     }
 
     // O - Ocak ekle
     if (e.key === 'o' || e.key === 'O') {
-        // Eğer boru çiziyorsak, aktif noktaya cihaz ekle
-        if (this.boruCizimAktif && this.geciciBoruBitis) {
-            // Önce mevcut boruyu tamamla
-            this.handleBoruClick(this.geciciBoruBitis);
-            // Boru çizimini sonlandır
-            this.cancelCurrentAction();
-        }
+        // Mevcut eylemleri iptal et (ghost boruyu iptal et, onaylama)
+        this.cancelCurrentAction();
+        setMode("select");
 
-        // TESİSAT modunda olduğumuzdan emin ol
+        // TESİSAT moduna geç
         if (state.currentDrawingMode !== "KARMA") {
             setDrawingMode("TESİSAT");
         }
 
-        // Ocak yerleştirme modunu başlat
-        this.manager.startPlacement(TESISAT_MODLARI.CIHAZ, { cihazTipi: 'OCAK' });
-        
-        // UI ikonunu güncelle
-        setMode("plumbingV2", true);
+        // Boş uca direkt ocak ekle
+        if (this.manager.placeDeviceAtOpenEnd('OCAK')) {
+            saveState();
+            update3DScene();
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Fixed three critical issues with K/O shortcuts:

1. **ESCAPE behavior**: K/O shortcuts now cancel ghost pipe instead of confirming it
   - Removed handleBoruClick call that was completing the ghost pipe
   - Now properly calls cancelCurrentAction() to cancel ongoing drawing

2. **Device placement**: Devices are now placed directly without waiting for icon click
   - Changed from startPlacement() to placeDeviceAtOpenEnd()
   - Added saveState() and update3DScene() calls after successful placement

3. **Empty endpoint detection**: Now correctly identifies truly empty pipe ends
   - Updated getBosBitisBorular() to check both p1 and p2 ends
   - Returns {pipe, end} object to specify which end is empty
   - Updated placeDeviceAtOpenEnd() to handle both baslangicBaglanti and bitisBaglanti

Changes:
- plumbing-manager.js: Enhanced getBosBitisBorular() and placeDeviceAtOpenEnd()
- interaction-manager.js: Fixed K/O handlers, added missing imports (setDrawingMode, update3DScene)
- input.js: Removed redundant K/O handler (interaction-manager handles it first)