### PR TITLE
Boru çizerken cihaz/sayaç eklenince activeTool'u doğru restore et

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -1310,6 +1310,7 @@ function initialize() {
             if (plumbingManager.interactionManager) {
                 plumbingManager.interactionManager.previousMode = state.currentMode;
                 plumbingManager.interactionManager.previousDrawingMode = state.currentDrawingMode;
+                plumbingManager.interactionManager.previousActiveTool = plumbingManager.activeTool;
             }
             // Aktif boru çizimini iptal et
             plumbingManager.interactionManager?.cancelCurrentAction();
@@ -1337,6 +1338,7 @@ function initialize() {
             if (plumbingManager.interactionManager) {
                 plumbingManager.interactionManager.previousMode = state.currentMode;
                 plumbingManager.interactionManager.previousDrawingMode = state.currentDrawingMode;
+                plumbingManager.interactionManager.previousActiveTool = plumbingManager.activeTool;
             }
             // Aktif boru çizimini iptal et
             plumbingManager.interactionManager?.cancelCurrentAction();
@@ -1353,6 +1355,7 @@ function initialize() {
             if (plumbingManager.interactionManager) {
                 plumbingManager.interactionManager.previousMode = state.currentMode;
                 plumbingManager.interactionManager.previousDrawingMode = state.currentDrawingMode;
+                plumbingManager.interactionManager.previousActiveTool = plumbingManager.activeTool;
             }
             // Aktif boru çizimini iptal et
             plumbingManager.interactionManager?.cancelCurrentAction();

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -479,6 +479,7 @@ export class InteractionManager {
             // Önceki modu kaydet
             this.previousMode = state.currentMode;
             this.previousDrawingMode = state.currentDrawingMode;
+            this.previousActiveTool = this.manager.activeTool;
 
             // TESİSAT moduna geç
             if (state.currentDrawingMode !== "KARMA") {
@@ -500,6 +501,7 @@ export class InteractionManager {
             // Önceki modu kaydet
             this.previousMode = state.currentMode;
             this.previousDrawingMode = state.currentDrawingMode;
+            this.previousActiveTool = this.manager.activeTool;
 
             // TESİSAT moduna geç
             if (state.currentDrawingMode !== "KARMA") {
@@ -522,6 +524,7 @@ export class InteractionManager {
             // Önceki modu kaydet
             this.previousMode = state.currentMode;
             this.previousDrawingMode = state.currentDrawingMode;
+            this.previousActiveTool = this.manager.activeTool;
 
             // TESİSAT moduna geç
             if (state.currentDrawingMode !== "KARMA") {
@@ -842,17 +845,13 @@ export class InteractionManager {
                             console.log(`[MODE] Mode restore: ${this.previousMode}`);
                             setMode(this.previousMode);
 
-                            // activeTool'u önceki moda göre ayarla
-                            // Eğer önceki mod boru çizim moduysa ('plumbingV2'), activeTool = 'boru'
-                            // Aksi halde activeTool = null (select modu)
-                            if (this.previousMode === 'plumbingV2') {
-                                this.manager.activeTool = 'boru';
-                            } else {
-                                this.manager.activeTool = null;
-                            }
+                            // activeTool'u kaydettiğimiz önceki değere geri yükle
+                            console.log(`[MODE] ActiveTool restore: ${this.previousActiveTool}`);
+                            this.manager.activeTool = this.previousActiveTool;
 
                             this.previousMode = null;
                             this.previousDrawingMode = null;
+                            this.previousActiveTool = null;
                         }, 10);
                     } else {
                         // Önceki mod yoksa, normal boru çizme moduna geç
@@ -886,17 +885,13 @@ export class InteractionManager {
                             console.log(`[MODE] Mode restore: ${this.previousMode}`);
                             setMode(this.previousMode);
 
-                            // activeTool'u önceki moda göre ayarla
-                            // Eğer önceki mod boru çizim moduysa ('plumbingV2'), activeTool = 'boru'
-                            // Aksi halde activeTool = null (select modu)
-                            if (this.previousMode === 'plumbingV2') {
-                                this.manager.activeTool = 'boru';
-                            } else {
-                                this.manager.activeTool = null;
-                            }
+                            // activeTool'u kaydettiğimiz önceki değere geri yükle
+                            console.log(`[MODE] ActiveTool restore: ${this.previousActiveTool}`);
+                            this.manager.activeTool = this.previousActiveTool;
 
                             this.previousMode = null;
                             this.previousDrawingMode = null;
+                            this.previousActiveTool = null;
                         }, 10);
                     } else {
                         // Önceki mod yoksa, normal boru çizme moduna geç


### PR DESCRIPTION
Sorun: Boru çizerken (activeTool='boru') cihaz eklendiğinde, cihaz ekleme sonrası activeTool yanlış ayarlanıyordu. previousMode'a göre tahmin edilmeye çalışılıyordu ama bu her zaman doğru sonuç vermiyordu.

Çözüm:
- previousActiveTool değişkeni eklendi
- Icon click ve klavye kısayollarında previousActiveTool kaydediliyor
- Cihaz/sayaç ekleme sonrası activeTool doğrudan previousActiveTool'dan restore ediliyor

Sonuç:
✅ Boru çizerken cihaz ekle → BORU moduna dön (icon seçili + boru çizer) ✅ SEÇ modundayken cihaz ekle → SEÇ moduna dön (icon seçili + seçer) ✅ Her durumda UI ile fonksiyon senkronize