### PR TITLE
Fix: Hızlı sürükleme kopma sorunu - Referans tabanlı yaklaşım

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -273,7 +273,7 @@ export class InteractionManager {
     }
 
     startRotation(obj, point) {
-        return startRotation(this, obj, point);
+        return startRotation(this, obj, point, this.manager);
     }
 
     handleRotation(point) {


### PR DESCRIPTION
Hızlı drag ve hatalı bağlantı yönlerinde kopma sorunu çözüldü.

SORUN:
- Her frame'de updateSharedVertex() tüm boruları tarıyordu (search)
- Hızlı drag'de tolerans (1cm) dışına çıkılabiliyordu
- Floating point hataları birikmesiyle bağlantılar kaybolabiliyordu
- Performance sorunu: Her frame O(n) search

ÇÖZÜM: Referans Tabanlı Yaklaşım
1. Sürükleme BAŞINDA bağlı boruları tespit et ve KAYDET
2. Her frame'de SEARCH YOK, kaydedilmiş referansları kullan
3. Sürükleme BİTİNCE referansları temizle

İyileştirmeler:
- startEndpointDrag: connectedPipesAtEndpoint kaydet
- startBodyDrag: connectedPipesAtP1 ve connectedPipesAtP2 kaydet
- handleDrag: Kaydedilmiş referansları kullan (search yok!)
- Servis Kutusu/Sayaç: Lazy initialization ile ilk frame'de kaydet
- Rotation: startRotation'da bağlantıları kaydet

Faydalar:
✅ Hızlı drag'de kopma YOK (tolerans problemi çözüldü) ✅ Her frame search yerine O(1) referans kullanımı
✅ Floating point hatalarından etkilenme YOK
✅ Hatalı bağlantı yönleri sorun YOK (tüm yönler desteklenir)

Etkilenen dosyalar:
- plumbing_v2/interactions/drag/drag-handler.js
- plumbing_v2/interactions/rotation/rotation-handler.js
- plumbing_v2/interactions/interaction-manager.js