### PR TITLE
Fix: Use pixel-based tolerance for selection (zoom-independent)

### DIFF
--- a/plumbing_v2/interactions/finders.js
+++ b/plumbing_v2/interactions/finders.js
@@ -9,6 +9,16 @@ import { setState, state } from '../../../general-files/main.js';
 import { TESISAT_CONSTANTS } from './tesisat-snap.js';
 
 /**
+ * Piksel toleransını world coordinates'e çevirir (zoom-aware)
+ * @param {number} pixelTolerance - Piksel cinsinden tolerance
+ * @returns {number} - World coordinates cinsinden tolerance (cm)
+ */
+export function pixelsToWorld(pixelTolerance) {
+    const zoom = state.zoom || 1.0;
+    return pixelTolerance / zoom;
+}
+
+/**
  * Bir noktada nesne bul (bileşen veya boru)
  * Öncelik sırası: 1) Bileşenler, 2) Borular (2cm), 3) Borular (5cm)
  */
@@ -30,9 +40,10 @@ export function findObjectAt(manager, point) {
     //     }
     // }
 
-    // ÖNCELİK 3: Borular (SENKRON tolerance - seçim ve sürükleme için aynı)
+    // ÖNCELİK 3: Borular (Piksel bazlı tolerance - zoom bağımsız)
+    const worldTolerance = pixelsToWorld(TESISAT_CONSTANTS.SELECTION_TOLERANCE_PIXELS);
     for (const pipe of manager.pipes) {
-        if (pipe.containsPoint && pipe.containsPoint(point, TESISAT_CONSTANTS.SELECTION_TOLERANCE)) {
+        if (pipe.containsPoint && pipe.containsPoint(point, worldTolerance)) {
             return pipe;
         }
     }

--- a/plumbing_v2/interactions/tesisat-snap.js
+++ b/plumbing_v2/interactions/tesisat-snap.js
@@ -25,8 +25,8 @@ export const TESISAT_CONSTANTS = {
     SNAP_MESAFESI: 20,          // cm - Snap yakalama mesafesi
     MIN_BORU_UZUNLUGU: 5,       // cm
     ACI_TOLERANSI: 20,           // derece - 90° snap toleransı
-    SELECTION_TOLERANCE: 20,     // cm - Seçim için tolerance (uzaktan seçim için yeterli)
-    CONNECTED_PIPES_TOLERANCE: 20, // cm - Bağlı boruları bulmak için tolerance (SENKRON - seçim ile aynı)
+    SELECTION_TOLERANCE_PIXELS: 12, // piksel - Seçim için tolerance (ZOOM BAĞIMSIZ - ekranda her zaman 12 piksel)
+    CONNECTED_PIPES_TOLERANCE: 20, // cm - Bağlı boruları bulmak için tolerance (world coordinates - fiziksel mesafe)
 };
 
 // Snap Tipleri

--- a/pointer/handle-pointer-down.js
+++ b/pointer/handle-pointer-down.js
@@ -7,6 +7,7 @@ import { screenToWorld } from '../draw/geometry.js';
 import { dom, state } from '../general-files/main.js';
 import { BAGLANTI_TIPLERI } from '../plumbing_v2/objects/pipe.js';
 import { TESISAT_CONSTANTS } from '../plumbing_v2/interactions/tesisat-snap.js';
+import { pixelsToWorld } from '../plumbing_v2/interactions/finders.js';
 
 export function handlePointerDown(e) {
     const rect = dom.c2d.getBoundingClientRect();
@@ -94,7 +95,9 @@ export function handlePointerDown(e) {
         }
 
         // Sonra boru uç noktası kontrolü yap (ÖNCE NOKTA - body'den önce)
-        const boruUcu = this.findBoruUcuAt(point, TESISAT_CONSTANTS.SELECTION_TOLERANCE); // SENKRON tolerance
+        // Piksel bazlı tolerance - zoom bağımsız
+        const worldTolerance = pixelsToWorld(TESISAT_CONSTANTS.SELECTION_TOLERANCE_PIXELS);
+        const boruUcu = this.findBoruUcuAt(point, worldTolerance);
         if (boruUcu) {
             // console.log('🎯 BORU UCU BULUNDU:', boruUcu.uc, boruUcu.boruId);
             const pipe = this.manager.pipes.find(p => p.id === boruUcu.boruId);
@@ -180,7 +183,9 @@ export function handlePointerDown(e) {
     }
 
     // 5. Boru ucu veya gövdesinden çizim başlat
-    const boruUcu2 = this.findBoruUcuAt(point, TESISAT_CONSTANTS.SELECTION_TOLERANCE);
+    // Piksel bazlı tolerance - zoom bağımsız
+    const worldTolerance2 = pixelsToWorld(TESISAT_CONSTANTS.SELECTION_TOLERANCE_PIXELS);
+    const boruUcu2 = this.findBoruUcuAt(point, worldTolerance2);
     if (boruUcu2) {
         const deviceVar = this.hasDeviceAtEndpoint(boruUcu2.boruId, boruUcu2.uc);
         const meterVar = this.hasMeterAtEndpoint(boruUcu2.boruId, boruUcu2.uc);
@@ -195,7 +200,9 @@ export function handlePointerDown(e) {
     }
 
     // 6. Boru gövdesinden çizim başlat
-    const boruGovde = this.findBoruGovdeAt(point, TESISAT_CONSTANTS.SELECTION_TOLERANCE);
+    // Piksel bazlı tolerance - zoom bağımsız
+    const worldTolerance3 = pixelsToWorld(TESISAT_CONSTANTS.SELECTION_TOLERANCE_PIXELS);
+    const boruGovde = this.findBoruGovdeAt(point, worldTolerance3);
     if (boruGovde) {
         this.startBoruCizim(boruGovde.nokta, boruGovde.boruId, BAGLANTI_TIPLERI.BORU);
         return true;


### PR DESCRIPTION
Problem: When zoomed out, 20cm world tolerance appeared as large area on screen, allowing selection from 20-30cm away. When zoomed in, same 20cm appeared tiny, making selection difficult.

Root cause: Selection tolerance was in world coordinates (cm), not screen coordinates (pixels). Zoom changes screen size but not world distance.

Solution: Implement pixel-based selection tolerance
- Added SELECTION_TOLERANCE_PIXELS: 12 pixels (zoom-independent)
- Created pixelsToWorld() helper function: converts pixels → world coords Formula: worldDistance = pixels / zoom
  - Zoom in (2x): 12px = 6cm world (precise selection)
  - Zoom out (0.5x): 12px = 24cm world (easier selection)
- Updated all selection points to use pixel-based tolerance:
  * findObjectAt: Uses pixelsToWorld for pipe detection
  * findBoruUcuAt: Converts pixels to world before checking
  * findBoruGovdeAt: Converts pixels to world before checking

Key insight:
- SELECTION_TOLERANCE_PIXELS: For mouse interaction (screen space)
- CONNECTED_PIPES_TOLERANCE: For physical connections (world space)

Benefits:
- ✅ Consistent selection feel at any zoom level
- ✅ Always selects from ~12 pixels on screen (not 20-30cm!)
- ✅ Zoom in: More precise (smaller world tolerance)
- ✅ Zoom out: Easier selection (larger world tolerance)
- ✅ Connected pipes still use 20cm physical distance

Files changed:
- plumbing_v2/interactions/tesisat-snap.js: Changed to pixel tolerance
- plumbing_v2/interactions/finders.js: Added pixelsToWorld helper
- pointer/handle-pointer-down.js: Convert all selections to pixel-based