### PR TITLE
Fix: Boru çizimine 'boşta boru ucu' kontrolü artık uygulanmıyor

### DIFF
--- a/plumbing_v2/interactions/pipe/pipe-drawing.js
+++ b/plumbing_v2/interactions/pipe/pipe-drawing.js
@@ -24,8 +24,9 @@ export function startBoruCizim(interactionManager, baslangicNoktasi, kaynakId = 
     }
 
     // ⚠️ KRİTİK: Korumalı noktalara boru başlatmayı engelle
-    if (isProtectedPoint(baslangicNoktasi, interactionManager.manager, null, null, excludeComponentId)) {
-        alert('⚠️ Bu noktadan boru başlatılamaz! (Korumalı nokta: Servis kutusu çıkışı, sayaç giriş/çıkışı, cihaz fleksi, dirsek veya boşta boru ucu)');
+    // NOT: skipBostaUcCheck=true çünkü boru çizerken boşta uçlara bağlanabilmeli
+    if (isProtectedPoint(baslangicNoktasi, interactionManager.manager, null, null, excludeComponentId, true)) {
+        alert('⚠️ Bu noktadan boru başlatılamaz! (Korumalı nokta: Servis kutusu çıkışı, sayaç giriş/çıkışı, cihaz fleksi veya dirsek)');
         console.warn('🚫 ENGEL: Başlangıç noktası korumalı!', baslangicNoktasi);
         return;
     }
@@ -352,15 +353,17 @@ export function handleBoruClick(interactionManager, point) {
     }
 
     // ⚠️ KRİTİK: Başlangıç noktası korumalı mı kontrol et
-    if (isProtectedPoint(interactionManager.boruBaslangic.nokta, interactionManager.manager, null, null, excludeComponentId)) {
+    // NOT: skipBostaUcCheck=true çünkü boru çizerken boşta uçlara bağlanabilmeli
+    if (isProtectedPoint(interactionManager.boruBaslangic.nokta, interactionManager.manager, null, null, excludeComponentId, true)) {
         alert('⚠️ Başlangıç noktası korumalı! Boru oluşturulamaz.');
         console.warn('🚫 ENGEL: Başlangıç noktası korumalı!', interactionManager.boruBaslangic.nokta);
         return;
     }
 
-    // ⚠️ KRİTİK: Bitiş noktası korumalı mı kontrol et (excludeComponentId yok, bitiş noktası için)
-    if (isProtectedPoint(point, interactionManager.manager, null, null)) {
-        alert('⚠️ Bu noktaya boru bağlanamaz! (Korumalı nokta: Servis kutusu çıkışı, sayaç giriş/çıkışı, cihaz fleksi, dirsek veya boşta boru ucu)');
+    // ⚠️ KRİTİK: Bitiş noktası korumalı mı kontrol et
+    // NOT: skipBostaUcCheck=true çünkü boru çizerken boşta uçlara bağlanabilmeli
+    if (isProtectedPoint(point, interactionManager.manager, null, null, null, true)) {
+        alert('⚠️ Bu noktaya boru bağlanamaz! (Korumalı nokta: Servis kutusu çıkışı, sayaç giriş/çıkışı, cihaz fleksi veya dirsek)');
         console.warn('🚫 ENGEL: Bitiş noktası korumalı!', point);
         return;
     }


### PR DESCRIPTION
KRİTİK SORUN:
"Boşta boru ucu" kontrolü HER boşta olan ucu koruyor. Ama kullanıcı yeni boru çizerken TAM O BOŞTA UCA bağlanmak istiyor! Bu yüzden hiçbir boru çizilemiyor, her yere "korumalı nokta" uyarısı geliyor.

MANTIK HATASI:
- Endpoint drag: Bir boru ucunu başka boşta bir uca taşırken ENGELLE ✅
- Boru çizimi: Yeni boru çizerken boşta uca BAĞLANMALI ❌ (hatalı engelliyordu)

DÜZELTME:
1. isProtectedPoint'e skipBostaUcCheck parametresi eklendi
2. skipBostaUcCheck = true ise "boşta boru ucu" kontrolü ATLANIR
3. Boru çiziminde (startBoruCizim ve handleBoruClick) skipBostaUcCheck=true
4. Endpoint drag'de skipBostaUcCheck=false (default)

SONUÇ:
✅ Boru çizerken boşta uçlara bağlanabilirsin
✅ Endpoint drag'de boşta uçlar hala korunuyor (birbirine birleşemezler) ✅ Servis kutusu, sayaç, cihaz fleksi ve dirsekler her durumda korunuyor

Dosyalar:
- drag-handler.js:26,29,125,158
- pipe-drawing.js:27-28,356-357,364-365