### PR TITLE
Canlı hat kuralları uygulandı ve başlangıç simgesi güncellendi

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -1153,12 +1153,25 @@ export class InteractionManager {
         if (colorGroup) {
             kaynakColorGroup = colorGroup;
         } else if (kaynakId && kaynakTip) {
-            // Parametre yoksa, ataları kontrol et
-            // Metafor: K→D→B→A takibi, en başta sayaç var mı?
-            if (this.hasAncestorMeter(kaynakId, kaynakTip)) {
-                kaynakColorGroup = 'TURQUAZ'; // İç tesisat (sayaç sonrası)
+            // Önce kaynak boru CANLI_HAT mi kontrol et
+            if (kaynakTip === BAGLANTI_TIPLERI.BORU) {
+                const kaynakBoru = this.manager.pipes.find(p => p.id === kaynakId);
+                if (kaynakBoru && kaynakBoru.colorGroup === 'CANLI_HAT') {
+                    // KURAL: Canlı hattan çizilen borular da canlı hat olmalı
+                    kaynakColorGroup = 'CANLI_HAT';
+                } else if (this.hasAncestorMeter(kaynakId, kaynakTip)) {
+                    kaynakColorGroup = 'TURQUAZ'; // İç tesisat (sayaç sonrası)
+                } else {
+                    kaynakColorGroup = 'YELLOW'; // Kolon tesisat (sayaç öncesi)
+                }
             } else {
-                kaynakColorGroup = 'YELLOW'; // Kolon tesisat (sayaç öncesi)
+                // Parametre yoksa, ataları kontrol et
+                // Metafor: K→D→B→A takibi, en başta sayaç var mı?
+                if (this.hasAncestorMeter(kaynakId, kaynakTip)) {
+                    kaynakColorGroup = 'TURQUAZ'; // İç tesisat (sayaç sonrası)
+                } else {
+                    kaynakColorGroup = 'YELLOW'; // Kolon tesisat (sayaç öncesi)
+                }
             }
         }
 
@@ -3472,6 +3485,7 @@ export class InteractionManager {
         // Hayali boruyu işaretle (özel renk grubu)
         hayaliBoru.colorGroup = 'CANLI_HAT'; // Sarı kesikli çizgi olarak çizilecek
         hayaliBoru.floorId = state.currentFloor?.id;
+        hayaliBoru.isCanliHatOrigin = true; // Bu gerçek başlangıç noktası (elektrik simgesi göster)
 
         // Hayali boruyu manager'a ekle
         this.manager.pipes.push(hayaliBoru);

--- a/plumbing_v2/objects/pipe.js
+++ b/plumbing_v2/objects/pipe.js
@@ -270,6 +270,12 @@ export class Boru {
         boru1.colorGroup = this.colorGroup;
         boru2.colorGroup = this.colorGroup;
 
+        // ✨ CANLI HAT ORİJİN FLAG'İNİ KOPYALA - SADECE boru1'e (başlangıç parçası)
+        if (this.isCanliHatOrigin) {
+            boru1.isCanliHatOrigin = true; // Başlangıç simgesi sadece ilk parçada
+            boru2.isCanliHatOrigin = false; // Split edilmiş parça değil
+        }
+
         // Bağlantıları aktar
         boru1.baslangicBaglanti = { ...this.baslangicBaglanti };
         boru2.bitisBaglanti = { ...this.bitisBaglanti };

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -344,11 +344,14 @@ export class PlumbingRenderer {
                     // Kesikli çizgi ayarını sıfırla
                     ctx.setLineDash([]);
 
-                    // Başlangıç noktasında elektrik simgesi (p1)
-                    ctx.save();
-                    ctx.rotate(-angle); // Rotasyonu geri al (simge düz durmalı)
-                    this.drawElektrikSimgesi(ctx, 0, 0, dashColor);
-                    ctx.restore();
+                    // Başlangıç noktasında elektrik simgesi (p1) - SADECE gerçek başlangıç noktasında
+                    // isCanliHatOrigin flag'i ile kontrol et (boru split edildiğinde gösterme)
+                    if (pipe.isCanliHatOrigin) {
+                        ctx.save();
+                        ctx.rotate(-angle); // Rotasyonu geri al (simge düz durmalı)
+                        this.drawElektrikSimgesi(ctx, 0, 0, dashColor);
+                        ctx.restore();
+                    }
                 } else {
                     // Normal boru - Gradient ile 3D silindir etkisi (Kenarlarda yumuşak siyahlık)
                     const gradient = ctx.createLinearGradient(0, -width / 2, 0, width / 2);
@@ -1952,6 +1955,12 @@ export class PlumbingRenderer {
         ctx.beginPath();
         ctx.moveTo(spacing, -height);
         ctx.lineTo(spacing, height);
+        ctx.stroke();
+
+        // Küçük boş yuvarlak (merkez)
+        ctx.beginPath();
+        ctx.arc(0, 0, 4, 0, Math.PI * 2);
+        ctx.lineWidth = 1.5;
         ctx.stroke();
 
         ctx.restore();


### PR DESCRIPTION
- Elektrik simgesine küçük boş yuvarlak eklendi (merkez)
- isCanliHatOrigin flag'i eklendi - gerçek başlangıç noktasını işaretler
- Boru split edildiğinde sadece ilk parça (boru1) origin flag'ini tutar
- KURAL: Canlı hattan boru çizildiğinde yeni boru da CANLI_HAT olur
- startBoruCizim fonksiyonu kaynak borunun CANLI_HAT olup olmadığını kontrol eder
- Servis kutusu yoksa sayaç öncesi tüm borular kesikli çizilir