### PR TITLE
Fix: Null checks for body drag connected pipes

### DIFF
--- a/plumbing_v2/interactions/drag/drag-handler.js
+++ b/plumbing_v2/interactions/drag/drag-handler.js
@@ -963,8 +963,8 @@ export function handleDrag(interactionManager, point) {
 
         // SHARED VERTEX: Başlangıçta kaydedilmiş bağlı borular (collision check için)
         const connectedPipes = [
-            ...interactionManager.connectedPipesAtP1.map(c => c.pipe),
-            ...interactionManager.connectedPipesAtP2.map(c => c.pipe)
+            ...(interactionManager.connectedPipesAtP1 || []).map(c => c.pipe),
+            ...(interactionManager.connectedPipesAtP2 || []).map(c => c.pipe)
         ];
 
         // Basit yaklaşım: Her boru ucunu kontrol et, eğer o uç bir dirsekse 4cm, değilse 1.5cm tolerans
@@ -1046,16 +1046,20 @@ export function handleDrag(interactionManager, point) {
             interactionManager.ghostBridgePipes = []; // Ghost yok
 
             // P1: Başlangıçta tespit edilen bağlı boruları güncelle (search yok!)
-            interactionManager.connectedPipesAtP1.forEach(({ pipe: connectedPipe, endpoint: connectedEndpoint }) => {
-                connectedPipe[connectedEndpoint].x = newP1.x;
-                connectedPipe[connectedEndpoint].y = newP1.y;
-            });
+            if (interactionManager.connectedPipesAtP1) {
+                interactionManager.connectedPipesAtP1.forEach(({ pipe: connectedPipe, endpoint: connectedEndpoint }) => {
+                    connectedPipe[connectedEndpoint].x = newP1.x;
+                    connectedPipe[connectedEndpoint].y = newP1.y;
+                });
+            }
 
             // P2: Başlangıçta tespit edilen bağlı boruları güncelle (search yok!)
-            interactionManager.connectedPipesAtP2.forEach(({ pipe: connectedPipe, endpoint: connectedEndpoint }) => {
-                connectedPipe[connectedEndpoint].x = newP2.x;
-                connectedPipe[connectedEndpoint].y = newP2.y;
-            });
+            if (interactionManager.connectedPipesAtP2) {
+                interactionManager.connectedPipesAtP2.forEach(({ pipe: connectedPipe, endpoint: connectedEndpoint }) => {
+                    connectedPipe[connectedEndpoint].x = newP2.x;
+                    connectedPipe[connectedEndpoint].y = newP2.y;
+                });
+            }
         }
 
         return;


### PR DESCRIPTION
SORUN: Body drag'de hala kopma oluyor
LOG ANALİZİ:
- İlk 6 drag: P1: 1 bağlı, P2: 1 bağlı ✓
- Son 2 drag: P1: 0, P2: 0 ❌
- Demek ki ilk drag'lerde tespit ediliyor ama sonra KOPUYOR!

KÖK NEDEN: Body drag'de 3 yerde NULL kontrolü eksik!
1. Satır 966-967: Spread operator (collision check)
2. Satır 1049: connectedPipesAtP1.forEach
3. Satır 1055: connectedPipesAtP2.forEach

Eğer bu referanslar undefined/null ise:
- undefined.map() veya undefined.forEach() hata verir
- Kod DURUR ve bağlı borular güncellenmez
- Sonuç: KOPMA!

ÇÖZÜM:
1. Spread operator: || [] ile default empty array
2. P1 forEach: if kontrolü ile güvenli hale getirildi
3. P2 forEach: if kontrolü ile güvenli hale getirildi

Artık null/undefined durumunda bile kod çalışır!