### PR TITLE
Fix: Preserve colorGroup when splitting pipes

### DIFF
--- a/plumbing_v2/objects/pipe.js
+++ b/plumbing_v2/objects/pipe.js
@@ -265,6 +265,8 @@ export class Boru {
         // Özellikleri kopyala
         boru1.floorId = this.floorId;
         boru2.floorId = this.floorId;
+        boru1.colorGroup = this.colorGroup;
+        boru2.colorGroup = this.colorGroup;
 
         // Bağlantıları aktar
         boru1.baslangicBaglanti = { ...this.baslangicBaglanti };


### PR DESCRIPTION
When pipes are split using double-click (T command), the colorGroup property (YELLOW/TURQUAZ) was not being preserved. This caused pipes after the meter (sayaç) to revert to YELLOW color instead of maintaining TURQUAZ color.

Fixed by copying colorGroup property to both new pipe segments in the splitAt() method.