### PR TITLE
İç tesisat (servis kutusu olmadan) sayaç yerleştirme sistemi eklendi

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -292,6 +292,13 @@ export class PlumbingRenderer {
 
             ctx.save();
 
+            // Kesikli çizgi desteği (İÇ TESİSAT için temsili boru)
+            if (pipe.lineStyle === 'dashed') {
+                ctx.setLineDash([5, 5]);
+            } else {
+                ctx.setLineDash([]);
+            }
+
             // Koordinat sistemini borunun başlangıcına taşı ve döndür
             ctx.translate(pipe.p1.x, pipe.p1.y);
             ctx.rotate(angle);


### PR DESCRIPTION
Özellikler:
- Projede servis kutusu yoksa sayaç boş alana eklenebilir
- İlk tıklama: 50cm kesikli temsili boru + sayaç + vana eklenir
- Otomatik rotate moduna geçer
- İkinci tıklama: Rotate tamamlanır ve boru çizimi başlar
- Temsili boru kolon renginde kesikli çizilir
- Rotate sırasında tüm grup birlikte döner

Değişiklikler:
- interaction-manager.js:
  - hasServisKutusu() helper fonksiyonu eklendi
  - case 'sayac': servis kutusu kontrolü ve İÇ TESİSAT modu eklendi
  - handleRotation: Temsili boru güncelleme desteği eklendi
  - handlePointerDown: 2. tıklama için rotate bitirme eklendi
- plumbing-renderer.js:
  - drawPipes: Kesikli çizgi (dashed) desteği eklendi