### PR TITLE
Sayaç sonrası tüm borular ve preview'lar TURQUAZ

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -1196,16 +1196,21 @@ export class InteractionManager {
                 );
                 if (sayac) {
                     sayac.baglaCikis(boru.id);
-
-                    // ✨ Sayaç sonrası boruları TURQUAZ yap
-                    setTimeout(() => {
-                        this.manager.updatePipeColorsAfterMeter(sayac.id);
-                    }, 0);
                 }
             }
         }
 
         this.manager.pipes.push(boru);
+
+        // ✨ Sayaç sonrası boruları TURQUAZ yap (boru eklendikten SONRA)
+        if (this.boruBaslangic.kaynakTip === BAGLANTI_TIPLERI.SAYAC) {
+            const sayac = this.manager.components.find(
+                c => c.id === this.boruBaslangic.kaynakId && c.type === 'sayac'
+            );
+            if (sayac) {
+                this.manager.updatePipeColorsAfterMeter(sayac.id);
+            }
+        }
 
         // State'i senkronize et
         this.manager.saveToState();

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -46,7 +46,26 @@ export class PlumbingRenderer {
         // Geçici boru çizgisi (boru çizim modunda)
         const geciciBoru = manager.interactionManager?.getGeciciBoruCizgisi();
         if (geciciBoru) {
-            this.drawGeciciBoru(ctx, geciciBoru);
+            // Geçici borunun renk grubunu belirle
+            let geciciColorGroup = 'YELLOW'; // Varsayılan
+
+            // Başlangıç noktasının kaynağına göre renk belirle
+            const boruBaslangic = manager.interactionManager?.boruBaslangic;
+            if (boruBaslangic) {
+                // Sayaç çıkışından başlıyorsa TURQUAZ
+                if (boruBaslangic.kaynakTip === 'sayac') {
+                    geciciColorGroup = 'TURQUAZ';
+                }
+                // Boru ucundan başlıyorsa o borunun rengini al
+                else if (boruBaslangic.kaynakTip === 'boru' && boruBaslangic.kaynakId) {
+                    const baslangicBoru = manager.findPipeById(boruBaslangic.kaynakId);
+                    if (baslangicBoru) {
+                        geciciColorGroup = baslangicBoru.colorGroup || 'YELLOW';
+                    }
+                }
+            }
+
+            this.drawGeciciBoru(ctx, geciciBoru, geciciColorGroup);
         }
 
         if (shouldBeFaded) {
@@ -432,7 +451,7 @@ export class PlumbingRenderer {
         });
     }
 
-    drawGeciciBoru(ctx, geciciBoru) {
+    drawGeciciBoru(ctx, geciciBoru, colorGroup = 'YELLOW') {
         ctx.save();
 
         // Geçici boru için de aynı stil ve zoom kompenzasyonu
@@ -452,9 +471,8 @@ export class PlumbingRenderer {
         ctx.translate(geciciBoru.p1.x, geciciBoru.p1.y);
         ctx.rotate(angle);
 
-        // Aynı yumuşak gradient - varsayılan YELLOW renk grubu
+        // Renk grubuna göre gradient oluştur
         const gradient = ctx.createLinearGradient(0, -width / 2, 0, width / 2);
-        const colorGroup = 'YELLOW'; // Geçici boru için varsayılan
         gradient.addColorStop(0.0, this.getRenkByGroup(colorGroup, 'boru', 0.3));
         gradient.addColorStop(0.5, this.getRenkByGroup(colorGroup, 'boru', 1));
         gradient.addColorStop(1, this.getRenkByGroup(colorGroup, 'boru', 0.3));


### PR DESCRIPTION
Düzeltmeler:
- setTimeout kaldırıldı: Renk güncellemesi boru eklendikten hemen sonra
- Preview/ghost borular artık doğru renkte:
  * Sayaç çıkışından çizilen preview → TURQUAZ
  * TURQUAZ borudan devam eden preview → TURQUAZ
  * Diğer preview'lar → YELLOW (varsayılan)
- drawGeciciBoru() artık colorGroup parametresi alıyor
- Otomatik renk devamı: Bir boradan devam edilirse o borunun rengi

Test: Sayaç ekle → Çıkıştan boru çiz → Tüm borular ve preview TURQUAZ