### PR TITLE
Fix chimney editing and auto-creation

### DIFF
--- a/plumbing_v2/interactions/component-placement.js
+++ b/plumbing_v2/interactions/component-placement.js
@@ -8,6 +8,7 @@ import { saveState } from '../../general-files/history.js';
 import { BAGLANTI_TIPLERI, createBoru } from '../objects/pipe.js';
 import { createSayac } from '../objects/meter.js';
 import { createVana } from '../objects/valve.js';
+import { createBaca } from '../objects/chimney.js';
 import { canPlaceValveOnPipe, getObjectsOnPipe } from './placement-utils.js';
 import { TESISAT_MODLARI } from './interaction-manager.js';
 
@@ -487,13 +488,25 @@ export function handleCihazEkleme(cihaz) {
     // State'e kaydet
     this.manager.saveToState();
 
-    // KOMBI eklendiğinde otomatik baca modunu başlat
-    if (cihaz.cihazTipi === 'KOMBI') {
-        // Yeni baca ghost oluştur
-        setTimeout(() => {
-            this.manager.startPlacement(TESISAT_MODLARI.BACA);
-            setMode("plumbingV2", true);
-        }, 50);
+    // Baca gerektiren cihazlar için otomatik baca oluştur
+    if (cihaz.bacaGerekliMi()) {
+        // Baca oluştur - cihaz merkezinden başlayarak sağa doğru 100cm
+        const baca = createBaca(cihaz.x, cihaz.y, cihaz.id, {
+            floorId: cihaz.floorId
+        });
+
+        // İlk segment: Sağa doğru 100cm (1m)
+        const ilkSegmentBitis = {
+            x: cihaz.x + 100, // 1m = 100cm
+            y: cihaz.y
+        };
+        baca.addSegment(ilkSegmentBitis.x, ilkSegmentBitis.y);
+
+        // Çizimi bitir - böylece baca seçilebilir ve düzenlenebilir olur
+        baca.finishDrawing();
+
+        // Bileşenlere ekle
+        this.manager.components.push(baca);
     }
 
     // console.log('[handleCihazEkleme] ✓ Cihaz başarıyla eklendi. Toplam components:', this.manager.components.length);

--- a/pointer/handle-pointer-down.js
+++ b/pointer/handle-pointer-down.js
@@ -96,6 +96,9 @@ export function handlePointerDown(e) {
             }
         }
 
+        // Piksel bazlı tolerance - zoom bağımsız
+        const worldTolerance = pixelsToWorld(TESISAT_CONSTANTS.SELECTION_TOLERANCE_PIXELS);
+
         // Baca segment endpoint kontrolü (boru noktası kontrolünden önce - daha yüksek öncelik)
         const bacalar = this.manager.components.filter(c => c.type === 'baca' && c.isSelected);
         for (const baca of bacalar) {
@@ -111,8 +114,6 @@ export function handlePointerDown(e) {
         }
 
         // Sonra boru uç noktası kontrolü yap (ÖNCE NOKTA - body'den önce)
-        // Piksel bazlı tolerance - zoom bağımsız
-        const worldTolerance = pixelsToWorld(TESISAT_CONSTANTS.SELECTION_TOLERANCE_PIXELS);
         const boruUcu = this.findBoruUcuAt(point, worldTolerance);
         if (boruUcu) {
             // console.log('🎯 BORU UCU BULUNDU:', boruUcu.uc, boruUcu.boruId);


### PR DESCRIPTION
Changes:
- Auto-create chimney with 1m horizontal segment when device is placed
- Chimneys now automatically start with a segment to the right (100cm)
- Finished chimneys are now selectable and editable
- Fixed worldTolerance variable declaration order bug in pointer handler

User can now:
- Click on chimneys to select them
- Drag chimney endpoints to modify shape
- Chimneys start pre-configured instead of requiring manual drawing