### PR TITLE
Cihaz/sayaç ekleme sonrası mod durumunu düzelt

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -1306,6 +1306,11 @@ function initialize() {
     }
     if (dom.bSayac) {
         dom.bSayac.addEventListener("click", () => {
+            // Önceki modu kaydet (icon ile eklenmeden önceki durumu restore için)
+            if (plumbingManager.interactionManager) {
+                plumbingManager.interactionManager.previousMode = state.currentMode;
+                plumbingManager.interactionManager.previousDrawingMode = state.currentDrawingMode;
+            }
             // Aktif boru çizimini iptal et
             plumbingManager.interactionManager?.cancelCurrentAction();
             if (state.currentDrawingMode !== "KARMA") {
@@ -1328,6 +1333,11 @@ function initialize() {
     }
     if (dom.bKombi) {
         dom.bKombi.addEventListener("click", () => {
+            // Önceki modu kaydet (icon ile eklenmeden önceki durumu restore için)
+            if (plumbingManager.interactionManager) {
+                plumbingManager.interactionManager.previousMode = state.currentMode;
+                plumbingManager.interactionManager.previousDrawingMode = state.currentDrawingMode;
+            }
             // Aktif boru çizimini iptal et
             plumbingManager.interactionManager?.cancelCurrentAction();
             if (state.currentDrawingMode !== "KARMA") {
@@ -1339,6 +1349,11 @@ function initialize() {
     }
     if (dom.bOcak) {
         dom.bOcak.addEventListener("click", () => {
+            // Önceki modu kaydet (icon ile eklenmeden önceki durumu restore için)
+            if (plumbingManager.interactionManager) {
+                plumbingManager.interactionManager.previousMode = state.currentMode;
+                plumbingManager.interactionManager.previousDrawingMode = state.currentDrawingMode;
+            }
             // Aktif boru çizimini iptal et
             plumbingManager.interactionManager?.cancelCurrentAction();
             if (state.currentDrawingMode !== "KARMA") {

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -831,7 +831,7 @@ export class InteractionManager {
                     // Sayacın çıkış noktasından çizim başlat
                     const cikisNoktasi = component.getCikisNoktasi();
                     this.startBoruCizim(cikisNoktasi, component.id, BAGLANTI_TIPLERI.SAYAC);
-                    // Önceki moda dön (S tuşu ile eklenmişse)
+                    // Önceki moda dön (S tuşu ile eklenmişse veya icon ile eklenmişse)
                     if (this.previousMode) {
                         console.log(`[MODE] Sayaç eklendi, önceki moda dönülüyor: ${this.previousMode}`);
                         setTimeout(() => {
@@ -841,7 +841,16 @@ export class InteractionManager {
                             }
                             console.log(`[MODE] Mode restore: ${this.previousMode}`);
                             setMode(this.previousMode);
-                            this.manager.activeTool = 'boru';
+
+                            // activeTool'u önceki moda göre ayarla
+                            // Eğer önceki mod boru çizim moduysa ('plumbingV2'), activeTool = 'boru'
+                            // Aksi halde activeTool = null (select modu)
+                            if (this.previousMode === 'plumbingV2') {
+                                this.manager.activeTool = 'boru';
+                            } else {
+                                this.manager.activeTool = null;
+                            }
+
                             this.previousMode = null;
                             this.previousDrawingMode = null;
                         }, 10);
@@ -866,7 +875,7 @@ export class InteractionManager {
                 // Cihaz ekleme - K/O kısayolu gibi boru çizme moduna geç ama çizim başlatma
                 const success = this.handleCihazEkleme(component);
                 if (success) {
-                    // Önceki moda dön (K/O tuşu ile eklenmişse)
+                    // Önceki moda dön (K/O tuşu ile eklenmişse veya icon ile eklenmişse)
                     if (this.previousMode) {
                         console.log(`[MODE] Cihaz eklendi, önceki moda dönülüyor: ${this.previousMode}`);
                         setTimeout(() => {
@@ -876,7 +885,16 @@ export class InteractionManager {
                             }
                             console.log(`[MODE] Mode restore: ${this.previousMode}`);
                             setMode(this.previousMode);
-                            this.manager.activeTool = 'boru';
+
+                            // activeTool'u önceki moda göre ayarla
+                            // Eğer önceki mod boru çizim moduysa ('plumbingV2'), activeTool = 'boru'
+                            // Aksi halde activeTool = null (select modu)
+                            if (this.previousMode === 'plumbingV2') {
+                                this.manager.activeTool = 'boru';
+                            } else {
+                                this.manager.activeTool = null;
+                            }
+
                             this.previousMode = null;
                             this.previousDrawingMode = null;
                         }, 10);


### PR DESCRIPTION
Sorunlar:
- Boru çizerken kısayoldan cihaz ekleyince UI SEÇ modunda kalıyordu ama boru çizimi yapıyordu
- Boru çizerken icon'dan cihaz ekleyince UI BORU modunda görünüyordu ama SEÇ işlevi yapıyordu
- SEÇ modunda cihaz/sayaç eklenince yanlışlıkla BORU moduna geçiyordu

Düzeltmeler:
- Icon click handler'larında previousMode ve previousDrawingMode kaydediliyor
- placeComponent'te cihaz/sayaç ekleme sonrası activeTool doğru restore ediliyor:
  * Önceki mod 'plumbingV2' ise -> activeTool = 'boru'
  * Önceki mod 'select' ise -> activeTool = null
- Artık her durumda UI ile gerçek durum senkronize