### PR TITLE
Sayaç ve cihaz iyileştirmeleri: 7 madde tamamlandı

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -608,8 +608,8 @@ function onKeyDown(e) {
     if (e.ctrlKey && e.key.toLowerCase() === "y") { e.preventDefault(); redo(); return; }
 
     // --- Yeni Tesisat Sistemi (v2) Klavye İşlemleri ---
-    // PlumbingV2 modunda VEYA tesisat nesnesi seçiliyse
-    if (state.currentMode === "plumbingV2" || state.currentMode === "MİMARİ-TESİSAT" ||
+    // PlumbingV2, Select, MİMARİ-TESİSAT modlarında VEYA tesisat nesnesi seçiliyse
+    if (state.currentMode === "plumbingV2" || state.currentMode === "select" || state.currentMode === "MİMARİ-TESİSAT" ||
         (state.selectedObject && ['pipe', 'boru', 'servis_kutusu', 'sayac', 'vana', 'cihaz'].includes(state.selectedObject.type))) {
         const handled = plumbingManager.interactionManager.handleKeyDown(e);
         if (handled) {
@@ -818,7 +818,8 @@ function onKeyDown(e) {
         plumbingManager.startPipeMode(); // Boru çizim aracını başlat
         setMode("plumbingV2", true); // UI'yı güncelle (ikonu aktif et)
     }
-    if (e.key.toLowerCase() === "s" && !e.ctrlKey && !e.altKey && !e.shiftKey && !inFPSMode) setMode("drawSymmetry"); // YENİ SATIR
+    // S tuşu artık sayaç eklemek için kullanılıyor (interaction-manager.js'de)
+    // if (e.key.toLowerCase() === "s" && !e.ctrlKey && !e.altKey && !e.shiftKey && !inFPSMode) setMode("drawSymmetry");
 
 }
 

--- a/plumbing_v2/objects/meter.js
+++ b/plumbing_v2/objects/meter.js
@@ -16,7 +16,7 @@ export const SAYAC_CONFIG = {
     height: 24,         // cm - Gövde yüksekliği
     depth: 16,          // cm - 3D Derinlik
     color: 0xA8A8A8,    // Metalik gri
-    rijitUzunluk: 10,   // Çıkış borusu uzunluğu (Sayacın üstünden boru hattına kadar)
+    rijitUzunluk: 2,    // Çıkış borusu uzunluğu (Giriş kolu hizasına denk gelir)
     connectionOffset: 5 // Merkezden sağa/sola sapma miktarı (giriş/çıkış arası 10cm)
 
 };
@@ -159,18 +159,11 @@ export class Sayac {
     }
 
     /**
-     * Giriş noktası etrafında döndür
+     * Merkez etrafında döndür
      */
     rotate(deltaDerece) {
-        const girisNoktasi = this.getGirisNoktasi();
-
-        // Rotasyonu uygula
+        // Rotasyonu uygula (merkez sabit kalır)
         this.rotation = (this.rotation + deltaDerece) % 360;
-
-        // Merkezi giriş noktasına göre yeniden hesapla (giriş sabit kalsın)
-        const yeniGiris = this.getGirisNoktasi();
-        this.x += girisNoktasi.x - yeniGiris.x;
-        this.y += girisNoktasi.y - yeniGiris.y;
 
         return {
             cikisBagliBoruId: this.cikisBagliBoruId,


### PR DESCRIPTION
1. Sayaç artık merkez noktasından döndürülebilir (giriş noktası yerine)
2. Sayaç eklendiğinde çıkış kolundan çizim başlar
3. Sayaç çıkış kolu uzunluğu giriş kolu hizasına eşitlendi (2cm)
4. S kısayolu simetri yerine sayaç eklemek için kullanılıyor
5. Kombi/ocak icon ekleme davranışı kısayol (K/O) ile aynı yapıldı
6. Seç modunda S/K/O kısayolları aktif edildi
7. Boru bölme: cihaz/sayaç grubu pozisyona göre doğru segmente taşınıyor

Değişiklikler:
- meter.js: rotate() merkez etrafında döner, rijitUzunluk 2cm
- interaction-manager.js: S tuşu sayaç ekler, sayaç çıkış noktasından çizim, cihaz ekleme icon davranışı düzeltildi, boru bölme pozisyon bazlı
- input.js: S tuşu yoruma alındı, seç modunda tesisat kısayolları aktif