### PR TITLE
Fix: Increase tolerance to 20cm and sync all connected pipe detection

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -191,10 +191,10 @@ export function isProtectedPoint(point, manager, currentPipe, oldPoint, excludeC
  * @param {Array} pipes - Tüm borular
  * @param {Object} point - Nokta {x, y}
  * @param {Object} excludePipe - Hariç tutulacak boru (opsiyonel)
- * @param {number} tolerance - Mesafe toleransı (cm)
+ * @param {number} tolerance - Mesafe toleransı (cm) - varsayılan olarak CONNECTED_PIPES_TOLERANCE kullanılır
  * @returns {Array} [{pipe, endpoint}, ...] - Bu noktada ucu olan tüm borular
  */
-export function findPipesAtPoint(pipes, point, excludePipe = null, tolerance = 1.5) {
+export function findPipesAtPoint(pipes, point, excludePipe = null, tolerance = TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE) {
     const pipesAtPoint = [];
 
     pipes.forEach(pipe => {
@@ -232,8 +232,8 @@ export function findPipesAtPoint(pipes, point, excludePipe = null, tolerance = 1
  * @param {Object} excludePipe - Hariç tutulacak boru (opsiyonel)
  */
 export function updateSharedVertex(pipes, oldPoint, newPoint, excludePipe = null) {
-    // Eski noktada ucu olan tüm boruları bul
-    const pipesAtPoint = findPipesAtPoint(pipes, oldPoint, excludePipe, 1.0);
+    // Eski noktada ucu olan tüm boruları bul - SENKRON tolerance kullan
+    const pipesAtPoint = findPipesAtPoint(pipes, oldPoint, excludePipe, TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE);
 
     // Her borunun sadece o ucunu yeni noktaya taşı
     pipesAtPoint.forEach(({ pipe, endpoint }) => {

--- a/plumbing_v2/interactions/rotation-handler.js
+++ b/plumbing_v2/interactions/rotation-handler.js
@@ -5,6 +5,7 @@
 
 import { saveState } from '../../../general-files/history.js';
 import { findPipesAtPoint } from './drag-handler.js';
+import { TESISAT_CONSTANTS } from './tesisat-snap.js';
 
 /**
  * Döndürme tutamacını bul (çubuğun ucundaki daire) - yukarı yönde
@@ -56,8 +57,8 @@ export function startRotation(context, obj, point, manager) {
     if (obj.type === 'sayac' && obj.cikisBagliBoruId) {
         const cikisBoru = manager.pipes.find(p => p.id === obj.cikisBagliBoruId);
         if (cikisBoru) {
-            context.rotationConnectedPipes = findPipesAtPoint(manager.pipes, cikisBoru.p1, cikisBoru, 1.0);
-            console.log(`[ROTATION START] ${context.rotationConnectedPipes.length} bağlı boru tespit edildi`);
+            context.rotationConnectedPipes = findPipesAtPoint(manager.pipes, cikisBoru.p1, cikisBoru, TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE);
+            console.log(`[ROTATION START] ${context.rotationConnectedPipes.length} bağlı boru tespit edildi (tolerance: ${TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE} cm)`);
         }
     }
 }

--- a/plumbing_v2/interactions/tesisat-snap.js
+++ b/plumbing_v2/interactions/tesisat-snap.js
@@ -25,8 +25,8 @@ export const TESISAT_CONSTANTS = {
     SNAP_MESAFESI: 20,          // cm - Snap yakalama mesafesi
     MIN_BORU_UZUNLUGU: 5,       // cm
     ACI_TOLERANSI: 20,           // derece - 90° snap toleransı
-    SELECTION_TOLERANCE: 15,     // cm - Seçim ve bağlı boru bulma için ortak tolerance (SENKRON)
-    CONNECTED_PIPES_TOLERANCE: 15, // cm - Bağlı boruları bulmak için tolerance (SENKRON)
+    SELECTION_TOLERANCE: 20,     // cm - Seçim için tolerance (uzaktan seçim için yeterli)
+    CONNECTED_PIPES_TOLERANCE: 20, // cm - Bağlı boruları bulmak için tolerance (SENKRON - seçim ile aynı)
 };
 
 // Snap Tipleri


### PR DESCRIPTION
Problem: Pipes still disconnected when selected remotely even with 15cm tolerance. Root causes found:
1. rotation-handler.js used only 1.0cm tolerance for connected pipes
2. updateSharedVertex used only 1.0cm tolerance
3. findPipesAtPoint default parameter was 1.5cm (unsafe fallback)
4. 15cm tolerance was insufficient for zoom-independent reliable selection

Solution:
- Increased SELECTION_TOLERANCE: 15cm → 20cm
- Increased CONNECTED_PIPES_TOLERANCE: 15cm → 20cm
- Updated findPipesAtPoint default parameter to use CONNECTED_PIPES_TOLERANCE
- Fixed rotation-handler.js to use CONNECTED_PIPES_TOLERANCE (1.0 → 20cm)
- Fixed updateSharedVertex to use CONNECTED_PIPES_TOLERANCE (1.0 → 20cm)

Benefits:
- Even safer remote selection (20cm = SNAP_MESAFESI)
- All connected pipe detection now synchronized at 20cm
- No hardcoded tolerance values - all use TESISAT_CONSTANTS
- Works reliably at any zoom level
- Fixes disconnection during rotation operations

Files changed:
- plumbing_v2/interactions/tesisat-snap.js: Increased tolerances to 20cm
- plumbing_v2/interactions/drag-handler.js: Updated findPipesAtPoint default & updateSharedVertex
- plumbing_v2/interactions/rotation-handler.js: Fixed rotation connected pipes tolerance