### PR TITLE
Fix: colorGroup parametresi artık override edilmiyor

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -1019,13 +1019,16 @@ export class InteractionManager {
         // Kaynak borunun renk grubunu sakla (split sonrası renk devam etsin)
         let kaynakColorGroup = colorGroup || 'YELLOW'; // Parametre öncelikli
 
+        // Kaynak boru varsa kontrol et
         if (kaynakTip === BAGLANTI_TIPLERI.BORU && kaynakId) {
             // Kaynak boruyu bul (manager.pipes içinde ara)
             const kaynakBoru = this.manager.pipes.find(p => p.id === kaynakId);
 
             if (kaynakBoru) {
-                // Kaynak borunun renk grubunu al
-                kaynakColorGroup = kaynakBoru.colorGroup || 'YELLOW';
+                // Renk grubunu al (SADECE parametre yoksa!)
+                if (!colorGroup) {
+                    kaynakColorGroup = kaynakBoru.colorGroup || 'YELLOW';
+                }
 
                 // Tıklanan noktanın hangi uç (p1 mi p2 mi) olduğunu anla
                 // Gelen nokta zaten borunun ucu olduğu için mesafe neredeyse 0'dır.


### PR DESCRIPTION
KRİTİK HATA:
- colorGroup parametresi geliyordu
- Ama sonra kaynakBoru.colorGroup ile ÜZERİNE yazılıyordu!
- Sonuç: Split sonrası turquaz boru sarıya dönüyordu

DÜZELTME:
- Parametre varsa (if (!colorGroup)) kontrolü eklendi
- Artık SADECE parametre yoksa kaynakBoru'dan alınıyor
- Parametre varsa kesinlikle korunuyor

MANTIK:
1. colorGroup parametresi var mı? → Kullan
2. Yok mu? → Kaynak borudan al
3. O da yoksa? → YELLOW (varsayılan)

SONUÇ: Renk artık kesinlikle doğru!