### PR TITLE
Boru uç renklerinin dark/light modda düzgün çalışması için düzeltme

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -49,7 +49,8 @@ export class PlumbingRenderer {
     }
 
     isLightMode() {
-        return state.isLightMode === true;
+        // main.js'ten import edilen fonksiyonu kullan
+        return isLightMode();
     }
 
 


### PR DESCRIPTION
PlumbingRenderer.isLightMode() metodu state.isLightMode değerine bakıyordu ancak bu değer hiçbir zaman güncellenmediği için her zaman dark mode renkleri kullanılıyordu. Şimdi main.js'ten import edilen isLightMode() fonksiyonunu kullanıyor ve tema değişikliklerini doğru algılıyor.