### PR TITLE
fix: Proper empty endpoint detection and complete device placement

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -461,11 +461,10 @@ handleKeyDown(e) {
             setDrawingMode("TESİSAT");
         }
 
-        let devicePlaced = false;
+        let boruUcuInfo = null;
 
-        // Eğer aktif çizim noktası varsa, o boruya ekle
+        // Eğer aktif çizim noktası varsa, o boruyu kullan
         if (activeDrawPoint && activeDrawPoint.kaynakId) {
-            // Kaynak boruyu bul
             const sourcePipe = this.manager.findPipeById(activeDrawPoint.kaynakId);
             if (sourcePipe) {
                 // Hangi uçtan çizim başlatılmıştı?
@@ -474,39 +473,16 @@ handleKeyDown(e) {
                 const distToP2 = Math.hypot(point.x - sourcePipe.p2.x, point.y - sourcePipe.p2.y);
                 const endPoint = distToP1 < distToP2 ? 'p1' : 'p2';
 
-                // O uca direkt kombi ekle
-                const connectionPoint = sourcePipe[endPoint];
-                const floorId = sourcePipe.floorId || state.currentFloor?.id;
-                const newDevice = createCihaz(connectionPoint.x, connectionPoint.y, 'KOMBI', { floorId });
-
-                if (newDevice) {
-                    this.manager.components.push(newDevice);
-
-                    // Borunun bağlantısını güncelle
-                    if (endPoint === 'p1') {
-                        sourcePipe.baslangicBaglanti = {
-                            tip: 'cihaz',
-                            hedefId: newDevice.id,
-                            noktaIndex: 0
-                        };
-                    } else {
-                        sourcePipe.bitisBaglanti = {
-                            tip: 'cihaz',
-                            hedefId: newDevice.id,
-                            noktaIndex: 0
-                        };
-                    }
-
-                    this.manager.saveToState();
-                    saveState();
-                    update3DScene();
-                    devicePlaced = true;
-                }
+                boruUcuInfo = {
+                    pipe: sourcePipe,
+                    end: endPoint,
+                    point: sourcePipe[endPoint]
+                };
             }
         }
 
-        // Aktif çizim noktası yoksa veya ekleme başarısız olduysa, boş uca ekle
-        if (!devicePlaced && this.manager.placeDeviceAtOpenEnd('KOMBI')) {
+        // placeDeviceAtOpenEnd handleCihazEkleme kullanır - vana, fleks otomatik eklenir
+        if (this.manager.placeDeviceAtOpenEnd('KOMBI', boruUcuInfo)) {
             saveState();
             update3DScene();
         }
@@ -530,11 +506,10 @@ handleKeyDown(e) {
             setDrawingMode("TESİSAT");
         }
 
-        let devicePlaced = false;
+        let boruUcuInfo = null;
 
-        // Eğer aktif çizim noktası varsa, o boruya ekle
+        // Eğer aktif çizim noktası varsa, o boruyu kullan
         if (activeDrawPoint && activeDrawPoint.kaynakId) {
-            // Kaynak boruyu bul
             const sourcePipe = this.manager.findPipeById(activeDrawPoint.kaynakId);
             if (sourcePipe) {
                 // Hangi uçtan çizim başlatılmıştı?
@@ -543,39 +518,16 @@ handleKeyDown(e) {
                 const distToP2 = Math.hypot(point.x - sourcePipe.p2.x, point.y - sourcePipe.p2.y);
                 const endPoint = distToP1 < distToP2 ? 'p1' : 'p2';
 
-                // O uca direkt ocak ekle
-                const connectionPoint = sourcePipe[endPoint];
-                const floorId = sourcePipe.floorId || state.currentFloor?.id;
-                const newDevice = createCihaz(connectionPoint.x, connectionPoint.y, 'OCAK', { floorId });
-
-                if (newDevice) {
-                    this.manager.components.push(newDevice);
-
-                    // Borunun bağlantısını güncelle
-                    if (endPoint === 'p1') {
-                        sourcePipe.baslangicBaglanti = {
-                            tip: 'cihaz',
-                            hedefId: newDevice.id,
-                            noktaIndex: 0
-                        };
-                    } else {
-                        sourcePipe.bitisBaglanti = {
-                            tip: 'cihaz',
-                            hedefId: newDevice.id,
-                            noktaIndex: 0
-                        };
-                    }
-
-                    this.manager.saveToState();
-                    saveState();
-                    update3DScene();
-                    devicePlaced = true;
-                }
+                boruUcuInfo = {
+                    pipe: sourcePipe,
+                    end: endPoint,
+                    point: sourcePipe[endPoint]
+                };
             }
         }
 
-        // Aktif çizim noktası yoksa veya ekleme başarısız olduysa, boş uca ekle
-        if (!devicePlaced && this.manager.placeDeviceAtOpenEnd('OCAK')) {
+        // placeDeviceAtOpenEnd handleCihazEkleme kullanır - vana, fleks otomatik eklenir
+        if (this.manager.placeDeviceAtOpenEnd('OCAK', boruUcuInfo)) {
             saveState();
             update3DScene();
         }

--- a/plumbing_v2/plumbing-manager.js
+++ b/plumbing_v2/plumbing-manager.js
@@ -149,19 +149,64 @@ export class PlumbingManager {
      */
     getBosBitisBorular() {
         const bosUclar = [];
+        const currentFloorId = state.currentFloor?.id;
 
         for (const pipe of this.pipes) {
-            // p1 ucu boş mu? (baslangicBaglanti hedefId yoksa)
-            if (!pipe.baslangicBaglanti.hedefId) {
-                bosUclar.push({ pipe, end: 'p1' });
+            // Sadece aktif kattaki boruları kontrol et
+            if (currentFloorId && pipe.floorId && pipe.floorId !== currentFloorId) {
+                continue;
             }
-            // p2 ucu boş mu? (bitisBaglanti hedefId yoksa)
+
+            // p1 ucu kontrol et
+            if (!pipe.baslangicBaglanti.hedefId) {
+                // Gerçekten boş mu? (T-junction veya başka bir boru bağlı değil mi?)
+                if (this.isTrulyFreeEndpoint(pipe.p1)) {
+                    bosUclar.push({ pipe, end: 'p1' });
+                }
+            }
+
+            // p2 ucu kontrol et
             if (!pipe.bitisBaglanti.hedefId) {
-                bosUclar.push({ pipe, end: 'p2' });
+                // Gerçekten boş mu? (T-junction veya başka bir boru bağlı değil mi?)
+                if (this.isTrulyFreeEndpoint(pipe.p2)) {
+                    bosUclar.push({ pipe, end: 'p2' });
+                }
             }
         }
 
         return bosUclar;
+    }
+
+    /**
+     * Bir noktanın gerçekten boş uç olup olmadığını kontrol eder
+     * (T-junction, başka boru bağlantısı yok)
+     */
+    isTrulyFreeEndpoint(point, tolerance = 1) {
+        let pipeCount = 0;
+        const currentFloorId = state.currentFloor?.id;
+
+        for (const boru of this.pipes) {
+            // Sadece aktif kattaki boruları kontrol et
+            if (currentFloorId && boru.floorId && boru.floorId !== currentFloorId) {
+                continue;
+            }
+
+            const distP1 = Math.hypot(point.x - boru.p1.x, point.y - boru.p1.y);
+            const distP2 = Math.hypot(point.x - boru.p2.x, point.y - boru.p2.y);
+
+            if (distP1 < tolerance || distP2 < tolerance) {
+                pipeCount++;
+            }
+
+            // T-junction veya daha karmaşık (3+ boru) - DOLU UÇ
+            if (pipeCount > 2) {
+                return false;
+            }
+        }
+
+        // Sadece 1 boru varsa gerçek boş uç
+        // 2 boru varsa birleşim noktası - DOLU sayılır
+        return pipeCount === 1;
     }
 
     /**
@@ -244,58 +289,70 @@ export class PlumbingManager {
 
     /**
      * Boş bir boru ucuna "Kombi" veya "Ocak" gibi bir cihaz yerleştirir.
+     * handleCihazEkleme ile tam entegre - vana, fleks otomatik eklenir
      * @param {string} deviceType - Yerleştirilecek cihazın tipi ('KOMBI', 'OCAK', vb.)
+     * @param {object} boruUcuInfo - Opsiyonel boru ucu bilgisi {pipe, end, point}
      */
-    placeDeviceAtOpenEnd(deviceType) {
+    placeDeviceAtOpenEnd(deviceType, boruUcuInfo = null) {
         // Sadece 'KOMBI' ve 'OCAK' tiplerine izin ver
         if (deviceType !== 'KOMBI' && deviceType !== 'OCAK') {
             console.warn(`Unsupported device type for automatic placement: ${deviceType}`);
             return false;
         }
 
-        // Boş boru uçlarını al
-        const openEnds = this.getBosBitisBorular();
-        if (openEnds.length === 0) {
-            console.log("Otomatik yerleştirme için boşta boru ucu bulunamadı.");
-            return false; // Boşta boru ucu yoksa bir şey yapma
+        let targetPipe, targetEnd, targetPoint;
+
+        // Eğer özel boru ucu bilgisi verilmişse onu kullan
+        if (boruUcuInfo) {
+            targetPipe = boruUcuInfo.pipe;
+            targetEnd = boruUcuInfo.end;
+            targetPoint = boruUcuInfo.point;
+        } else {
+            // Yoksa, boş boru uçlarını bul
+            const openEnds = this.getBosBitisBorular();
+            if (openEnds.length === 0) {
+                console.log("Otomatik yerleştirme için boşta boru ucu bulunamadı.");
+                return false;
+            }
+
+            const { pipe, end } = openEnds[0];
+            targetPipe = pipe;
+            targetEnd = end;
+            targetPoint = pipe[end];
         }
 
-        // İlk boş ucu seç
-        const { pipe, end } = openEnds[0];
-        const connectionPoint = pipe[end]; // pipe.p1 veya pipe.p2
-        const floorId = pipe.floorId || state.currentFloor?.id;
+        const floorId = targetPipe.floorId || state.currentFloor?.id;
 
-        // Yeni cihazı oluştur
-        const newDevice = createCihaz(connectionPoint.x, connectionPoint.y, deviceType, { floorId });
+        // Cihazı oluştur (geçici pozisyon, handleCihazEkleme ayarlayacak)
+        const newDevice = createCihaz(targetPoint.x, targetPoint.y, deviceType, { floorId });
 
         if (!newDevice) {
             console.error("Cihaz oluşturulamadı.");
             return false;
         }
 
-        // Cihazı component listesine ekle
-        this.components.push(newDevice);
+        // Ghost connection info ekle (handleCihazEkleme kullanır)
+        newDevice.ghostConnectionInfo = {
+            boruUcu: {
+                boruId: targetPipe.id,
+                nokta: targetPoint,
+                uc: targetEnd,
+                boru: targetPipe
+            }
+        };
 
-        // Borunun bağlantısını yeni cihaza güncelle (hangi uçsa o)
-        if (end === 'p1') {
-            pipe.baslangicBaglanti = {
-                tip: 'cihaz',
-                hedefId: newDevice.id,
-                noktaIndex: 0 // Cihazların genelde tek bağlantı noktası olur (index 0)
-            };
+        // interactionManager'ın handleCihazEkleme metodunu kullan
+        // Bu vana, fleks, pozisyon hesaplama gibi her şeyi otomatik yapar
+        const success = this.interactionManager.handleCihazEkleme(newDevice);
+
+        if (success) {
+            // handleCihazEkleme cihazı components'a ekledi
+            console.log(`${deviceType} başarıyla boş boru ucuna eklendi (${targetEnd}) - vana ve fleks ile.`);
+            return true;
         } else {
-            pipe.bitisBaglanti = {
-                tip: 'cihaz',
-                hedefId: newDevice.id,
-                noktaIndex: 0
-            };
+            console.error("Cihaz ekleme başarısız oldu.");
+            return false;
         }
-
-        // Değişiklikleri hemen state'e kaydet
-        this.saveToState();
-
-        console.log(`${deviceType} başarıyla boş boru ucuna eklendi (${end}).`);
-        return true; // Başarılı olduğunu belirt
     }
 
 


### PR DESCRIPTION
Fixed two critical issues with K/O device placement:

1. **Empty endpoint detection (getBosBitisBorular)**:
   - Previously: Only checked hedefId, incorrectly identified occupied endpoints as empty
   - Now: Uses isTrulyFreeEndpoint() to check for T-junctions and pipe connections
   - Only endpoints with exactly 1 pipe (not 2+) are considered truly empty
   - Added floor filtering to only check pipes on current floor

2. **Device placement (placeDeviceAtOpenEnd)**:
   - Previously: Only placed device, no valve/flex/proper positioning
   - Now: Uses handleCihazEkleme() for complete device placement system
   - Automatically adds valve 4cm from pipe end
   - Calculates proper flex length (20cm)
   - Positions device correctly based on pipe direction
   - Creates ghostConnectionInfo for handleCihazEkleme integration

3. **K/O shortcuts simplified**:
   - Removed duplicate device placement logic
   - Now just pass boruUcuInfo to placeDeviceAtOpenEnd()
   - All valve/flex logic handled by handleCihazEkleme()

Result: K/O shortcuts now place devices with complete system (valve + flex + device) at truly empty pipe endpoints, exactly like clicking the device icon.