### PR TITLE
Debug: Add critical tracking for pipe object replacement

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -342,6 +342,22 @@ export function startBodyDrag(interactionManager, pipe, point) {
     console.log(`  P2: (${pipe.p2.x.toFixed(1)}, ${pipe.p2.y.toFixed(1)})`);
     console.log(`  Toplam boru sayısı: ${interactionManager.manager.pipes.length}`);
 
+    // CRITICAL DEBUG: Track if pipe object is being replaced between drags
+    if (!window.__lastDraggedPipe) {
+        window.__lastDraggedPipe = { pipe: null, positions: null };
+    }
+    if (window.__lastDraggedPipe.pipe === pipe) {
+        console.log(`  ✓ Same pipe object as last drag`);
+    } else if (window.__lastDraggedPipe.pipe && window.__lastDraggedPipe.pipe.id === pipe.id) {
+        console.log(`  ⚠️ DIFFERENT pipe object with same ID! (OBJECT WAS REPLACED!)`);
+        if (window.__lastDraggedPipe.positions) {
+            const lastP1 = window.__lastDraggedPipe.positions.p1;
+            const jumpX = Math.abs(pipe.p1.x - lastP1.x);
+            const jumpY = Math.abs(pipe.p1.y - lastP1.y);
+            console.log(`  ⚠️ Position jump from last exit: X=${jumpX.toFixed(1)} cm, Y=${jumpY.toFixed(1)} cm`);
+        }
+    }
+
     // DEBUG: Check for duplicate pipes with same ID
     const duplicates = interactionManager.manager.pipes.filter(p => p.id === pipe.id);
     if (duplicates.length > 1) {
@@ -1304,5 +1320,15 @@ export function endDrag(interactionManager) {
         console.log(`[END DRAG] EXIT - Boru ${debugPipe.id.substring(0,12)}...`);
         console.log(`  P1: (${debugPipe.p1.x.toFixed(1)}, ${debugPipe.p1.y.toFixed(1)}), P2: (${debugPipe.p2.x.toFixed(1)}, ${debugPipe.p2.y.toFixed(1)})`);
         console.log('─'.repeat(80));
+
+        // CRITICAL: Save pipe reference and positions for next drag comparison
+        if (!window.__lastDraggedPipe) {
+            window.__lastDraggedPipe = {};
+        }
+        window.__lastDraggedPipe.pipe = debugPipe;
+        window.__lastDraggedPipe.positions = {
+            p1: { x: debugPipe.p1.x, y: debugPipe.p1.y },
+            p2: { x: debugPipe.p2.x, y: debugPipe.p2.y }
+        };
     }
 }

--- a/plumbing_v2/plumbing-manager.js
+++ b/plumbing_v2/plumbing-manager.js
@@ -232,6 +232,12 @@ export class PlumbingManager {
      * State'den yükle
      */
     loadFromState() {
+        // DEBUG: Track when state is loaded (this might be corrupting positions!)
+        console.log('═'.repeat(80));
+        console.log('[CRITICAL] loadFromState() CALLED - Pipes being reloaded from state!');
+        console.log('  Stack trace:', new Error().stack);
+        console.log('═'.repeat(80));
+
         // Boruları yükle
         if (state.plumbingPipes) {
             this.pipes = state.plumbingPipes.map(data => Boru.fromJSON(data));


### PR DESCRIPTION
Added logging to detect THE ROOT CAUSE of position jumps:

1. loadFromState() detection:
   - Logs when pipes are reloaded from state
   - Shows stack trace to identify caller
   - This would replace ALL pipe objects with JSON-deserialized copies

2. Pipe object identity tracking:
   - Compares pipe object reference between consecutive drags
   - Detects if same ID but DIFFERENT object (replacement occurred)
   - Calculates exact position jump when replacement happens

3. Position tracking across drag boundary:
   - Saves pipe reference + positions at END of endDrag()
   - Compares at START of next startBodyDrag()
   - Will reveal if object replacement is causing 11.7cm jumps

Expected findings:
- If loadFromState() logs appear → undo/redo is corrupting state
- If "OBJECT WAS REPLACED" logs appear → something is recreating pipes
- Position jump calculation will show exact corruption amount