### PR TITLE
drawColumn: getWallFillColor fonksiyon çağrısı düzeltildi

### DIFF
--- a/draw/renderer2d.js
+++ b/draw/renderer2d.js
@@ -296,7 +296,7 @@ export function drawColumn(column, isSelected = false) {
 
     // Çizim moduna göre renk ayarla
     const adjustedBorderColor = getAdjustedColor(wallBorderColor, 'column');
-    const adjustedFillColor = getAdjustedColor(getWallFillColor, 'column'); // Temaya göre dinamik
+    const adjustedFillColor = getAdjustedColor(getWallFillColor(), 'column'); // Fonksiyon çağrısı düzeltildi
 
     // Çizim stilleri
     ctx2d.fillStyle = adjustedFillColor; // İçini arka plan rengiyle doldur


### PR DESCRIPTION
- getWallFillColor bir fonksiyon, () ile çağrılmalı
- Önceki hata: parseHex'e fonksiyon objesi gönderiliyordu
- TypeError: hex.replace is not a function hatası düzeltildi