### PR TITLE
Ghost görüntü sadece mouse hareketi sonrası görünsün

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -51,8 +51,8 @@ export class PlumbingRenderer {
             }
         }
 
-        // Ghost eleman (her zaman yarı saydam)
-        if (manager.tempComponent) {
+        // Ghost eleman (her zaman yarı saydam) - sadece mouse hareket ettikten sonra görünsün
+        if (manager.tempComponent && manager.interactionManager.lastMousePoint) {
             ctx.save();
             ctx.globalAlpha = 0.6;
 


### PR DESCRIPTION
İkona tıkladığında ghost görüntü artık hemen görünmüyor. Kullanıcı mouse'u hareket ettirdiğinde (lastMousePoint set edildiğinde) ghost rendering başlıyor. Bu daha temiz bir UX sağlıyor.