### PR TITLE
Servis kutusu ve sayaç çıkış validasyonu düzeltildi

### DIFF
--- a/plumbing_v2/objects/meter.js
+++ b/plumbing_v2/objects/meter.js
@@ -222,7 +222,12 @@ export class Sayac {
      * Çıkışa boru bağla (Rijit)
      */
     baglaCikis(boruId) {
+        if (this.cikisBagliBoruId) {
+            console.warn('Sayaç çıkışı zaten kullanımda');
+            return false;
+        }
         this.cikisBagliBoruId = boruId;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Sorun:
- Servis kutusu ve sayaç çıkışlarından birden fazla hat eklenebiliyordu
- Hat taşınırken bağlantılar kopuyordu
- Validation metodları çağrılıyor ama etkili olmuyordu

Çözüm:
1. startBoruCizim çağrılarında eksik BAGLANTI_TIPLERI parametreleri eklendi
   - placeComponent içinde servis kutusu için parametre eksikti

2. meter.js baglaCikis() metoduna validation eklendi
   - Artık zaten kullanımda olan çıkışa bağlantı yapılamıyor
   - service-box.js ile tutarlı hale getirildi

3. handleBoruClick içinde return değerleri kontrol ediliyor
   - baglaBoru() ve baglaCikis() false dönerse boru eklenmez
   - Kullanıcı uyarı mesajı alır

4. Boru silindiğinde bağlantılar doğru şekilde temizleniyor
   - Servis kutusu için boruBaglantisinKaldir() kullanılıyor
   - Sayaç için cikisBagliBoruId null yapılıyor

Değişiklikler:
- plumbing_v2/interactions/interaction-manager.js
  * placeComponent(): servis_kutusu için BAGLANTI_TIPLERI.SERVIS_KUTUSU eklendi
  * handleBoruClick(): baglaBoru/baglaCikis return değerleri kontrol ediliyor
  * removeObject(): bağlantı temizleme sayaç için de eklendi

- plumbing_v2/objects/meter.js
  * baglaCikis(): çıkış kullanımda ise false döndürüyor