### PR TITLE
Fix: Sayaç döndürme hatası ve kutu split koordinat güncellemesi

### DIFF
--- a/plumbing_v2/interactions/drag/drag-handler.js
+++ b/plumbing_v2/interactions/drag/drag-handler.js
@@ -52,7 +52,7 @@ function getNodeConnections(pipes, point, excludePipe = null) {
  * @param {Object} oldPoint - Eski nokta {x, y}
  * @param {Object} newPoint - Yeni nokta {x, y}
  */
-function updateNodeConnections(pipes, oldPoint, newPoint) {
+export function updateNodeConnections(pipes, oldPoint, newPoint) {
     const connections = getNodeConnections(pipes, oldPoint);
 
     // Parent'ı güncelle

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -43,7 +43,6 @@ import {
     startDrag,
     startBodyDrag,
     handleDrag,
-    updateConnectedPipesChain,
     endDrag
 } from './drag/drag-handler.js';
 
@@ -262,10 +261,6 @@ export class InteractionManager {
         return handleDrag(this, point);
     }
 
-    updateConnectedPipesChain(oldPoint, newPoint) {
-        return updateConnectedPipesChain(this, oldPoint, newPoint);
-    }
-
     endDrag() {
         return endDrag(this);
     }
@@ -282,7 +277,7 @@ export class InteractionManager {
     }
 
     handleRotation(point) {
-        return handleRotation(this, point, this.manager, updateConnectedPipesChain);
+        return handleRotation(this, point, this.manager);
     }
 
     endRotation() {
@@ -290,7 +285,7 @@ export class InteractionManager {
     }
 
     updateConnectedPipe(result) {
-        return updateConnectedPipe(result, this.manager, updateConnectedPipesChain);
+        return updateConnectedPipe(result, this.manager);
     }
 
     /**

--- a/plumbing_v2/interactions/pipe/pipe-drawing.js
+++ b/plumbing_v2/interactions/pipe/pipe-drawing.js
@@ -164,11 +164,33 @@ export function handlePipeSplit(interactionManager, pipe, splitPoint, startDrawi
     if (pipe.baslangicBaglanti?.tip === BAGLANTI_TIPLERI.SERVIS_KUTUSU) {
         const sk = interactionManager.manager.components.find(c => c.id === pipe.baslangicBaglanti.hedefId);
         if (sk && sk.bagliBoruId === pipe.id) {
+            const oldP1 = { ...boru1.p1 }; // Eski koordinat
             sk.baglaBoru(boru1.id);
+
             // Kutu çıkışını boru1.p1'e zorla eşitle (bağlantıyı koru)
             const cikis = sk.getCikisNoktasi();
             boru1.p1.x = cikis.x;
             boru1.p1.y = cikis.y;
+
+            // Parent-children'ları güncelle (diğer bağlı boruları da taşı)
+            const TOLERANCE = 1.0;
+            interactionManager.manager.pipes.forEach(p => {
+                if (p === boru1 || p === boru2) return;
+
+                // p1'i güncelle
+                const distToP1 = Math.hypot(p.p1.x - oldP1.x, p.p1.y - oldP1.y);
+                if (distToP1 < TOLERANCE) {
+                    p.p1.x = cikis.x;
+                    p.p1.y = cikis.y;
+                }
+
+                // p2'yi güncelle
+                const distToP2 = Math.hypot(p.p2.x - oldP1.x, p.p2.y - oldP1.y);
+                if (distToP2 < TOLERANCE) {
+                    p.p2.x = cikis.x;
+                    p.p2.y = cikis.y;
+                }
+            });
         }
     }
 
@@ -176,11 +198,31 @@ export function handlePipeSplit(interactionManager, pipe, splitPoint, startDrawi
     if (pipe.baslangicBaglanti?.tip === BAGLANTI_TIPLERI.SAYAC) {
         const meter = interactionManager.manager.components.find(c => c.id === pipe.baslangicBaglanti.hedefId);
         if (meter && meter.cikisBagliBoruId === pipe.id) {
+            const oldP1 = { ...boru1.p1 }; // Eski koordinat
             meter.cikisBagliBoruId = boru1.id;
+
             // Sayaç çıkışını boru1.p1'e zorla eşitle
             const cikis = meter.getCikisNoktasi();
             boru1.p1.x = cikis.x;
             boru1.p1.y = cikis.y;
+
+            // Parent-children'ları güncelle
+            const TOLERANCE = 1.0;
+            interactionManager.manager.pipes.forEach(p => {
+                if (p === boru1 || p === boru2) return;
+
+                const distToP1 = Math.hypot(p.p1.x - oldP1.x, p.p1.y - oldP1.y);
+                if (distToP1 < TOLERANCE) {
+                    p.p1.x = cikis.x;
+                    p.p1.y = cikis.y;
+                }
+
+                const distToP2 = Math.hypot(p.p2.x - oldP1.x, p.p2.y - oldP1.y);
+                if (distToP2 < TOLERANCE) {
+                    p.p2.x = cikis.x;
+                    p.p2.y = cikis.y;
+                }
+            });
         }
     }
 

--- a/plumbing_v2/interactions/rotation/rotation-handler.js
+++ b/plumbing_v2/interactions/rotation/rotation-handler.js
@@ -4,6 +4,7 @@
  */
 
 import { saveState } from '../../../general-files/history.js';
+import { updateNodeConnections } from '../drag/drag-handler.js';
 
 /**
  * Döndürme tutamacını bul (çubuğun ucundaki daire) - yukarı yönde
@@ -54,7 +55,7 @@ export function startRotation(context, obj, point) {
 /**
  * Döndürme işle
  */
-export function handleRotation(context, point, manager, updateConnectedPipesChain) {
+export function handleRotation(context, point, manager) {
     if (!context.dragObject) return;
 
     const obj = context.dragObject;
@@ -125,8 +126,8 @@ export function handleRotation(context, point, manager, updateConnectedPipesChai
                 const yeniCikis = obj.getCikisNoktasi();
                 cikisBoru.moveP1(yeniCikis);
 
-                // Bağlı boru zincirini güncelle
-                updateConnectedPipesChain(oldP1, yeniCikis);
+                // Parent ve children'ları güncelle
+                updateNodeConnections(manager.pipes, oldP1, yeniCikis);
             }
         }
     }
@@ -146,7 +147,7 @@ export function endRotation(context, manager) {
 /**
  * Bağlı boruyu güncelle
  */
-export function updateConnectedPipe(result, manager, updateConnectedPipesChain) {
+export function updateConnectedPipe(result, manager) {
     if (!result) return;
 
     if (result.bagliBoruId && result.delta) {
@@ -163,8 +164,8 @@ export function updateConnectedPipe(result, manager, updateConnectedPipesChain) 
             // Yeni p1 pozisyonu
             const newP1 = { x: boru.p1.x, y: boru.p1.y };
 
-            // Bağlı boru zincirini güncelle
-            updateConnectedPipesChain(oldP1, newP1);
+            // Parent ve children'ları güncelle
+            updateNodeConnections(manager.pipes, oldP1, newP1);
         }
     }
 
@@ -176,8 +177,8 @@ export function updateConnectedPipe(result, manager, updateConnectedPipesChain) 
 
             boru.moveP1(result.yeniCikis);
 
-            // Bağlı boru zincirini güncelle
-            updateConnectedPipesChain(oldP1, result.yeniCikis);
+            // Parent ve children'ları güncelle
+            updateNodeConnections(manager.pipes, oldP1, result.yeniCikis);
         }
     }
 }


### PR DESCRIPTION
SORUN 1: Sayaç döndürme hatası
Sayaç döndürürken "Cannot read properties of undefined (reading 'pipes')" hatası veriyordu.

KÖK NEDEN:
rotation-handler.js dosyasında updateConnectedPipesChain fonksiyonu yanlış parametrelerle çağrılıyordu. Eski imza: (interactionManager, oldPoint, newPoint) ama (oldP1, yeniCikis) olarak çağrılıyordu.

ÇÖZÜM:
- updateNodeConnections'u export ettik
- rotation-handler'da import edip doğru parametrelerle kullandık
- interaction-manager'dan updateConnectedPipesChain kaldırıldı

SORUN 2: Kutu hala bozuk
Kutu çıkışındaki boru bölündükten sonra kutu koordinatı güncelleniyordu ama diğer bağlı borular eski koordinatta kalıyordu.

ÇÖZÜM:
handlePipeSplit'te kutu/sayaç bağlantısı güncellendikten SONRA, o noktadaki TÜM boruların koordinatlarını güncelliyoruz.

Değişiklikler:
- updateNodeConnections: export edildi
- rotation-handler: updateNodeConnections import ve kullan
- interaction-manager: updateConnectedPipesChain kaldırıldı
- handlePipeSplit: Kutu/sayaç güncellemesinden sonra parent-children güncelle

Artık hem sayaç dönüyor hem kutu split sonrası düzgün çalışıyor!