### PR TITLE
Debug: Track mouse distance from pipe when drag starts

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -336,10 +336,21 @@ export function startBodyDrag(interactionManager, pipe, point) {
     interactionManager.bodyDragInitialP1 = { ...pipe.p1 };
     interactionManager.bodyDragInitialP2 = { ...pipe.p2 };
 
+    // CRITICAL DEBUG: Check if mouse position matches pipe position
+    const mouseDistanceFromPipe = Math.min(
+        Math.hypot(point.x - pipe.p1.x, point.y - pipe.p1.y),
+        Math.hypot(point.x - pipe.p2.x, point.y - pipe.p2.y)
+    );
+
     // DEBUG: Sürüklenen borunun detaylarını yazdır
     console.log(`[BODY DRAG START] Boru ID: ${pipe.id}`);
-    console.log(`  P1: (${pipe.p1.x.toFixed(1)}, ${pipe.p1.y.toFixed(1)})`);
-    console.log(`  P2: (${pipe.p2.x.toFixed(1)}, ${pipe.p2.y.toFixed(1)})`);
+    console.log(`  BORU P1: (${pipe.p1.x.toFixed(1)}, ${pipe.p1.y.toFixed(1)})`);
+    console.log(`  BORU P2: (${pipe.p2.x.toFixed(1)}, ${pipe.p2.y.toFixed(1)})`);
+    console.log(`  FARE POS: (${point.x.toFixed(1)}, ${point.y.toFixed(1)})`);
+    console.log(`  🎯 FARE ↔ BORU MESAFE: ${mouseDistanceFromPipe.toFixed(1)} cm`);
+    if (mouseDistanceFromPipe > 5) {
+        console.log(`  ⚠️⚠️⚠️  UYARI: Fare borudan ${mouseDistanceFromPipe.toFixed(1)} cm uzakta! (>5cm)`);
+    }
     console.log(`  Toplam boru sayısı: ${interactionManager.manager.pipes.length}`);
 
     // CRITICAL DEBUG: Track if pipe object is being replaced between drags


### PR DESCRIPTION
Added critical logging to detect if user's zoom-out issue is related to mouse position being far from the pipe:

1. Shows PIPE position vs MOUSE position when drag starts
2. Calculates distance between mouse and nearest pipe endpoint
3. Warns if mouse is >5cm away from pipe (beyond findObjectAt tolerance)

User reported: "When zoomed out and clicking NEAR the pipe (not exactly on it), pipes disconnect"

This will reveal if:
- Mouse position is being used instead of pipe position somewhere
- Selection tolerance (5cm) is allowing clicks far from actual pipe
- The 11.7cm position jump correlates with mouse distance from pipe

Expected output when bug occurs:
  BORU P1: (-180.9, -2.1) FARE POS: (-180.1, 9.6) ⚠️ UYARI: Fare borudan 11.7 cm uzakta!

This would prove the mouse click is FAR from the pipe, explaining why connected pipes aren't found (they're at the PIPE position, not mouse position).