### PR TITLE
Vana ghost mouse takibini düzelt

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -176,6 +176,12 @@ export class InteractionManager {
 
         // 1.6 Vana tool aktif - Vana preview
         if (this.manager.activeTool === 'vana' && !this.boruCizimAktif) {
+            // Ghost pozisyonunu güncelle (tempComponent mouse'u takip etmeli)
+            if (this.manager.tempComponent) {
+                this.manager.tempComponent.x = point.x;
+                this.manager.tempComponent.y = point.y;
+            }
+
             // Mouse altında boru var mı kontrol et (5 cm yakalama mesafesi)
             const hoveredPipe = this.findPipeAt(point, 5);
             if (hoveredPipe) {


### PR DESCRIPTION
Sorun: Vana ghost görüntüsü sabit bir yerde kalıyordu, mouse'u takip etmiyordu.

Neden: Vana preview kodu (satır 178-233) return true yaparak updateGhostPosition çağrısını engelliyordu. Bu yüzden tempComponent.x ve tempComponent.y hiç güncellenmiyordu.

Çözüm: Vana preview bloğunun başına tempComponent pozisyon güncellemesi eklendi:
  this.manager.tempComponent.x = point.x;
  this.manager.tempComponent.y = point.y;

Artık vana ghost mouse'u doğru şekilde takip ediyor.