### PR TITLE
Revert: Bağımsız boruların birleşmesine neden olan snap healing kaldı…

### DIFF
--- a/plumbing_v2/interactions/drag/drag-handler.js
+++ b/plumbing_v2/interactions/drag/drag-handler.js
@@ -187,41 +187,6 @@ export function startBodyDrag(interactionManager, pipe, point) {
     interactionManager.bodyDragInitialP1 = { ...pipe.p1 };
     interactionManager.bodyDragInitialP2 = { ...pipe.p2 };
 
-    // ✨ BAĞLANTI İYİLEŞTİRME: Hızlı ardışık drag sırasında floating-point hatalarını düzelt
-    // Sürüklenen borunun endpoint'lerine yakın olan diğer boru uçlarını tam olarak aynı noktaya çek
-    const SNAP_TOLERANCE = 2.0; // 2cm içindeki bağlantıları düzelt
-    const pipes = interactionManager.manager.pipes;
-
-    // P1 için snap
-    pipes.forEach(otherPipe => {
-        if (otherPipe === pipe) return;
-        const distToP1 = Math.hypot(otherPipe.p1.x - pipe.p1.x, otherPipe.p1.y - pipe.p1.y);
-        if (distToP1 > 0 && distToP1 < SNAP_TOLERANCE) {
-            otherPipe.p1.x = pipe.p1.x;
-            otherPipe.p1.y = pipe.p1.y;
-        }
-        const distToP2 = Math.hypot(otherPipe.p2.x - pipe.p1.x, otherPipe.p2.y - pipe.p1.y);
-        if (distToP2 > 0 && distToP2 < SNAP_TOLERANCE) {
-            otherPipe.p2.x = pipe.p1.x;
-            otherPipe.p2.y = pipe.p1.y;
-        }
-    });
-
-    // P2 için snap
-    pipes.forEach(otherPipe => {
-        if (otherPipe === pipe) return;
-        const distToP1 = Math.hypot(otherPipe.p1.x - pipe.p2.x, otherPipe.p1.y - pipe.p2.y);
-        if (distToP1 > 0 && distToP1 < SNAP_TOLERANCE) {
-            otherPipe.p1.x = pipe.p2.x;
-            otherPipe.p1.y = pipe.p2.y;
-        }
-        const distToP2 = Math.hypot(otherPipe.p2.x - pipe.p2.x, otherPipe.p2.y - pipe.p2.y);
-        if (distToP2 > 0 && distToP2 < SNAP_TOLERANCE) {
-            otherPipe.p2.x = pipe.p2.x;
-            otherPipe.p2.y = pipe.p2.y;
-        }
-    });
-
     // P1 noktası için parent ve children'ları bul
     const p1Connections = getNodeConnections(interactionManager.manager.pipes, pipe.p1, pipe);
     interactionManager.p1Parent = p1Connections.parent;


### PR DESCRIPTION
…rıldı

Önceki commit'te (0137286) eklenen "bağlantı iyileştirme" mekanizması hatalıydı. Bu mekanizma TÜM borulara bakıp 2cm içindeki herhangi bir boru ucunu birbirine yapıştırıyordu - bağımsız borular dahil.

Sorun: Ayrı ayrı çizilmiş 2 bağımsız boru ucunu birbirine sürükleyince otomatik olarak birleşiyorlardı.

Çözüm: Snap healing mekanizması tamamen kaldırıldı. Mevcut occupation check mekanizması (1.5cm tolerance) bağımsız boruların birbirine yaklaşmasını zaten engelliyor.

Dosya: plumbing_v2/interactions/drag/drag-handler.js:190-223 (silindi)