### PR TITLE
Add chimney (baca) double-click split functionality

### DIFF
--- a/general-files/actions.js
+++ b/general-files/actions.js
@@ -230,6 +230,12 @@ export function getObjectAtPoint(pos) {
         return validateFloorMatch(result, currentFloorId);
     }
 
+    // 2.5.6 Baca (Chimney) Gövdesi
+    if (pipeHandleHit && pipeHandleHit.type === 'baca' && pipeHandleHit.handle === 'body') {
+        const result = { type: 'baca', object: pipeHandleHit.object, handle: pipeHandleHit.handle };
+        return validateFloorMatch(result, currentFloorId);
+    }
+
     // 2.6 Kiriş Gövdesi
     if (beamHandleHit && beamHandleHit.handle === 'body') return beamHandleHit;
 

--- a/general-files/input.js
+++ b/general-files/input.js
@@ -990,6 +990,9 @@ export function setupInputListeners() {
         } else if (object && object.type === 'plumbingPipe' && object.handle === 'body') {
             // Boru gövdesine çift tıklanırsa bölme işlemi yap
             splitPipeAtClickPosition(object.object, clickPos);
+        } else if (object && object.type === 'baca' && object.handle === 'body') {
+            // Baca gövdesine çift tıklanırsa bölme işlemi yap
+            splitChimneyAtClickPosition(object.object, clickPos);
         }
     });
     c2d.addEventListener("wheel", onWheel, { passive: false }); // onWheel'i zoom.js'den kullan
@@ -1209,7 +1212,28 @@ function splitPipeAtClickPosition(pipeToSplit, clickPos) {
     if (window.plumbingManager && window.plumbingManager.interactionManager) {
         // ✨ BURASI DEĞİŞTİ: false parametresi ile çizim modunu engelliyoruz
         window.plumbingManager.interactionManager.handlePipeSplit(pipeToSplit, clickPos, false);
-        
+
         setState({ selectedObject: null });
+    }
+}
+
+// Baca bölme fonksiyonu
+function splitChimneyAtClickPosition(chimneyToSplit, clickPos) {
+    if (!chimneyToSplit || !chimneyToSplit.segments || chimneyToSplit.segments.length === 0) {
+        return;
+    }
+
+    // Bacayı böl
+    const result = chimneyToSplit.splitAt(clickPos);
+
+    if (result) {
+        // Başarılı bölme - render'ı güncelle
+        requestRender();
+        setState({ selectedObject: null });
+
+        // Undo/redo için kaydet
+        if (window.undoRedoManager) {
+            window.undoRedoManager.recordState();
+        }
     }
 }

--- a/plumbing_v2/plumbing-manager.js
+++ b/plumbing_v2/plumbing-manager.js
@@ -438,7 +438,7 @@ export class PlumbingManager {
             // Baca için özel containsPoint kontrolü
             if (comp.type === 'baca') {
                 if (comp.containsPoint(pos, tolerance)) {
-                    return { type: 'component', object: comp, handle: 'body' };
+                    return { type: 'baca', object: comp, handle: 'body' };
                 }
                 continue;
             }


### PR DESCRIPTION
Implemented double-click splitting for chimneys, similar to pipe splitting:

- Added splitAt() method to Baca class to split a segment at a point
- Added splitChimneyAtClickPosition() function in input.js
- Updated plumbing-manager to return type 'baca' instead of 'component'
- Added chimney body click handling in actions.js
- Added double-click event handler for chimneys

Users can now double-click on a chimney segment to split it at that point, with a minimum 10cm distance from segment endpoints.