### PR TITLE
FİX: Boru çizimi aktifken servis kutusu/sayaca tıklama sorunu düzeltildi

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -328,8 +328,24 @@ export class InteractionManager {
 
         // 1. Boru çizim modunda tıklama
         if (this.boruCizimAktif) {
-            this.handleBoruClick(targetPoint);
-            return true;
+            // Servis kutusuna veya sayaca tıklanırsa mevcut çizimi iptal et
+            const clickedServisKutusu = this.manager.components.find(c =>
+                c.type === 'servis_kutusu' && c.containsPoint && c.containsPoint(point)
+            );
+            const clickedSayac = this.manager.components.find(c =>
+                c.type === 'sayac' && c.containsPoint && c.containsPoint(point)
+            );
+
+            if (clickedServisKutusu || clickedSayac) {
+                // Mevcut çizimi iptal et ve yeni çizim başlatmak için devam et
+                console.log('[DEBUG] Boru çizimi aktifken servis kutusu/sayaca tıklandı, çizim iptal ediliyor...');
+                this.cancelCurrentAction();
+                // Aşağıdaki kodlar yeni çizimi başlatacak
+            } else {
+                // Normal boru tıklaması - çizime devam et
+                this.handleBoruClick(targetPoint);
+                return true;
+            }
         }
 
         // 1.5. İç tesisat sayaç yerleştirme - ikinci nokta tıklaması


### PR DESCRIPTION
Sorun: Kullanıcı ilk boruyu çizdikten sonra servis kutusuna tekrar tıkladığında, sistem mevcut boru çizimini devam ettiriyordu. Bu yüzden ikinci boru servis kutusundan değil, ilk borunun ucundan çiziliyordu.

Çözüm: Boru çizimi aktifken servis kutusu veya sayaca tıklanırsa, mevcut çizim iptal ediliyor ve yeni çizim başlatılıyor.

Bu sayede validasyon doğru çalışıyor ve ikinci hat engelleniyor.