### PR TITLE
CANLI_HAT fleks ghost ve X-Y snap sorunlarını düzelt

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -286,9 +286,31 @@ export class InteractionManager {
 
                 return true;
             } else {
-                // İkinci tıklama - Sayaç konumu (mouse'un tıkladığı yer)
-                const sayacKonumu = { x: targetPoint.x, y: targetPoint.y };
-                console.log('[CANLI HAT] Sayaç konumu:', sayacKonumu);
+                // İkinci tıklama - X-Y snap uygulanmış pozisyonu kullan (ghost'tan)
+                // Ghost component zaten X-Y snap'li pozisyonda (updateGhostPreview'da hesaplandı)
+                let sayacKonumu;
+                if (this.manager.tempComponent) {
+                    // Ghost'un X-Y snap'li pozisyonunu kullan
+                    const baslangic = this.canliHatBaslangic;
+                    let dx = point.x - baslangic.x;
+                    let dy = point.y - baslangic.y;
+
+                    // X-Y yönüne snap (90 derece) - ghost preview ile aynı mantık
+                    if (Math.abs(dx) > Math.abs(dy)) {
+                        dy = 0; // Yatay
+                    } else {
+                        dx = 0; // Dikey
+                    }
+
+                    sayacKonumu = {
+                        x: baslangic.x + dx,
+                        y: baslangic.y + dy
+                    };
+                } else {
+                    sayacKonumu = { x: targetPoint.x, y: targetPoint.y };
+                }
+
+                console.log('[CANLI HAT] Sayaç konumu (X-Y snap):', sayacKonumu);
 
                 // Hayali boru + sayaç ekle
                 const success = this.handleCanliHatSayacEkleme(this.canliHatBaslangic, sayacKonumu);


### PR DESCRIPTION
İki ayrı sorun vardı:

1. CANLI_HAT'tan Uzun Fleks Ghost:
   - Cihaz/sayaç ghost preview'da fleks boru ucundan başlıyordu
   - Eğer boru sayaca/servis kutusuna bağlıysa, fleks onların çıkış noktasından başlamalı (CANLI_HAT ucundan değil)
   - CANLI_HAT borularına hiç fleks çizilmeyecek şekilde düzeltildi

2. X-Y Snap Gösterip Serbest Çiziyor:
   - CANLI_HAT modunda ghost preview X-Y snap gösteriyordu
   - Ama tıklamada raw mouse point kullanılıyordu
   - Artık tıklama anında da aynı X-Y snap mantığı uygulanıyor

Değişiklikler:
- plumbing-renderer.js: drawCihazGhostConnection ve drawSayacGhostConnection metodlarında fleks başlangıç noktası hesaplaması ve CANLI_HAT kontrolü
- interaction-manager.js: CANLI_HAT modunda tıklama anında X-Y snap uygulama