### PR TITLE
Fix critical chimney drawing bug - prevent ghost reset during drawing

### DIFF
--- a/plumbing_v2/interactions/ghost-updater.js
+++ b/plumbing_v2/interactions/ghost-updater.js
@@ -156,7 +156,15 @@ export function updateGhostPosition(ghost, point, snap) {
     }
     // Baca için: sadece cihaz üzerine snap yap
     else if (ghost.type === 'baca') {
-        // Cihazları bul (currentFloor'da olan)
+        // KRITIK: Baca zaten yerleştirilmiş ve çizim modundaysa, cihaz snap yapma!
+        // Sadece ilk yerleştirme için cihaz bulmalıyız
+        if (ghost.parentCihazId && ghost.isDrawing) {
+            // Baca çizim modunda - hiçbir şey yapma
+            // Ghost segment renderer tarafından otomatik çizilecek (currentSegmentStart -> mouse)
+            return;
+        }
+
+        // Cihazları bul (currentFloor'da olan) - SADECE İLK YERLEŞTIRME İÇİN
         const currentFloorId = state.currentFloor?.id;
         const cihazlar = this.manager.components.filter(c =>
             c.type === 'cihaz' &&


### PR DESCRIPTION
Problem:
- Ghost updater was continuously resetting chimney position to device center
- Every mouse movement during drawing would snap chimney back to device
- User could not draw multi-segment chimneys with elbows

Root Cause:
- ghost-updater.js was always executing device snap logic
- It reset startX, startY, and currentSegmentStart on every mouse move
- This happened even after chimney placement began (parentCihazId set)

Solution:
- Added early return when chimney is already placed and in drawing mode
- Check: if (ghost.parentCihazId && ghost.isDrawing) return
- Device snap now only runs during initial placement
- Ghost segment rendering continues normally (currentSegmentStart -> mouse)

Now users can:
1. Click to place chimney on device
2. Click multiple times to add segments/elbows
3. Press ESC to finish with ventilation grill