### PR TITLE
Sayaç öncesi/sonrası için boru renk grupları sistemi

### DIFF
--- a/plumbing_v2/objects/pipe.js
+++ b/plumbing_v2/objects/pipe.js
@@ -13,20 +13,38 @@
 
 import { TESISAT_CONSTANTS } from '../interactions/tesisat-snap.js';
 
+// Renk Grupları (Sayaç Öncesi/Sonrası)
+export const RENK_GRUPLARI = {
+    YELLOW: {
+        id: 'yellow',
+        name: 'Sarı (Sayaç Öncesi)',
+        boru: 'rgba(255, 255, 0, {opacity})',      // Sarı
+        dirsek: 'rgba(255, 255, 0, {opacity})',    // Sarı
+        fleks: '#FFD700'                            // Altın sarısı
+    },
+    TURQUAZ: {
+        id: 'turquaz',
+        name: 'Turquaz (Sayaç Sonrası)',
+        boru: 'rgba(64, 224, 208, {opacity})',     // Turquaz
+        dirsek: 'rgba(64, 224, 208, {opacity})',   // Turquaz
+        fleks: '#40E0D0'                            // Turquaz
+    }
+};
+
 // Boru Tipleri
 export const BORU_TIPLERI = {
     STANDART: {
         id: 'standart',
         name: 'Standart Boru',
         diameter: 2,        // cm
-        color: 0xFFFF00,    // Sarı (doğalgaz)
+        color: 0xFFFF00,    // Sarı (doğalgaz) - deprecated, colorGroup kullan
         lineWidth: 4
     },
     KALIN: {
         id: 'kalin',
         name: 'Kalın Boru',
         diameter: 4,
-        color: 0xFFCC00,    // Koyu sarı
+        color: 0xFFCC00,    // Koyu sarı - deprecated, colorGroup kullan
         lineWidth: 6
     }
 };
