### PR TITLE
Canvas gradient renkleri THEME_COLORS'a taşındı

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -21,7 +21,7 @@ import { getColumnCorners } from '../architectural-objects/columns.js';
 import { getBeamCorners } from '../architectural-objects/beams.js';
 import { getStairCorners } from '../architectural-objects/stairs.js';
 import { getObjectAtPoint } from '../general-files/actions.js';
-import { state, dom, getWallFillColor, getCanvasClearColor } from '../general-files/main.js';
+import { state, dom, getWallFillColor, getCanvasClearColor, THEME_COLORS, isLightMode } from '../general-files/main.js';
 import { getCameraViewInfo } from '../scene3d/scene3d-camera.js';
 
 
@@ -263,24 +263,21 @@ export function draw2D() {
     // Get device pixel ratio for crisp rendering
     const dpr = window.devicePixelRatio || 1;
 
-    // Canvas background - radial gradient
+    // Canvas background - radial gradient (THEME_COLORS'dan)
     const centerX = c2d.width / 2;
     const centerY = c2d.height / 2;
     const radius = Math.max(c2d.width, c2d.height) * 0.7;
 
     const gradient = ctx2d.createRadialGradient(centerX, centerY, 0, centerX, centerY, radius);
 
-    if (isLightMode()) {
-        // Aydınlık mod: Merkez beyaz, kenarlar gri
-        gradient.addColorStop(0, '#FFFFFF');    // Merkez - saf beyaz
-        gradient.addColorStop(0.5, '#F8F8F8');  // Orta
-        gradient.addColorStop(1, '#E8E8E8');    // Kenar - açık gri
-    } else {
-        // Karanlık mod: Merkez koyu gri, kenarlar daha koyu
-        gradient.addColorStop(0, '#2A2A2A');    // Merkez
-        gradient.addColorStop(0.5, '#232323');  // Orta
-        gradient.addColorStop(1, '#1A1A1A');    // Kenar - daha koyu
-    }
+    // Gradient renklerini THEME_COLORS'dan al
+    const gradientColors = isLightMode()
+        ? THEME_COLORS.light.canvasGradient
+        : THEME_COLORS.dark.canvasGradient;
+
+    gradient.addColorStop(0, gradientColors.center);    // Merkez
+    gradient.addColorStop(0.5, gradientColors.mid);     // Orta
+    gradient.addColorStop(1, gradientColors.edge);      // Kenar
 
     ctx2d.fillStyle = gradient;
     ctx2d.fillRect(0, 0, c2d.width, c2d.height);

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -32,6 +32,11 @@ export const THEME_COLORS = {
         background: '#30302e',
         backgroundGradient: null, // Koyu modda gradient yok
         canvas: '#30302e', // Canvas temizleme rengi
+        canvasGradient: {
+            center: '#2A2A2A',  // Merkez - koyu gri
+            mid: '#232323',     // Orta
+            edge: '#1A1A1A'     // Kenar - daha koyu
+        },
 
         // Grid
         grid: '#2e2e2e',
@@ -65,6 +70,11 @@ export const THEME_COLORS = {
         background: '#e6e7e7',
         backgroundGradient: 'radial-gradient(ellipse at center, #fdffff 0%, #e7fafa 100%)',
         canvas: '#e6e7e7', // Canvas temizleme rengi
+        canvasGradient: {
+            center: '#FFFFFF',  // Merkez - saf beyaz
+            mid: '#F8F8F8',     // Orta
+            edge: '#E8E8E8'     // Kenar - açık gri
+        },
 
         // Grid
         grid: '#dfdddd',


### PR DESCRIPTION
- THEME_COLORS.light.canvasGradient: {center, mid, edge} renkleri eklendi
- THEME_COLORS.dark.canvasGradient: {center, mid, edge} renkleri eklendi
- draw2d.js artık THEME_COLORS'dan gradient renklerini alıyor
- Hardcode renkler kaldırıldı, merkezi tema yönetimi sağlandı