### PR TITLE
Sayaç fleksini sol rakora bağla (gövdeye değil)

### DIFF
--- a/plumbing_v2/objects/meter.js
+++ b/plumbing_v2/objects/meter.js
@@ -60,7 +60,18 @@ export class Sayac {
      */
     getGirisLocalKoordinat() {
         return {
-            x: -this.config.connectionOffset, 
+            x: -this.config.connectionOffset,
+            y: -this.config.height / 2
+        };
+    }
+
+    /**
+     * Sol rakorun local koordinatı
+     * KURAL: FLEKS BU NOKTAYA BAĞLANIR (Gövde değil, sadece rakor)
+     */
+    getSolRakorLocalKoordinat() {
+        return {
+            x: -this.config.connectionOffset,
             y: -this.config.height / 2
         };
     }
@@ -73,8 +84,8 @@ export class Sayac {
      */
     getCikisLocalKoordinat() {
         return {
-            x: this.config.connectionOffset, 
-            y: -this.config.height / 2 - this.config.rijitUzunluk 
+            x: this.config.connectionOffset,
+            y: -this.config.height / 2 - this.config.rijitUzunluk
         };
     }
     
@@ -108,6 +119,14 @@ export class Sayac {
      */
     getGirisNoktasi() {
         return this.localToWorld(this.getGirisLocalKoordinat());
+    }
+
+    /**
+     * Sol rakorun dünya koordinatları
+     * KURAL: FLEKS BU NOKTAYA BAĞLANIR
+     */
+    getSolRakorNoktasi() {
+        return this.localToWorld(this.getSolRakorLocalKoordinat());
     }
 
     /**

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1036,7 +1036,8 @@ export class PlumbingRenderer {
                 }
             }
 
-            const connectionPoint = comp.getGirisNoktasi();
+            // FLEKS SOL RAKORA BAĞLANIR (gövdeye değil)
+            const connectionPoint = comp.getSolRakorNoktasi();
             const deviceCenter = { x: comp.x, y: comp.y };
             this.drawWavyConnectionLine(ctx, connectionPoint, zoom, manager, targetPoint, deviceCenter);
 
@@ -1854,7 +1855,8 @@ export class PlumbingRenderer {
         }
 
         // 2. Fleks Çizgisi (Basit kesikli çizgi)
-        const giris = ghost.getGirisNoktasi();
+        // FLEKS SOL RAKORA BAĞLANIR (gövdeye değil)
+        const solRakor = ghost.getSolRakorNoktasi();
 
         ctx.globalAlpha = 0.6;
         ctx.strokeStyle = '#FFD700'; // Sarı
@@ -1864,8 +1866,8 @@ export class PlumbingRenderer {
         ctx.beginPath();
         // Boru ucundan (veya vana hizasından)
         ctx.moveTo(boruUcu.nokta.x, boruUcu.nokta.y);
-        // Sayacın girişine
-        ctx.lineTo(giris.x, giris.y);
+        // Sayacın sol rakoruna
+        ctx.lineTo(solRakor.x, solRakor.y);
         ctx.stroke();
 
         ctx.setLineDash([]);


### PR DESCRIPTION
- meter.js'e getSolRakorNoktasi() metodu eklendi
- Fleks bağlantısı giriş noktası yerine sol rakora yapıldı
- Hem normal hem ghost rendering güncellendi