### PR TITLE
Fix: Exclude output pipe when dragging input pipe endpoint to prevent…

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -260,12 +260,41 @@ export function startEndpointDrag(interactionManager, pipe, endpoint, point) {
     // SHARED VERTEX: Bağlı boruları ÖNCEDENtespit et ve kaydet (hızlı drag için)
     // Sürüklenen uç noktadaki TÜM bağlı boruları bul ve referanslarını sakla
     const draggedPoint = endpoint === 'p1' ? pipe.p1 : pipe.p2;
-    interactionManager.connectedPipesAtEndpoint = findPipesAtPoint(
-        interactionManager.manager.pipes,
-        draggedPoint,
-        pipe,
-        TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE // SENKRON tolerance - seçim ile aynı
+
+    // 🚨 KRİTİK: Eğer bu boru bir sayacın giriş hattıysa, ÇIKIŞ borusunu EXCLUDE et!
+    // Aksi halde çıkış borusu da giriş ucuna çekiliyor (10cm aralık, 20cm tolerance!)
+    const connectedMeter = interactionManager.manager.components.find(c =>
+        c.type === 'sayac' &&
+        c.fleksBaglanti &&
+        c.fleksBaglanti.boruId === pipe.id
     );
+
+    let excludePipes = [pipe];
+    if (connectedMeter && connectedMeter.cikisBagliBoruId) {
+        const cikisBoru = interactionManager.manager.pipes.find(p => p.id === connectedMeter.cikisBagliBoruId);
+        if (cikisBoru) {
+            excludePipes.push(cikisBoru);
+            console.log('[ENDPOINT DRAG] Sayaç giriş hattı - çıkış borusu exclude edildi');
+        }
+    }
+
+    // Bağlı boruları bul (çıkış borusu hariç)
+    const connectedPipesAtEndpoint = [];
+    interactionManager.manager.pipes.forEach(p => {
+        if (excludePipes.includes(p)) return;
+
+        const distToP1 = Math.hypot(p.p1.x - draggedPoint.x, p.p1.y - draggedPoint.y);
+        const distToP2 = Math.hypot(p.p2.x - draggedPoint.x, p.p2.y - draggedPoint.y);
+
+        if (distToP1 < TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE) {
+            connectedPipesAtEndpoint.push({ pipe: p, endpoint: 'p1' });
+        }
+        if (distToP2 < TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE) {
+            connectedPipesAtEndpoint.push({ pipe: p, endpoint: 'p2' });
+        }
+    });
+
+    interactionManager.connectedPipesAtEndpoint = connectedPipesAtEndpoint;
 
     console.log(`[ENDPOINT DRAG START] ${interactionManager.connectedPipesAtEndpoint.length} bağlı boru tespit edildi (tolerance: ${TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE} cm)`);
 }


### PR DESCRIPTION
… pulling

Problem:
- When dragging input pipe ENDPOINT (not body), output pipe was being pulled toward the input endpoint, detaching from meter
- Input and output connectors are only 10cm apart
- CONNECTED_PIPES_TOLERANCE is 20cm
- findPipesAtPoint was detecting output pipe as "connected" to input endpoint
- Output pipe was added to connectedPipesAtEndpoint and moved with input drag

Root Cause:
- In startEndpointDrag (line 263-268), findPipesAtPoint only excluded the dragged pipe itself
- Did not exclude meter's output pipe when dragging input pipe endpoint
- Output pipe's p1 (at meter output, 10cm from input) was within 20cm tolerance
- Output pipe was incorrectly treated as connected and moved with input

Solution:
- Detect if dragged pipe is meter input pipe (fleksBaglanti.boruId check)
- If yes, find and exclude the output pipe from connected pipes search
- Use manual loop instead of findPipesAtPoint to support multiple exclusions
- Output pipe now stays at meter output point, not pulled toward input

Impact:
- Input pipe endpoint can be dragged without affecting output pipe
- Output pipe remains rigidly attached to meter at all times
- Fixes "output pipe pulled toward input" issue during endpoint drag