### PR TITLE
PlumbingManager init() metodunda loadFromState çağrısı eklendi

### DIFF
--- a/plumbing_v2/objects/meter.js
+++ b/plumbing_v2/objects/meter.js
@@ -300,6 +300,12 @@ export class Sayac {
      * Deserialize
      */
     static fromJSON(data) {
+        // Eski veri formatı kontrolü - config property eksikse eski veri!
+        if (!data.cikisBagliBoruId && data.girisBagliBoruId && !data.fleksBaglanti) {
+            console.error('❌ ESKİ SAYAÇ VERİSİ! localStorage.clear() ile temizleyin ve sayfayı yenileyin!');
+            throw new Error('Eski sayaç verisi desteklenmiyor. localStorage temizlenmeli!');
+        }
+
         const sayac = new Sayac(data.x, data.y, {
             floorId: data.floorId
         });

--- a/plumbing_v2/plumbing-manager.js
+++ b/plumbing_v2/plumbing-manager.js
@@ -34,6 +34,8 @@ export class PlumbingManager {
     }
 
     init() {
+        // State'den veri yükle (sayfa yüklendiğinde)
+        this.loadFromState();
     }
 
     /**


### PR DESCRIPTION
Sorun: Sayfa yüklendiğinde plumbingManager.init() boş olduğu için state.plumbingBlocks düz JSON objesi olarak kalıyordu. fromJSON() çağrılmadığı için bileşenler class instance'ı değildi.

Çözüm:
- plumbingManager.init() içinde loadFromState() çağrısı eklendi
- Sayaç constructor'ında gereksiz debug log kaldırıldı
- Eski sayaç verisi kontrolü eklendi

Artık sayfa yüklendiğinde tüm bileşenler doğru class instance'ı olarak yükleniyor.