### PR TITLE
Canlı hat sayaç ekleme için cihaz boru yakalama filtrelendi ve sayaç …

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -280,6 +280,10 @@ export class InteractionManager {
                 this.canliHatBaslangic = { x: targetPoint.x, y: targetPoint.y };
                 console.log('[CANLI HAT] Başlangıç noktası kaydedildi:', this.canliHatBaslangic);
                 console.log('[CANLI HAT] Şimdi sayaç konumuna tıklayın');
+
+                // Sayaç ghost'u oluştur (preview için)
+                this.manager.startPlacement(TESISAT_MODLARI.SAYAC);
+
                 return true;
             } else {
                 // İkinci tıklama - Sayaç konumu
@@ -2036,6 +2040,11 @@ export class InteractionManager {
         const candidates = [];
 
         for (const boru of this.manager.pipes) {
+            // CANLI HAT borularını yoksay - bunlar hayali borular
+            if (boru.colorGroup === 'CANLI_HAT') {
+                continue;
+            }
+
             // Sadece aktif kattaki boruları kontrol et
             if (currentFloorId && boru.floorId && boru.floorId !== currentFloorId) {
                 continue;


### PR DESCRIPTION
…ghost eklendi

DEĞİŞİKLİKLER:

1. Cihaz/sayaç ekleme sırasında canlı hat borularını yoksay
   - findBoruUcuAt fonksiyonunda filtre eklendi
   - colorGroup === 'CANLI_HAT' olan borular atlanıyor
   - Ghost ve gerçek ekleme için geçerli

2. İlk tıklamadan sonra sayaç ghost preview
   - İlk tıklama → Başlangıç set + sayaç ghost oluştur
   - Mouse hareket → Kesikli çizgi + sayaç ghost görünür
   - İkinci tıklama → Sayaç eklenir

3. Vana kısmı düz (son 20cm)
   - Kod zaten var, test edilecek
   - Mantık: Son 20cm düz, geri kalanı kesikli