### PR TITLE
Fix: Null check for servis kutusu and sayaç connected pipes

### DIFF
--- a/plumbing_v2/interactions/drag/drag-handler.js
+++ b/plumbing_v2/interactions/drag/drag-handler.js
@@ -842,10 +842,12 @@ export function handleDrag(interactionManager, point) {
                 boru.p1.y = newCikis.y;
 
                 // Kaydedilmiş bağlı boruları güncelle (her frame search yok!)
-                interactionManager.servisKutusuConnectedPipes.forEach(({ pipe: connectedPipe, endpoint: connectedEndpoint }) => {
-                    connectedPipe[connectedEndpoint].x = newCikis.x;
-                    connectedPipe[connectedEndpoint].y = newCikis.y;
-                });
+                if (interactionManager.servisKutusuConnectedPipes) {
+                    interactionManager.servisKutusuConnectedPipes.forEach(({ pipe: connectedPipe, endpoint: connectedEndpoint }) => {
+                        connectedPipe[connectedEndpoint].x = newCikis.x;
+                        connectedPipe[connectedEndpoint].y = newCikis.y;
+                    });
+                }
             }
         }
         return;
@@ -911,10 +913,12 @@ export function handleDrag(interactionManager, point) {
                 const newP1 = { x: cikisBoru.p1.x, y: cikisBoru.p1.y };
 
                 // Kaydedilmiş bağlı boruları güncelle (her frame search yok!)
-                interactionManager.sayacConnectedPipes.forEach(({ pipe: connectedPipe, endpoint: connectedEndpoint }) => {
-                    connectedPipe[connectedEndpoint].x = newP1.x;
-                    connectedPipe[connectedEndpoint].y = newP1.y;
-                });
+                if (interactionManager.sayacConnectedPipes) {
+                    interactionManager.sayacConnectedPipes.forEach(({ pipe: connectedPipe, endpoint: connectedEndpoint }) => {
+                        connectedPipe[connectedEndpoint].x = newP1.x;
+                        connectedPipe[connectedEndpoint].y = newP1.y;
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
SORUN: Hala kopma oluyor - "belki biraz geç koptu ama koptu"
KÖK NEDEN: forEach çağrıları NULL kontrolü olmadan yapılıyor!

Eğer:
- startDrag() içinde bagliBoruId veya cikisBagliBoruId null ise
- Veya boru bulunamazsa
- servisKutusuConnectedPipes/sayacConnectedPipes UNDEFINED kalır
- undefined.forEach() hata verir ve kod DURUR!

ÇÖZÜM:
- Servis kutusu forEach çağrısına null kontrolü eklendi
- Sayaç forEach çağrısına null kontrolü eklendi
- Artık undefined ise forEach çağrılmaz

DETAY:
1. handleDrag() içinde servisKutusuConnectedPipes kontrolü
2. handleDrag() içinde sayacConnectedPipes kontrolü
3. Eğer null/undefined ise sessizce atla