### PR TITLE
Fix: Sayaç sonrası cihaz fleksleri doğru renkte (bağlı oldukları boru…

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -818,7 +818,7 @@ export class PlumbingRenderer {
 
             const connectionPoint = comp.getGirisNoktasi();
             const deviceCenter = { x: comp.x, y: comp.y };
-            this.drawWavyConnectionLine(ctx, connectionPoint, zoom, manager, targetPoint, deviceCenter);
+            this.drawWavyConnectionLine(ctx, connectionPoint, zoom, manager, targetPoint, deviceCenter, comp);
 
             ctx.restore();
         }
@@ -908,7 +908,7 @@ export class PlumbingRenderer {
 
             const connectionPoint = comp.getGirisNoktasi();
             const deviceCenter = { x: comp.x, y: comp.y };
-            this.drawWavyConnectionLine(ctx, connectionPoint, zoom, manager, targetPoint, deviceCenter);
+            this.drawWavyConnectionLine(ctx, connectionPoint, zoom, manager, targetPoint, deviceCenter, comp);
 
             ctx.restore();
         }
@@ -1340,10 +1340,18 @@ export class PlumbingRenderer {
         return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     }
 
-    drawWavyConnectionLine(ctx, connectionPoint, zoom, manager, targetPoint = null, deviceCenter = null) {
+    drawWavyConnectionLine(ctx, connectionPoint, zoom, manager, targetPoint = null, deviceCenter = null, comp = null) {
         let closestPipeEnd = targetPoint;
         let pipeDirection = null;
         let colorGroup = 'YELLOW'; // Varsayılan renk grubu
+
+        // ÖNCE: Eğer cihaz ve fleks bağlantısı varsa, O borunun rengini kullan!
+        if (comp && comp.fleksBaglanti?.boruId) {
+            const fleksBoru = manager.pipes.find(p => p.id === comp.fleksBaglanti.boruId);
+            if (fleksBoru) {
+                colorGroup = fleksBoru.colorGroup || 'YELLOW';
+            }
+        }
 
         // KRITIK: connectionPoint'i cihazın içine doğru uzat (15 cm)
         let adjustedConnectionPoint = connectionPoint;


### PR DESCRIPTION
… rengi)

ÖNCEKİ SORUN:
- Fleks rengi EN YAKIN borudan alınıyordu
- Eğer sayaç öncesi boru daha yakınsa, yanlış renk kullanılıyordu
- Sayaç sonrası cihazlar sarı fleksle çiziliyordu (yanlış!)

ÇÖZÜM:
- drawWavyConnectionLine'a comp parametresi eklendi
- Cihazın GERÇEKTE BAĞLI OLDUĞU boru bulunuyor (comp.fleksBaglanti.boruId)
- O borunun colorGroup'u kullanılıyor
- Artık sayaç sonrası cihazlar TURQUAZ fleksle çiziliyor (doğru!)

SONUÇ: Fleksler bağlı oldukları boru ile aynı renkte ✓