### PR TITLE
Fix: Enforce minimum 21cm distance when placing appliances

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -687,7 +687,8 @@ export class InteractionManager {
                 // Cihaz rotation'u sabit - tutamacı her zaman kuzeyde
                 ghost.rotation = 0;
 
-                // Fleks uzunluğu (maksimum mesafe)
+                // Fleks uzunluğu (minimum ve maksimum mesafe)
+                const minFleksUzunluk = 21; // cm - cihazın boru ucundan minimum uzaklığı (vana + fleks görünürlüğü için)
                 const maxFleksUzunluk = 50; // cm - cihazın boru ucundan maksimum uzaklığı
 
                 // Mouse'un boru ucundan mesafesini hesapla
@@ -699,12 +700,17 @@ export class InteractionManager {
                 // Cihaz merkezini hesapla
                 let merkezX, merkezY;
 
-                if (mouseUcMesafe <= maxFleksUzunluk) {
+                if (mouseUcMesafe < minFleksUzunluk) {
+                    // Mouse minimum fleks uzunluğundan daha yakın, minimum mesafeye yerleştir
+                    const oran = minFleksUzunluk / mouseUcMesafe;
+                    merkezX = boruUcu.nokta.x + (point.x - boruUcu.nokta.x) * oran;
+                    merkezY = boruUcu.nokta.y + (point.y - boruUcu.nokta.y) * oran;
+                } else if (mouseUcMesafe <= maxFleksUzunluk) {
                     // Mouse fleks uzunluğu içinde, mouse pozisyonuna yerleştir
                     merkezX = point.x;
                     merkezY = point.y;
                 } else {
-                    // Mouse fleks uzunluğundan dışarıda, fleks sınırı üzerinde mouse yönünde yerleştir
+                    // Mouse fleks uzunluğundan dışarıda, maksimum mesafeye mouse yönünde yerleştir
                     const oran = maxFleksUzunluk / mouseUcMesafe;
                     merkezX = boruUcu.nokta.x + (point.x - boruUcu.nokta.x) * oran;
                     merkezY = boruUcu.nokta.y + (point.y - boruUcu.nokta.y) * oran;


### PR DESCRIPTION
When placing appliances (ocak, kombi, etc.) near pipe ends, enforce a minimum 21cm distance to ensure the flexible hose (fleks) is always visible. Previously, appliances could be placed directly at the pipe end, making the fleks invisible.

Changes:
- Added minFleksUzunluk = 21cm to ghost positioning logic
- If mouse is closer than 21cm to pipe end, appliance is automatically positioned at exactly 21cm distance
- This ensures valve (8cm) + visible fleks hose fit properly
- Maintains existing behavior for distances between 21-50cm