### PR TITLE
Fix: Boru bölme sürüklemede bağlantı kopma sorunu

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -149,6 +149,7 @@ export class InteractionManager {
         this.dragAxisPoint = null;
         this.connectedPipeAtP1 = null;
         this.connectedPipeAtP2 = null;
+        this.endpointConnections = null; // Endpoint sürükleme için bağlı borular snapshot'i
         this.useBridgeMode = false;
         this.dragStartObjectPos = null;
         this.axisLockDetermined = false;


### PR DESCRIPTION
Kutu veya sayaç çıkışındaki bir hattı böldüğümüzde ve dikey boruyu sürükleyerek kutu/sayaç üzerine getirdiğimizde, bağlantı borusunun uzunluğu sıfıra düşüyor ve geri çekerken kutu kopuyordu.

Sorun: updateConnectedPipesChain fonksiyonu "anlık yakınlık" mantığıyla çalışıyordu. Boru uzunluğu sıfıra düşünce her iki uç da aynı noktada olduğu için ikisi de birlikte hareket ediyordu.

Çözüm: Sürükleme başladığında bağlı boruları "snapshot" olarak kaydedip, sürükleme sırasında sadece bu snapshot'teki boruların ilgili uçlarını güncelleyerek, boru uzunluğu sıfıra düşse bile doğru uçların hareket etmesini sağladık.

Değişiklikler:
- startEndpointDrag: Bağlı boruları endpointConnections'a kaydet
- startBodyDrag: Zaten connectedPipeAtP1/P2 kaydediyordu (✓)
- handleDrag: updateConnectedPipesChain yerine snapshot kullan
- endDrag: Snapshot'i temizle
- InteractionManager: endpointConnections field'ı ekle