@@ -50,6 +68,9 @@ export class Boru {
         // Uç noktalar
         this.p1 = { x: p1.x, y: p1.y, z: p1.z || 0 };
         this.p2 = { x: p2.x, y: p2.y, z: p2.z || 0 };
+
+        // Renk Grubu (Sayaç Öncesi/Sonrası)
+        this.colorGroup = 'YELLOW'; // Varsayılan: Sarı (Sayaç Öncesi)
 
         // Kat bilgisi
         this.floorId = null;
@@ -404,6 +425,7 @@ export class Boru {
             id: this.id,
             type: this.type,
             boruTipi: this.boruTipi,
+            colorGroup: this.colorGroup,
             p1: { ...this.p1 },
             p2: { ...this.p2 },
             floorId: this.floorId,
@@ -421,6 +443,7 @@ export class Boru {
     static fromJSON(data) {
         const boru = new Boru(data.p1, data.p2, data.boruTipi);
         boru.id = data.id;
+        boru.colorGroup = data.colorGroup || 'YELLOW'; // Varsayılan: Sarı (geriye dönük uyumluluk)
         boru.floorId = data.floorId;
         boru.baslangicBaglanti = data.baslangicBaglanti || { tip: null, hedefId: null, noktaIndex: null };
         boru.bitisBaglanti = data.bitisBaglanti || { tip: null, hedefId: null, noktaIndex: null };

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1,4 +1,4 @@
-import { BORU_TIPLERI } from './objects/pipe.js';
+import { BORU_TIPLERI, RENK_GRUPLARI } from './objects/pipe.js';
 import { SERVIS_KUTUSU_CONFIG, CIKIS_YONLERI } from './objects/service-box.js';
 import { SAYAC_CONFIG } from './objects/meter.js';
 import { VANA_CONFIG, VANA_TIPLERI } from './objects/valve.js';
@@ -8,6 +8,19 @@ import { BG, getAdjustedColor, state } from '../general-files/main.js';
 export class PlumbingRenderer {
     constructor() {
         this.secilenRenk = '#00BFFF'; // Seçili nesne rengi
+    }
+
+    /**
+     * Renk grubundan opacity ile renk al
+     */
+    getRenkByGroup(colorGroup, tip, opacity) {
+        const group = RENK_GRUPLARI[colorGroup] || RENK_GRUPLARI.YELLOW;
+        const template = group[tip];
+
+        if (template.includes('{opacity}')) {
+            return template.replace('{opacity}', opacity);
+        }
+        return template;
     }
 
     render(ctx, manager) {
@@ -175,14 +188,14 @@ export class PlumbingRenderer {
                 // Gradient ile 3D silindir etkisi (Kenarlarda yumuşak siyahlık)
                 const gradient = ctx.createLinearGradient(0, -width / 2, 0, width / 2);
 
+                // Renk grubuna göre renk seç
+                const colorGroup = pipe.colorGroup || 'YELLOW';
+
                 // Kenarlarda hafif karartma, ortası boru rengi
                 // Geçişler yumuşak tutuldu
-                gradient.addColorStop(0.0, 'rgba(255, 255,0,  0.5)');
-                gradient.addColorStop(0.5, 'rgba(255, 255,0,  1)');
-                gradient.addColorStop(1, 'rgba( 255, 255,0,  0.5)');
-                // gradient.addColorStop(0.0, 'rgba(0,255, 255,  0.3)');
-                // gradient.addColorStop(0.5,  'rgba(0, 255, 255, 1)');
-                // gradient.addColorStop(1, 'rgba( 0, 255, 255, 0.3)');
+                gradient.addColorStop(0.0, this.getRenkByGroup(colorGroup, 'boru', 0.5));
+                gradient.addColorStop(0.5, this.getRenkByGroup(colorGroup, 'boru', 1));
+                gradient.addColorStop(1, this.getRenkByGroup(colorGroup, 'boru', 0.5));
 
                 ctx.fillStyle = gradient;
                 ctx.fillRect(0, -width / 2, length, width);
@@ -245,14 +258,10 @@ export class PlumbingRenderer {
     }
 
     drawElbows(ctx, pipes, breakPoints) {
-        // Çizim moduna göre renk ayarla (Orijinal düz renk yapısı korundu)
-        // const adjustedGray = getAdjustedColor('rgba(0, 133, 133, 1)', 'boru');
-        const adjustedGray = getAdjustedColor('rgba( 219, 219,0,  1)', 'boru');
-
-
-        ctx.fillStyle = adjustedGray;
-
         breakPoints.forEach(bp => {
+            // Dirsek rengini ilk borunun colorGroup'una göre belirle
+            const firstPipe = bp.pipes[0];
+            const colorGroup = firstPipe?.colorGroup || 'YELLOW';
             // En büyük genişliği bul (merkez daire için)
             let maxArmWidth = 0;
             const armLength = 3;      // 3 cm kol uzunluğu
@@ -260,9 +269,9 @@ export class PlumbingRenderer {
 
             const dm = bp.diameters[1] + armExtraWidth * 2
             const adjustedGrayx = ctx.createRadialGradient(bp.x, bp.y, dm / 4, bp.x, bp.y, dm / 2);
-            adjustedGrayx.addColorStop(0, 'rgba(255, 255, 0, 1)');
-            adjustedGrayx.addColorStop(0.2, 'rgba(255, 255, 0, 1)');
-            adjustedGrayx.addColorStop(1, 'rgba(255, 255, 0, .8)');
+            adjustedGrayx.addColorStop(0, this.getRenkByGroup(colorGroup, 'dirsek', 1));
+            adjustedGrayx.addColorStop(0.2, this.getRenkByGroup(colorGroup, 'dirsek', 1));
+            adjustedGrayx.addColorStop(1, this.getRenkByGroup(colorGroup, 'dirsek', 0.8));
             ctx.fillStyle = adjustedGrayx;
             ctx.beginPath();
             ctx.arc(bp.x, bp.y, dm / 2, 0, Math.PI * 2);
@@ -288,10 +297,10 @@ export class PlumbingRenderer {
 
                 // Kenarlarda hafif karartma, ortası boru rengi
                 // Geçişler yumuşak tutuldu
-                gradientdar.addColorStop(0.0, 'rgba(255, 255,0,  0.6)');
-                gradientdar.addColorStop(0.2, 'rgba(255, 255,0,  1)');
-                gradientdar.addColorStop(0.6, 'rgba(255, 255,0, 1)');
-                gradientdar.addColorStop(1, 'rgba( 255, 255,0,  0.6)');
+                gradientdar.addColorStop(0.0, this.getRenkByGroup(colorGroup, 'dirsek', 0.6));
+                gradientdar.addColorStop(0.2, this.getRenkByGroup(colorGroup, 'dirsek', 1));
+                gradientdar.addColorStop(0.6, this.getRenkByGroup(colorGroup, 'dirsek', 1));
+                gradientdar.addColorStop(1, this.getRenkByGroup(colorGroup, 'dirsek', 0.6));
 
 
                 // 3 cm'lik ana kol (dikdörtgen)
@@ -300,9 +309,9 @@ export class PlumbingRenderer {
 
                 const gradientgenis = ctx.createLinearGradient(0, -armWidth / 2, 0, armWidth / 2);
                 // İç kısımda hafif parlaklık efekti
-                gradientgenis.addColorStop(0.0, 'rgba(255, 255,0,  0.8)');
-                gradientgenis.addColorStop(0.5, 'rgba(255, 255,0,  1)');
-                gradientgenis.addColorStop(1, 'rgba( 255, 255,0,  0.8)');
+                gradientgenis.addColorStop(0.0, this.getRenkByGroup(colorGroup, 'dirsek', 0.8));
+                gradientgenis.addColorStop(0.5, this.getRenkByGroup(colorGroup, 'dirsek', 1));
+                gradientgenis.addColorStop(1, this.getRenkByGroup(colorGroup, 'dirsek', 0.8));
 
 
                 // Uçta kalın çizgi (sağdan soldan 0.2 cm taşan, 1.5x kalın)
@@ -443,14 +452,12 @@ export class PlumbingRenderer {
         ctx.translate(geciciBoru.p1.x, geciciBoru.p1.y);
         ctx.rotate(angle);
 
-        // Aynı yumuşak gradient
+        // Aynı yumuşak gradient - varsayılan YELLOW renk grubu
         const gradient = ctx.createLinearGradient(0, -width / 2, 0, width / 2);
-        // gradient.addColorStop(0.0, 'rgba(0,255, 255,  0.3)'); 
-        // gradient.addColorStop(0.5,  'rgba(0, 255, 255, 1)');  
-        // gradient.addColorStop(1, 'rgba( 0, 255, 255, 0.3)');  
-        gradient.addColorStop(0.0, 'rgba(255, 255, 0, 0.3)');
-        gradient.addColorStop(0.5, 'rgba(255, 255, 0, 1)');
-        gradient.addColorStop(1, 'rgba(255, 255, 0, 0.3)');
+        const colorGroup = 'YELLOW'; // Geçici boru için varsayılan
+        gradient.addColorStop(0.0, this.getRenkByGroup(colorGroup, 'boru', 0.3));
+        gradient.addColorStop(0.5, this.getRenkByGroup(colorGroup, 'boru', 1));
+        gradient.addColorStop(1, this.getRenkByGroup(colorGroup, 'boru', 0.3));
         ctx.fillStyle = gradient;
         ctx.fillRect(0, -width / 2, length, width);
 
@@ -1441,6 +1448,7 @@ export class PlumbingRenderer {
     drawWavyConnectionLine(ctx, connectionPoint, zoom, manager, targetPoint = null, deviceCenter = null) {
         let closestPipeEnd = targetPoint;
         let pipeDirection = null;
+        let colorGroup = 'YELLOW'; // Varsayılan renk grubu
 
         // KRITIK: connectionPoint'i cihazın içine doğru uzat (15 cm)
         let adjustedConnectionPoint = connectionPoint;
@@ -1465,6 +1473,7 @@ export class PlumbingRenderer {
             const currentFloorId = state.currentFloor?.id;
             const pipes = (manager.pipes || []).filter(p => p.floorId === currentFloorId);
             let minDist = Infinity;
+            let closestPipe = null;
 
             // En yakın boru ucunu bul
             for (const pipe of pipes) {
@@ -1472,6 +1481,7 @@ export class PlumbingRenderer {
                 if (dist1 < minDist) {
                     minDist = dist1;
                     closestPipeEnd = { x: pipe.p1.x, y: pipe.p1.y };
+                    closestPipe = pipe;
                     const pipeLength = Math.hypot(pipe.p2.x - pipe.p1.x, pipe.p2.y - pipe.p1.y);
                     if (pipeLength > 0) {
                         pipeDirection = {
@@ -1485,6 +1495,7 @@ export class PlumbingRenderer {
                 if (dist2 < minDist) {
                     minDist = dist2;
                     closestPipeEnd = { x: pipe.p2.x, y: pipe.p2.y };
+                    closestPipe = pipe;
                     const pipeLength = Math.hypot(pipe.p2.x - pipe.p1.x, pipe.p2.y - pipe.p1.y);
                     if (pipeLength > 0) {
                         pipeDirection = {
@@ -1493,6 +1504,11 @@ export class PlumbingRenderer {
                         };
                     }
                 }
+            }
+
+            // En yakın borunun renk grubunu al
+            if (closestPipe) {
+                colorGroup = closestPipe.colorGroup || 'YELLOW';
             }
         }
 
@@ -1512,8 +1528,9 @@ export class PlumbingRenderer {
 
             ctx.save();
 
-            // Fleks rengini ayarla (sarı-altın rengi)
-            const adjustedColor = getAdjustedColor('#FFD700', 'cihaz');
+            // Fleks rengini renk grubuna göre ayarla
+            const fleksRenk = this.getRenkByGroup(colorGroup, 'fleks', 1);
+            const adjustedColor = getAdjustedColor(fleksRenk, 'cihaz');
             ctx.strokeStyle = adjustedColor;
             ctx.lineWidth = 1;  // Daha kalın
             ctx.lineCap = 'round';
@@ -1791,8 +1808,12 @@ export class PlumbingRenderer {
             fleksBitis = merkez;
         }
 
+        // Fleks rengini borunun colorGroup'una göre ayarla
+        const colorGroup = boru?.colorGroup || 'YELLOW';
+        const fleksRenk = this.getRenkByGroup(colorGroup, 'fleks', 1);
+
         ctx.globalAlpha = 0.6;
-        ctx.strokeStyle = '#FFD700'; // Sarı
+        ctx.strokeStyle = fleksRenk;
         ctx.lineWidth = 2;
         ctx.setLineDash([5, 5]); // Kesikli çizgi
 
@@ -1865,8 +1886,12 @@ export class PlumbingRenderer {
         // FLEKS SOL RAKORA BAĞLANIR (gövdeye değil)
         const solRakor = ghost.getSolRakorNoktasi();
 
+        // Fleks rengini borunun colorGroup'una göre ayarla
+        const colorGroup = boru?.colorGroup || 'YELLOW';
+        const fleksRenk = this.getRenkByGroup(colorGroup, 'fleks', 1);
+
         ctx.globalAlpha = 0.6;
-        ctx.strokeStyle = '#FFD700'; // Sarı
+        ctx.strokeStyle = fleksRenk;
         ctx.lineWidth = 2;
         ctx.setLineDash([5, 5]);
 


### PR DESCRIPTION
- RENK_GRUPLARI tanımlandı: YELLOW (sarı) ve TURQUAZ
- Boru sınıfına colorGroup özelliği eklendi (varsayılan: YELLOW)
- Renderer'da tüm çizim fonksiyonları colorGroup'a göre renk seçiyor:
  * Borular: Gradient renkler (sarı/turquaz)
  * Dirsekler: Boru renklerine uyumlu
  * Fleks bağlantılar: Bağlı olduğu borunun renginde
- Sarı gradient özellikleri korunarak turquaz versiyonu oluşturuldu
- Geriye dönük uyumluluk: Eski borular otomatik YELLOW olarak yüklenir

Kullanım: pipe.colorGroup = 'TURQUAZ' ile sayaç sonrası borular ayarlanabilir