### PR TITLE
Fix: Hızlı ardışık boru sürüklemede endpoint kopması sorunu

### DIFF
--- a/plumbing_v2/interactions/drag/drag-handler.js
+++ b/plumbing_v2/interactions/drag/drag-handler.js
@@ -187,6 +187,41 @@ export function startBodyDrag(interactionManager, pipe, point) {
     interactionManager.bodyDragInitialP1 = { ...pipe.p1 };
     interactionManager.bodyDragInitialP2 = { ...pipe.p2 };
 
+    // ✨ BAĞLANTI İYİLEŞTİRME: Hızlı ardışık drag sırasında floating-point hatalarını düzelt
+    // Sürüklenen borunun endpoint'lerine yakın olan diğer boru uçlarını tam olarak aynı noktaya çek
+    const SNAP_TOLERANCE = 2.0; // 2cm içindeki bağlantıları düzelt
+    const pipes = interactionManager.manager.pipes;
+
+    // P1 için snap
+    pipes.forEach(otherPipe => {
+        if (otherPipe === pipe) return;
+        const distToP1 = Math.hypot(otherPipe.p1.x - pipe.p1.x, otherPipe.p1.y - pipe.p1.y);
+        if (distToP1 > 0 && distToP1 < SNAP_TOLERANCE) {
+            otherPipe.p1.x = pipe.p1.x;
+            otherPipe.p1.y = pipe.p1.y;
+        }
+        const distToP2 = Math.hypot(otherPipe.p2.x - pipe.p1.x, otherPipe.p2.y - pipe.p1.y);
+        if (distToP2 > 0 && distToP2 < SNAP_TOLERANCE) {
+            otherPipe.p2.x = pipe.p1.x;
+            otherPipe.p2.y = pipe.p1.y;
+        }
+    });
+
+    // P2 için snap
+    pipes.forEach(otherPipe => {
+        if (otherPipe === pipe) return;
+        const distToP1 = Math.hypot(otherPipe.p1.x - pipe.p2.x, otherPipe.p1.y - pipe.p2.y);
+        if (distToP1 > 0 && distToP1 < SNAP_TOLERANCE) {
+            otherPipe.p1.x = pipe.p2.x;
+            otherPipe.p1.y = pipe.p2.y;
+        }
+        const distToP2 = Math.hypot(otherPipe.p2.x - pipe.p2.x, otherPipe.p2.y - pipe.p2.y);
+        if (distToP2 > 0 && distToP2 < SNAP_TOLERANCE) {
+            otherPipe.p2.x = pipe.p2.x;
+            otherPipe.p2.y = pipe.p2.y;
+        }
+    });
+
     // P1 noktası için parent ve children'ları bul
     const p1Connections = getNodeConnections(interactionManager.manager.pipes, pipe.p1, pipe);
     interactionManager.p1Parent = p1Connections.parent;


### PR DESCRIPTION
Hızlı ardışık sürükleme sırasında floating-point hataları ve küçük pozisyon kaymaları nedeniyle bağlantı noktaları tolerance (1cm) mesafesini aşıyordu. İkinci drag başladığında getNodeConnections bu bağlantıları bulamıyor ve boru endpoint'lerinden kopuyordu.

Çözüm:
- startBodyDrag başında bağlantı iyileştirme mekanizması eklendi
- Sürüklenen borunun p1 ve p2 noktalarına 2cm içinde olan diğer boru uçları otomatik olarak tam aynı noktaya hizalanıyor
- Bu sayede ardışık draglar arasında bağlantı tutarlılığı korunuyor

Dosya: plumbing_v2/interactions/drag/drag-handler.js:190-223