### PR TITLE
Canlı hat preview ve reset sorunları düzeltildi

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -289,9 +289,10 @@ export class InteractionManager {
                 // Hayali boru + sayaç ekle
                 const success = this.handleCanliHatSayacEkleme(this.canliHatBaslangic, sayacKonumu);
 
-                // Canlı hat modundan çık
+                // Canlı hat modundan çık - TAMAMEN SIFIRLA
                 this.canliHatModu = false;
                 this.canliHatBaslangic = null;
+                this.manager.tempComponent = null; // Ghost'u temizle
 
                 return true;
             }


### PR DESCRIPTION
DÜZELTMELER:

1. Vana kısmı düz yapıldı (son 20cm)
   - Kesikli kısım: başlangıç → (bitiş - 20cm)
   - Düz kısım: (bitiş - 20cm) → bitiş
   - Vana bu düz kısma yerleşecek

2. İkinci canlı hat temiz başlatma
   - canliHatModu, canliHatBaslangic reset
   - tempComponent temizlendi
   - Her sayaç ekleme tamamen bağımsız

3. Preview görüntüleme düzeltildi
   - Render koşulları aynen
   - drawCanliHatPreview basitleştirildi