### PR TITLE
CANLI_HAT borularını isTrulyFreeEndpoint kontrolünden hariç tut

### DIFF
--- a/plumbing_v2/plumbing-manager.js
+++ b/plumbing_v2/plumbing-manager.js
@@ -195,6 +195,11 @@ export class PlumbingManager {
         const currentFloorId = state.currentFloor?.id;
 
         for (const boru of this.pipes) {
+            // CANLI_HAT (hayali) borularını yoksay - gerçek tesisat kontrolü için
+            if (boru.colorGroup === 'CANLI_HAT') {
+                continue;
+            }
+
             // Sadece aktif kattaki boruları kontrol et
             if (currentFloorId && boru.floorId && boru.floorId !== currentFloorId) {
                 continue;


### PR DESCRIPTION
Sorun: Servis kutusu olmayan projelerde sayaç ekledikten sonra ocak eklerken, ocak ghost preview flexi ta sayaca kadar uzatıyordu. Servis kutusu olan projelerde bu sorun yoktu.

Sebep: isTrulyFreeEndpoint() metodu bir noktadaki boru sayısını kontrol ederken CANLI_HAT (hayali) borularını da sayıyordu. Bu yüzden:
- Servis kutusu VAR: Gerçek boru → Sayaç → Boru → (boş uç = 1 boru) ✓
- Servis kutusu YOK: CANLI_HAT → Sayaç → Boru → (boş uç = 2 boru) ✗

Çözüm: CANLI_HAT borularını sayıma dahil etme. Böylece her iki durumda da boş uç doğru şekilde tespit edilir ve ocak ghost preview doğru snap yapar.