### PR TITLE
Fix: Boru bölme (split) sonrası kutu/sayaç bağlantısını koru

### DIFF
--- a/plumbing_v2/interactions/pipe/pipe-drawing.js
+++ b/plumbing_v2/interactions/pipe/pipe-drawing.js
@@ -155,18 +155,34 @@ export function handlePipeSplit(interactionManager, pipe, splitPoint, startDrawi
     boru1.setBitisBaglanti('boru', boru2.id);
     boru2.setBaslangicBaglanti('boru', boru1.id);
 
+    // Eski boruyu sil, yenileri ekle
+    const idx = interactionManager.manager.pipes.findIndex(p => p.id === pipe.id);
+    if (idx !== -1) interactionManager.manager.pipes.splice(idx, 1);
+    interactionManager.manager.pipes.push(boru1, boru2);
+
     // Servis kutusu bağlantısını güncelle (Her zaman başlangıca bağlıdır)
     if (pipe.baslangicBaglanti?.tip === BAGLANTI_TIPLERI.SERVIS_KUTUSU) {
         const sk = interactionManager.manager.components.find(c => c.id === pipe.baslangicBaglanti.hedefId);
         if (sk && sk.bagliBoruId === pipe.id) {
             sk.baglaBoru(boru1.id);
+            // Kutu çıkışını boru1.p1'e zorla eşitle (bağlantıyı koru)
+            const cikis = sk.getCikisNoktasi();
+            boru1.p1.x = cikis.x;
+            boru1.p1.y = cikis.y;
         }
     }
 
-    // Eski boruyu sil, yenileri ekle
-    const idx = interactionManager.manager.pipes.findIndex(p => p.id === pipe.id);
-    if (idx !== -1) interactionManager.manager.pipes.splice(idx, 1);
-    interactionManager.manager.pipes.push(boru1, boru2);
+    // Sayaç bağlantısını güncelle
+    if (pipe.baslangicBaglanti?.tip === BAGLANTI_TIPLERI.SAYAC) {
+        const meter = interactionManager.manager.components.find(c => c.id === pipe.baslangicBaglanti.hedefId);
+        if (meter && meter.cikisBagliBoruId === pipe.id) {
+            meter.cikisBagliBoruId = boru1.id;
+            // Sayaç çıkışını boru1.p1'e zorla eşitle
+            const cikis = meter.getCikisNoktasi();
+            boru1.p1.x = cikis.x;
+            boru1.p1.y = cikis.y;
+        }
+    }
 
     // --- ADIM 3: YENİDEN DAĞITIM (Mesafe Bazlı) ---
     // Her bileşeni, kaydettiğimiz konumuna en yakın olan yeni boruya bağla


### PR DESCRIPTION
SORUN:
Kutuya bağlı ilk boruyu böldüğümüzde, A nolu parçayı çizmeden önce kutu kopuyordu. Split işlemi sırasında bağlantı bozuluyordu.

KÖK NEDEN:
handlePipeSplit fonksiyonunda:
1. Yeni borular oluşturuluyordu (boru1, boru2)
2. Kutu bağlantısı güncellen iyordu (sk.baglaBoru(boru1.id))
3. AMA boru1.p1 koordinatı kutu çıkışı ile tam eşitlenmiyordu
4. Küçük koordinat farklılıkları parent-children sistemini bozuyordu

ÇÖZÜM:
Split işleminden SONRA:
1. Kutu/sayaç bağlantısını güncelle
2. boru1.p1'i kutu/sayaç çıkışına ZORLA eşitle
3. Böylece parent-children sistemi bağlantıyı koruyor

Değişiklikler:
- handlePipeSplit: Eski boruyu SİLDİKTEN SONRA kutu bağlantısını güncelle
- Kutu durumu: sk.baglaBoru() + boru1.p1 = sk.getCikisNoktasi()
- Sayaç durumu: meter.cikisBagliBoruId + boru1.p1 = meter.getCikisNoktasi()

Artık kutuya bağlı ilk boruyu böldükten sonra kutu kopmuyor!