### PR TITLE
Split işleminde colorGroup ve bağlantılar düzeltildi

### DIFF
--- a/plumbing_v2/objects/pipe.js
+++ b/plumbing_v2/objects/pipe.js
@@ -266,9 +266,20 @@ export class Boru {
         boru1.floorId = this.floorId;
         boru2.floorId = this.floorId;
 
+        // ✨ RENGİ KOPYALA (Sayaç sonrası renkler korunsun!)
+        boru1.colorGroup = this.colorGroup;
+        boru2.colorGroup = this.colorGroup;
+
         // Bağlantıları aktar
         boru1.baslangicBaglanti = { ...this.baslangicBaglanti };
         boru2.bitisBaglanti = { ...this.bitisBaglanti };
+
+        // Boru1'in bitiş bağlantısını boru2'ye ayarla
+        boru1.bitisBaglanti = {
+            tip: 'boru',
+            hedefId: boru2.id,
+            noktaIndex: null
+        };
 
         // Boru2'nin başlangıç bağlantısını boru1'e ayarla
         boru2.baslangicBaglanti = {


### PR DESCRIPTION
Sorun 1: Boru split edildiğinde colorGroup kopyalanmıyordu
- Sayaç sonrası TURKUAZ boru split edilince SARI oluyordu
- Çözüm: splitAt metodunda colorGroup kopyalanıyor

Sorun 2: boru1'in bitiş bağlantısı eksikti
- boru2'nin başlangıcı boru1'e bağlıydı ✓
- boru1'in bitişi boru2'ye bağlı değildi ✗
- Çözüm: boru1.bitisBaglanti = boru2 olarak ayarlandı

Artık split sonrası:
- Her iki boru da aynı renkte (TURKUAZ korunur)
- Bağlantılar iki yönlü kurulur (atalar doğru takip edilir)