### PR TITLE
Sayaç config undefined hatası düzeltildi

### DIFF
--- a/plumbing_v2/objects/meter.js
+++ b/plumbing_v2/objects/meter.js
@@ -306,15 +306,20 @@ export class Sayac {
 
         sayac.id = data.id;
         sayac.rotation = data.rotation;
-        
+
         if (data.fleksBaglanti) {
             sayac.fleksBaglanti = { ...data.fleksBaglanti };
-        } else if (data.girisBagliBoruId) { 
+        } else if (data.girisBagliBoruId) {
             sayac.fleksBaglanti.boruId = data.girisBagliBoruId;
         }
 
         sayac.cikisBagliBoruId = data.cikisBagliBoruId;
         sayac.iliskiliVanaId = data.iliskiliVanaId;
+
+        // ✨ DÜZELTME: Config varlığını garantile (constructor'da oluşturulmalı ama yine de kontrol et)
+        if (!sayac.config) {
+            sayac.config = { ...SAYAC_CONFIG };
+        }
 
         // GÜNCELLEME: rijitUzunluk değerini geri yükle
         if (data.rijitUzunluk !== undefined) {

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1055,6 +1055,20 @@ export class PlumbingRenderer {
     }
 
     drawSayac(ctx, comp, manager) {
+        // ✨ DÜZELTME: Config yoksa default değerleri kullan (eski veri uyumluluğu için)
+        if (!comp.config) {
+            console.warn('⚠️ Sayaç config eksik, default değerler kullanılıyor:', comp.id);
+            comp.config = {
+                width: 22,
+                height: 24,
+                depth: 16,
+                color: 0xA8A8A8,
+                rijitUzunluk: 0,
+                connectionOffset: 5,
+                nutHeight: 4
+            };
+        }
+
         const { width, height, connectionOffset, nutHeight } = comp.config;
         const zoom = state.zoom || 1;
         const rijitUzunluk = comp.config.rijitUzunluk || (comp.ghostConnectionInfo ? 15 : 0);


### PR DESCRIPTION
Sorun: Eski verilerden yüklenen sayaçlarda config eksik olduğunda renderer'da "Cannot destructure property 'width' of 'comp.config'" hatası alınıyordu.

Düzeltme:
- Renderer'da config yoksa default SAYAC_CONFIG ile oluştur
- fromJSON'da config varlığını garantile
- Console uyarısı ekle (debug için)

Geriye dönük uyumluluk sağlandı.