### PR TITLE
Fix: Yeni eklenen component'in kendi çıkışı artık korunmuyor

### DIFF
--- a/plumbing_v2/interactions/drag/drag-handler.js
+++ b/plumbing_v2/interactions/drag/drag-handler.js
@@ -22,14 +22,16 @@ import { state } from '../../../general-files/main.js';
  * @param {Object} manager - PlumbingManager instance
  * @param {Object} currentPipe - Şu an sürüklenen boru (hariç tutulacak)
  * @param {Object} oldPoint - Sürüklenen ucun eski pozisyonu (hariç tutulacak)
+ * @param {string} excludeComponentId - Hariç tutulacak component ID (yeni eklenen component için)
  * @returns {boolean} - Nokta korumalı mı?
  */
-export function isProtectedPoint(point, manager, currentPipe, oldPoint) {
+export function isProtectedPoint(point, manager, currentPipe, oldPoint, excludeComponentId = null) {
     const TOLERANCE = 10; // 10 cm içinde korumalı nokta varsa engelle
 
     // 1. Servis kutusu çıkışı kontrolü
     const servisKutusuCikisi = manager.components.some(c => {
         if (c.type !== 'servis_kutusu') return false;
+        if (excludeComponentId && c.id === excludeComponentId) return false; // Yeni eklenen kutuyu atla
         const cikis = c.getCikisNoktasi();
         if (!cikis) return false;
         const dist = Math.hypot(point.x - cikis.x, point.y - cikis.y);
@@ -43,6 +45,7 @@ export function isProtectedPoint(point, manager, currentPipe, oldPoint) {
     // 2. Sayaç giriş kontrolü (fleks bağlantısı)
     const sayacGirisi = manager.components.some(c => {
         if (c.type !== 'sayac' || !c.fleksBaglanti) return false;
+        if (excludeComponentId && c.id === excludeComponentId) return false; // Yeni eklenen sayacı atla
         const giris = c.getGirisNoktasi();
         if (!giris) return false;
         const dist = Math.hypot(point.x - giris.x, point.y - giris.y);
@@ -56,6 +59,7 @@ export function isProtectedPoint(point, manager, currentPipe, oldPoint) {
     // 3. Sayaç çıkışı kontrolü
     const sayacCikisi = manager.components.some(c => {
         if (c.type !== 'sayac') return false;
+        if (excludeComponentId && c.id === excludeComponentId) return false; // Yeni eklenen sayacı atla
         const cikis = c.getCikisNoktasi();
         if (!cikis) return false;
         const dist = Math.hypot(point.x - cikis.x, point.y - cikis.y);
@@ -69,6 +73,7 @@ export function isProtectedPoint(point, manager, currentPipe, oldPoint) {
     // 4. Cihaz fleks bağlantısı kontrolü
     const cihazFleksi = manager.components.some(c => {
         if (c.type !== 'cihaz') return false;
+        if (excludeComponentId && c.id === excludeComponentId) return false; // Yeni eklenen cihazı atla
         // Cihazın giriş noktasını al (boruya bağlı olsun olmasın)
         const giris = c.getGirisNoktasi();
         if (!giris) return false;

--- a/plumbing_v2/interactions/pipe/pipe-drawing.js
+++ b/plumbing_v2/interactions/pipe/pipe-drawing.js
@@ -15,8 +15,16 @@ import { isProtectedPoint } from '../drag/drag-handler.js';
  * Boru çizim modunu başlat
  */
 export function startBoruCizim(interactionManager, baslangicNoktasi, kaynakId = null, kaynakTip = null, colorGroup = null) {
+    // Eğer kaynak bir servis kutusu, sayaç veya cihaz ise, o component'in kendi çıkışını hariç tut
+    let excludeComponentId = null;
+    if (kaynakTip === BAGLANTI_TIPLERI.SERVIS_KUTUSU ||
+        kaynakTip === BAGLANTI_TIPLERI.SAYAC ||
+        kaynakTip === BAGLANTI_TIPLERI.CIHAZ) {
+        excludeComponentId = kaynakId;
+    }
+
     // ⚠️ KRİTİK: Korumalı noktalara boru başlatmayı engelle
-    if (isProtectedPoint(baslangicNoktasi, interactionManager.manager, null, null)) {
+    if (isProtectedPoint(baslangicNoktasi, interactionManager.manager, null, null, excludeComponentId)) {
         alert('⚠️ Bu noktadan boru başlatılamaz! (Korumalı nokta: Servis kutusu çıkışı, sayaç giriş/çıkışı, cihaz fleksi, dirsek veya boşta boru ucu)');
         console.warn('🚫 ENGEL: Başlangıç noktası korumalı!', baslangicNoktasi);
         return;
@@ -335,14 +343,22 @@ export function handleBoruClick(interactionManager, point) {
     // Undo için state kaydet (her boru için ayrı undo entry)
     saveState();
 
+    // Eğer kaynak bir servis kutusu, sayaç veya cihaz ise, o component'in kendi çıkışını hariç tut
+    let excludeComponentId = null;
+    if (interactionManager.boruBaslangic.kaynakTip === BAGLANTI_TIPLERI.SERVIS_KUTUSU ||
+        interactionManager.boruBaslangic.kaynakTip === BAGLANTI_TIPLERI.SAYAC ||
+        interactionManager.boruBaslangic.kaynakTip === BAGLANTI_TIPLERI.CIHAZ) {
+        excludeComponentId = interactionManager.boruBaslangic.kaynakId;
+    }
+
     // ⚠️ KRİTİK: Başlangıç noktası korumalı mı kontrol et
-    if (isProtectedPoint(interactionManager.boruBaslangic.nokta, interactionManager.manager, null, null)) {
+    if (isProtectedPoint(interactionManager.boruBaslangic.nokta, interactionManager.manager, null, null, excludeComponentId)) {
         alert('⚠️ Başlangıç noktası korumalı! Boru oluşturulamaz.');
         console.warn('🚫 ENGEL: Başlangıç noktası korumalı!', interactionManager.boruBaslangic.nokta);
         return;
     }
 
-    // ⚠️ KRİTİK: Bitiş noktası korumalı mı kontrol et
+    // ⚠️ KRİTİK: Bitiş noktası korumalı mı kontrol et (excludeComponentId yok, bitiş noktası için)
     if (isProtectedPoint(point, interactionManager.manager, null, null)) {
         alert('⚠️ Bu noktaya boru bağlanamaz! (Korumalı nokta: Servis kutusu çıkışı, sayaç giriş/çıkışı, cihaz fleksi, dirsek veya boşta boru ucu)');
         console.warn('🚫 ENGEL: Bitiş noktası korumalı!', point);


### PR DESCRIPTION
SORUN:
Yeni servis kutusu, sayaç veya cihaz eklerken, otomatik olarak o component'ten boru çizimi başlatılıyor. Ama isProtectedPoint fonksiyonu o yeni eklenen component'in KENDİ çıkışını da korumalı olarak algılıyordu. Bu yüzden kullanıcı yeni component ekleyemiyordu.

DÜZELTME:
1. isProtectedPoint'e excludeComponentId parametresi eklendi
2. Eğer excludeComponentId verilirse, o component'in çıkışı korumalı olarak sayılmaz
3. startBoruCizim ve handleBoruClick'te kaynakTip kontrol ediliyor:
   - SERVIS_KUTUSU, SAYAC veya CIHAZ ise
   - excludeComponentId = kaynakId olarak geçiliyor

Artık:
✅ Yeni servis kutusu eklerken kendi çıkışından boru başlatılabiliyor ✅ Yeni sayaç eklerken kendi çıkışından boru başlatılabiliyor ✅ Yeni cihaz eklerken kendi girişine boru bağlanabiliyor ❌ Ama başka component'lerin çıkışları hala korunuyor

Dosyalar:
- plumbing_v2/interactions/drag/drag-handler.js:28,34,48,62,76
- plumbing_v2/interactions/pipe/pipe-drawing.js:18-24,27,346-352,355