### PR TITLE
Vana tanımını sadeleştir

### DIFF
--- a/plumbing_v2/plumbing-types.js
+++ b/plumbing_v2/plumbing-types.js
@@ -52,18 +52,6 @@ export const PLUMBING_COMPONENT_TYPES = {
         mountType: 'pipe', // Boru üzeri/ucu
         connectionLength: 10 // Giriş kolu esnekliği için ref
     },
-    VALVE: {
-        id: 'valve',
-        name: 'Vana',
-        width: 6,
-        height: 6,
-        color: 0xA0A0A0,
-        mountType: 'pipe',
-        subTypes: {
-            INTERMEDIATE: ['AKV', 'KKV', 'EMNIYET', 'CIHAZ', 'SELENOID', 'SAYAC'],
-            TERMINATION: ['BRANSMAN', 'YAN_BINA', 'DOMESTIK']
-        }
-    },
     DEVICE: {
         id: 'device',
         name: 'Cihaz',

--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -3,7 +3,6 @@ import { createColumn, onPointerDown as onPointerDownColumn, isPointInColumn } f
 import { createBeam, onPointerDown as onPointerDownBeam } from '../architectural-objects/beams.js';
 import { createStairs, onPointerDown as onPointerDownStairs, recalculateStepCount } from '../architectural-objects/stairs.js';
 import { plumbingManager, TESISAT_MODLARI } from '../plumbing_v2/plumbing-manager.js';
-import { PLUMBING_PIPE_TYPES, PLUMBING_COMPONENT_TYPES } from '../plumbing_v2/plumbing-types.js';
 import { onPointerDownDraw as onPointerDownDrawWall, onPointerDownSelect as onPointerDownSelectWall, wallExists } from '../wall/wall-handler.js';
 import { onPointerDownDraw as onPointerDownDrawDoor, onPointerDownSelect as onPointerDownSelectDoor } from '../architectural-objects/door-handler.js';
 import { onPointerDownGuide } from '../architectural-objects/guide-handler.js';


### PR DESCRIPTION
PLUMBING_COMPONENT_TYPES'dan VALVE tanımını kaldır. Bu tanım kullanılmıyordu ve gereksiz karmaşıklık yaratıyordu. Vana artık sadece valve.js içindeki Vana class'ı olarak tanımlı, boruya bağlı bir nesne olarak çalışıyor.

Değişiklikler:
- plumbing-types.js: VALVE tanımı kaldırıldı
- pointer-down.js: Kullanılmayan PLUMBING_COMPONENT_TYPES import'u kaldırıldı