### PR TITLE
Vana silme ve ghost görüntü sorunlarını düzelt

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -871,6 +871,9 @@ export class InteractionManager {
                     this.handleVanaPlacement(this.vanaPreview);
                     return;
                 }
+                // Vana pozisyonunu tıklanan noktaya ayarla (tempComponent başta 0,0'da oluşturuluyor)
+                component.x = point.x;
+                component.y = point.y;
                 saveState();
                 this.manager.components.push(component);
                 break;
@@ -1625,7 +1628,7 @@ export class InteractionManager {
         // state.selectedObject'i de set et (DELETE tuşu için)
         setState({
             selectedObject: {
-                type: 'valve',
+                type: 'vana',
                 object: vana,
                 pipe: pipe,
                 handle: 'body'


### PR DESCRIPTION
İki kritik sorunu düzelttik:

1. Vana silinemiyor sorunu:
   - selectValve fonksiyonunda type 'valve' (İngilizce) olarak set ediliyordu
   - Delete kontrolü 'vana' (Türkçe) arıyordu
   - type 'vana' olarak düzeltildi (interaction-manager.js:1628)

2. Vana ghost ekranın ortasında görünüyor sorunu:
   - tempComponent (0,0) konumunda oluşturuluyordu
   - Mouse hareket etmeden tıklanırsa pozisyon güncellenmiyordu
   - placeComponent içinde tıklanan noktaya pozisyon ayarlandı (interaction-manager.js:875-876)

Not: lastMousePoint sıfırlama zaten mevcuttu (plumbing-manager.js:47)