### PR TITLE
fix: Increase endpoint selection tolerance to prevent body drag near …

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -302,7 +302,7 @@ handlePointerDown(e) {
         }
 
         // Sonra boru uç noktası kontrolü yap (ÖNCE NOKTA - body'den önce)
-        const boruUcu = this.findBoruUcuAt(point, 2.5); // Nokta seçimi için 2.5 cm tolerance (daha hassas)
+        const boruUcu = this.findBoruUcuAt(point, 15); // Nokta seçimi için 15 cm tolerance - bağlantı noktası çevresini kapsar
         if (boruUcu) {
             console.log('🎯 BORU UCU BULUNDU:', boruUcu.uc, boruUcu.boruId);
             const pipe = this.manager.pipes.find(p => p.id === boruUcu.boruId);


### PR DESCRIPTION
…connections

Increased pipe endpoint selection tolerance from 2.5cm to 15cm.

This ensures that clicking near connection points (like the red dot areas in the UI) selects the endpoint for dragging instead of selecting the pipe body. This is the simple, clean solution to prevent accidental body drag operations that could cause visual issues near connection points.

Benefits:
- Larger endpoint hit area makes selection more intuitive
- Prevents body drag from triggering near connection points
- No complex protection logic needed
- Clean and maintainable solution