### PR TITLE
Fix chimney selection and device-chimney association bugs

### DIFF
--- a/plumbing_v2/interactions/ghost-updater.js
+++ b/plumbing_v2/interactions/ghost-updater.js
@@ -165,13 +165,14 @@ export function updateGhostPosition(ghost, point, snap) {
 
         let snapCihaz = null;
         const snapTolerance = 50; // 50cm içinde snap yap
+        let minDist = Infinity;
 
-        // En yakın cihazı bul
+        // En yakın cihazı bul (sadece ilki değil, en yakın olanı)
         for (const cihaz of cihazlar) {
             const dist = Math.hypot(point.x - cihaz.x, point.y - cihaz.y);
-            if (dist < snapTolerance) {
+            if (dist < snapTolerance && dist < minDist) {
+                minDist = dist;
                 snapCihaz = cihaz;
-                break;
             }
         }
 

--- a/plumbing_v2/interactions/selection-manager.js
+++ b/plumbing_v2/interactions/selection-manager.js
@@ -15,6 +15,16 @@ export function selectObject(interactionManager, obj) {
     // Önceki seçimi temizle
     if (interactionManager.selectedObject && interactionManager.selectedObject !== obj) {
         interactionManager.selectedObject.isSelected = false;
+
+        // Eğer önceki seçim cihaz ise, onun bacasının seçimini de temizle
+        if (interactionManager.selectedObject.type === 'cihaz') {
+            const prevBaca = interactionManager.manager.components.find(c =>
+                c.type === 'baca' && c.parentCihazId === interactionManager.selectedObject.id
+            );
+            if (prevBaca) {
+                prevBaca.isSelected = false;
+            }
+        }
     }
     // Vana seçimi temizle
     if (interactionManager.selectedValve) {
@@ -26,6 +36,25 @@ export function selectObject(interactionManager, obj) {
     }
     interactionManager.selectedObject = obj;
     obj.isSelected = true;
+
+    // Eğer seçilen nesne cihaz ise, bağlı bacayı da seç
+    if (obj.type === 'cihaz') {
+        const baca = interactionManager.manager.components.find(c =>
+            c.type === 'baca' && c.parentCihazId === obj.id
+        );
+        if (baca) {
+            baca.isSelected = true;
+        }
+    }
+    // Eğer seçilen nesne baca ise, bağlı cihazı da seç
+    else if (obj.type === 'baca' && obj.parentCihazId) {
+        const cihaz = interactionManager.manager.components.find(c =>
+            c.type === 'cihaz' && c.id === obj.parentCihazId
+        );
+        if (cihaz) {
+            cihaz.isSelected = true;
+        }
+    }
 
     // state.selectedObject'i de set et (DELETE tuşu için)
     setState({
@@ -78,6 +107,26 @@ export function selectValve(interactionManager, pipe, vana) {
 export function deselectObject(interactionManager) {
     if (interactionManager.selectedObject) {
         interactionManager.selectedObject.isSelected = false;
+
+        // Eğer seçim cihaz ise, bağlı bacayı da seçimden çıkar
+        if (interactionManager.selectedObject.type === 'cihaz') {
+            const baca = interactionManager.manager.components.find(c =>
+                c.type === 'baca' && c.parentCihazId === interactionManager.selectedObject.id
+            );
+            if (baca) {
+                baca.isSelected = false;
+            }
+        }
+        // Eğer seçim baca ise, bağlı cihazı da seçimden çıkar
+        else if (interactionManager.selectedObject.type === 'baca' && interactionManager.selectedObject.parentCihazId) {
+            const cihaz = interactionManager.manager.components.find(c =>
+                c.type === 'cihaz' && c.id === interactionManager.selectedObject.parentCihazId
+            );
+            if (cihaz) {
+                cihaz.isSelected = false;
+            }
+        }
+
         interactionManager.selectedObject = null;
     }
     if (interactionManager.selectedValve) {


### PR DESCRIPTION
Fixes:
1. Chimney ghost now correctly selects CLOSEST device instead of first device within tolerance
   - Changed from break-on-first-match to min-distance algorithm
   - Resolves issue where selecting stove (ocak) would incorrectly show boiler (kombi) chimney

2. Device and chimney are now selected together as a unit
   - Selecting a device also selects its associated chimney
   - Selecting a chimney also selects its parent device
   - Deselecting properly clears both device and chimney selection
   - Provides better UX for managing device-chimney pairs

Note: Multi-part chimneys with elbows are already supported - user can click multiple times to add segments before pressing ESC to finish.