### PR TITLE
Sayaç hizalama düzeltmesi - tüm yönler için doğru konumlandırma

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -700,14 +700,9 @@ export class InteractionManager {
                 const fleksUzunluk = 15; // cm
 
                 // Boru yönüne DİK (perpendicular) vektör hesapla
-                let perpX = dy / length;
-                let perpY = -dx / length;
-
-                // Her zaman "aşağı" yönünde asılsın
-                if (perpY < 0) {
-                    perpX = -perpX;
-                    perpY = -perpY;
-                }
+                // 90° saat yönünde (clockwise) döndürülmüş vektör: (-dy, dx)
+                let perpX = -dy / length;
+                let perpY = dx / length;
 
                 // Sayaç rotation'u: Boru yönü
                 ghost.rotation = Math.atan2(dy, dx) * 180 / Math.PI;
@@ -1240,16 +1235,9 @@ export class InteractionManager {
         const fleksUzunluk = 15; // cm
 
         // Boru yönüne DİK (perpendicular) vektör hesapla
-        // Right perpendicular: (dy, -dx) normalize edilmiş
-        let perpX = dy / length;
-        let perpY = -dx / length;
-
-        // Her zaman "aşağı" yönünde asılsın (Y pozitif aşağı)
-        // Eğer perpendicular yukarı doğruysa (perpY < 0), ters çevir
-        if (perpY < 0) {
-            perpX = -perpX;
-            perpY = -perpY;
-        }
+        // 90° saat yönünde (clockwise) döndürülmüş vektör: (-dy, dx)
+        let perpX = -dy / length;
+        let perpY = dx / length;
 
         // Sayaç rotation'u: Boru yönü (giriş rakoru boru yönünde olmalı)
         meter.rotation = Math.atan2(dy, dx) * 180 / Math.PI;


### PR DESCRIPTION
Sayaçların sağa, sola, aşağı ve yukarı yönlerde doğru şekilde hizalanması için perpendicular vektör hesaplaması düzeltildi.

Önceki kod her zaman aşağı yönde zorlarken, yeni kod boru yönüne göre 90° saat yönünde döndürülmüş vektör kullanıyor:
- Sağa giden boru → sayaç aşağıda
- Sola giden boru → sayaç yukarıda
- Aşağı giden boru → sayaç solda
- Yukarı giden boru → sayaç sağda

Düzeltilen dosyalar:
- interaction-manager.js (updateGhostPosition & handleSayacEndPlacement)