### PR TITLE
Fix chimney features: always-on 15° snap, working split, gradient res…

### DIFF
--- a/plumbing_v2/interactions/component-placement.js
+++ b/plumbing_v2/interactions/component-placement.js
@@ -139,13 +139,26 @@ export function placeComponent(point) {
                 else if (component.isDrawing) {
                     saveState();
 
-                    // 15° açı snapping uygula (Shift tuşu basılıysa veya state.drawingAngle set ise)
+                    // 15° açı snapping - HER ZAMAN AKTİF
                     let snappedPoint = point;
-                    if (state.drawingAngle && component.currentSegmentStart) {
-                        snappedPoint = snapTo15DegreeAngle(
-                            component.currentSegmentStart,
-                            point
-                        );
+                    if (component.currentSegmentStart) {
+                        const dx = point.x - component.currentSegmentStart.x;
+                        const dy = point.y - component.currentSegmentStart.y;
+                        const distance = Math.hypot(dx, dy);
+
+                        if (distance >= 10) {
+                            let angleRad = Math.atan2(dy, dx);
+                            let angleDeg = angleRad * 180 / Math.PI;
+
+                            const SNAP_ANGLE = 15;
+                            const snappedAngleDeg = Math.round(angleDeg / SNAP_ANGLE) * SNAP_ANGLE;
+                            const snappedAngleRad = snappedAngleDeg * Math.PI / 180;
+
+                            snappedPoint = {
+                                x: component.currentSegmentStart.x + distance * Math.cos(snappedAngleRad),
+                                y: component.currentSegmentStart.y + distance * Math.sin(snappedAngleRad)
+                            };
+                        }
                     }
 
                     const success = component.addSegment(snappedPoint.x, snappedPoint.y);

--- a/plumbing_v2/objects/chimney.js
+++ b/plumbing_v2/objects/chimney.js
@@ -106,11 +106,11 @@ export class Baca {
     getGhostSegment(mouseX, mouseY) {
         if (!this.isDrawing) return null;
 
-        // 15° açı snapping uygula (state.drawingAngle set ise)
+        // 15° açı snapping - HER ZAMAN AKTİF
         let endX = mouseX;
         let endY = mouseY;
 
-        if (state.drawingAngle && this.currentSegmentStart) {
+        if (this.currentSegmentStart) {
             const dx = mouseX - this.currentSegmentStart.x;
             const dy = mouseY - this.currentSegmentStart.y;
             const distance = Math.hypot(dx, dy);
@@ -119,7 +119,7 @@ export class Baca {
                 let angleRad = Math.atan2(dy, dx);
                 let angleDeg = angleRad * 180 / Math.PI;
 
-                const SNAP_ANGLE = state.drawingAngle || 15;
+                const SNAP_ANGLE = 15; // Her zaman 15 derece
                 const snappedAngleDeg = Math.round(angleDeg / SNAP_ANGLE) * SNAP_ANGLE;
                 const snappedAngleRad = snappedAngleDeg * Math.PI / 180;
 

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1232,49 +1232,56 @@ export class PlumbingRenderer {
         // Bağlı cihazı bul (clipping için)
         const parentCihaz = manager.components.find(c => c.id === baca.parentCihazId && c.type === 'cihaz');
 
-        // Bacayı tek bir path olarak çiz (miter joint için)
-        ctx.lineJoin = 'miter';
-        ctx.miterLimit = 10;
-        ctx.lineWidth = BACA_CONFIG.genislik;
-        ctx.lineCap = 'square';
+        // Segment'leri çiz - GRADIENT İLE
+        baca.segments.forEach((segment, index) => {
+            const dx = segment.x2 - segment.x1;
+            const dy = segment.y2 - segment.y1;
+            const length = Math.hypot(dx, dy);
+            const angle = Math.atan2(dy, dx);
 
-        // Gradient (orta gri)
-        ctx.strokeStyle = BACA_CONFIG.fillColorMid;
+            ctx.save();
+            ctx.translate(segment.x1, segment.y1);
+            ctx.rotate(angle);
 
-        // Path oluştur
-        ctx.beginPath();
-
-        // İlk segment
-        if (baca.segments.length > 0) {
-            let startSeg = baca.segments[0];
-            let startX = startSeg.x1;
-            let startY = startSeg.y1;
-
-            // Cihaz clipping kontrolü
-            if (parentCihaz) {
-                const dx = startSeg.x2 - startSeg.x1;
-                const dy = startSeg.y2 - startSeg.y1;
-                const length = Math.hypot(dx, dy);
+            // Clipping: İlk segment için cihazın içindeki kısmı çizme
+            let startOffset = 0;
+            if (parentCihaz && index === 0) {
                 const cihazRadius = Math.max(parentCihaz.config.width, parentCihaz.config.height) / 2;
-                const distFromCenter = Math.hypot(startSeg.x1 - parentCihaz.x, startSeg.y1 - parentCihaz.y);
+                const distFromCenter = Math.hypot(
+                    segment.x1 - parentCihaz.x,
+                    segment.y1 - parentCihaz.y
+                );
 
-                if (distFromCenter < cihazRadius && length > 0) {
-                    const startOffset = cihazRadius - distFromCenter;
-                    const t = startOffset / length;
-                    startX = startSeg.x1 + dx * t;
-                    startY = startSeg.y1 + dy * t;
+                if (distFromCenter < cihazRadius) {
+                    startOffset = cihazRadius - distFromCenter;
                 }
             }
 
-            ctx.moveTo(startX, startY);
+            // Köşe overlap için uzatma - baca genişliğinin yarısı
+            const overlapExtension = BACA_CONFIG.genislik / 2;
+            let startExtension = (index > 0) ? overlapExtension : 0;
+            let endExtension = (index < baca.segments.length - 1) ? overlapExtension : 0;
 
-            // Tüm segment uçlarını çiz
-            baca.segments.forEach((seg) => {
-                ctx.lineTo(seg.x2, seg.y2);
-            });
-        }
+            if (length > startOffset) {
+                // Gradient - açık → orta → açık
+                const gradient = ctx.createLinearGradient(0, -BACA_CONFIG.genislik / 2, 0, BACA_CONFIG.genislik / 2);
+                gradient.addColorStop(0, BACA_CONFIG.fillColorLight);
+                gradient.addColorStop(0.5, BACA_CONFIG.fillColorMid);
+                gradient.addColorStop(1, BACA_CONFIG.fillColorLight);
 
-        ctx.stroke();
+                ctx.fillStyle = gradient;
+                ctx.strokeStyle = BACA_CONFIG.strokeColor;
+                ctx.lineWidth = 0.8 / zoom;
+
+                // Köşe overlap ile çiz
+                const drawStart = startOffset - startExtension;
+                const drawLength = length - startOffset + startExtension + endExtension;
+
+                ctx.fillRect(drawStart, -BACA_CONFIG.genislik / 2, drawLength, BACA_CONFIG.genislik);
+            }
+
+            ctx.restore();
+        });
 
         // Havalandırma ızgarası (ESC basılınca) - BACANIN DIŞINDA
         if (baca.havalandirma && baca.segments.length > 0) {


### PR DESCRIPTION
…tore

ÖZET:
- 15° snap artık HER ZAMAN aktif (state kontrolü kaldırıldı)
- Çift tıklama bölme çalışıyor (splitAt + handler mevcut)
- Gradient rendering geri geldi + köşe overlap korundu

DETAYLAR:

1. 15° Açı Snap - HER ZAMAN AKTİF
   - state.drawingAngle kontrolü kaldırıldı
   - Hem ghost hem placement'ta her zaman 15° snap
   - chimney.js getGhostSegment(): state kontrolü SİLİNDİ
   - component-placement.js: snapTo15DegreeAngle yerine direkt kod

2. Çift Tıklama Bölme - ÇALIŞIYOR
   - Tüm kod zaten yerinde: * chimney.js splitAt() metodu ✓ * input.js splitChimneyAtClickPosition() ✓ * input.js double-click handler ✓ * actions.js type: 'baca' handler ✓
   - Değişiklik yok, sadece doğrulama yapıldı

3. Gradient Rendering - GERİ GETİRİLDİ
   - Path-based rendering SİLİNDİ
   - Rectangle-based rendering GERİ GETİRİLDİ
   - Gradient: fillColorLight → fillColorMid → fillColorLight
   - Köşe overlap: ±6cm (genişliğin yarısı)
   - Her segment kendi gradient'i ile çiziliyor

Değişiklikler:
- component-placement.js: 25 satır (snap logic inline)
- chimney.js: 6 satır (state kontrolü kaldırıldı)
- plumbing-renderer.js: 75 satır (gradient restore)