### PR TITLE
Fix: Update input pipe when dragging meter to prevent connector merge

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -1027,6 +1027,22 @@ export function handleDrag(interactionManager, point) {
 
         // Sayacı axis-locked pozisyona taşı (SMOOTH!)
         sayac.move(newX, newY);
+
+        // 🚨 KRİTİK: Hem GİRİŞ hem de ÇIKIŞ borularını güncelle
+        // Giriş borusunu güncelle (fleks bağlantı)
+        if (sayac.fleksBaglanti?.boruId) {
+            const girisBoru = interactionManager.manager.pipes.find(p => p.id === sayac.fleksBaglanti.boruId);
+            if (girisBoru) {
+                // Giriş borusunun hangi ucu sayaca bağlı?
+                const endpoint = sayac.fleksBaglanti.endpoint;
+                if (endpoint) {
+                    // O ucu DELTA kadar taşı
+                    girisBoru[endpoint].x += dx;
+                    girisBoru[endpoint].y += dy;
+                }
+            }
+        }
+
         // Çıkış borusunu güncelle - CACHED SİSTEM (KOPMA SORUNU ÇÖZÜLDÜ!)
         // Sadece çıkış borusunun p1 ucunu güncelle, p2 ve bağlı borular sabit
         if (sayac.cikisBagliBoruId) {


### PR DESCRIPTION
Problem:
- When dragging the meter, input and output connectors were merging
- Only the output pipe was being updated during meter drag
- The input pipe (fleks connection) endpoint was not moving with the meter

Root Cause:
- In handleDrag (line 1028-1067), only the output pipe was updated
- The input pipe endpoint remained at its original position
- As meter moved, the static input endpoint appeared to merge with moving output

Solution:
- Added input pipe update logic before output pipe update (line 1032-1044)
- Input pipe endpoint is now moved by delta (dx, dy) along with meter
- Uses the same delta-based movement as output pipe for consistency

Impact:
- Input and output connectors now maintain proper 10cm separation during drag
- Both rotation and dragging now handle meter connectors correctly