### PR TITLE
Fixture önizlemesi artık mouse konumunda gösteriliyor

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -31,6 +31,9 @@ export class InteractionManager {
         this.snapSystem = new TesisatSnapSystem(manager);
         this.activeSnap = null;
 
+        // Son bilinen mouse pozisyonu (world koordinatlarında)
+        this.lastMousePoint = null;
+
         // Boru çizim durumu
         this.boruCizimAktif = false;
         this.boruBaslangic = null;
@@ -77,6 +80,9 @@ export class InteractionManager {
         const mouseScreenY = e.clientY - rect.top;
         const point = screenToWorld(mouseScreenX, mouseScreenY);
         const walls = state.walls;
+
+        // Son mouse pozisyonunu kaydet
+        this.lastMousePoint = point;
 
         // Debug: Mouse koordinatları (sadece cihaz ghost için, ilk 3 kez)
         if (this.manager.activeTool === 'cihaz' && this.manager.tempComponent && !this._mouseDebugCount) {

--- a/plumbing_v2/plumbing-manager.js
+++ b/plumbing_v2/plumbing-manager.js
@@ -73,6 +73,12 @@ export class PlumbingManager {
                 return;
         }
 
+        // Son bilinen mouse pozisyonunu kullanarak başlangıç pozisyonunu ayarla
+        if (this.interactionManager.lastMousePoint) {
+            this.tempComponent.x = this.interactionManager.lastMousePoint.x;
+            this.tempComponent.y = this.interactionManager.lastMousePoint.y;
+        }
+
     }
 
     /**


### PR DESCRIPTION
İkona tıklandığında (örnek: kombi) önizleme artık ekranın ortasında değil, doğrudan mouse ucunda gösteriliyor. Bu değişiklik:

- InteractionManager'a lastMousePoint özelliği eklendi (mouse pozisyonunu takip için)
- handlePointerMove'da lastMousePoint güncelleniyor
- startPlacement'da tempComponent başlangıç pozisyonu lastMousePoint'e ayarlanıyor