### PR TITLE
DÜZELTME: Gradient+miter, eksen snap, split debug

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -992,6 +992,7 @@ export function setupInputListeners() {
             splitPipeAtClickPosition(object.object, clickPos);
         } else if (object && object.type === 'baca' && object.handle === 'body') {
             // Baca gövdesine çift tıklanırsa bölme işlemi yap
+            console.log('🔥 BACA DOUBLE-CLICK DETECTED!', object);
             splitChimneyAtClickPosition(object.object, clickPos);
         }
     });
@@ -1219,14 +1220,23 @@ function splitPipeAtClickPosition(pipeToSplit, clickPos) {
 
 // Baca bölme fonksiyonu
 function splitChimneyAtClickPosition(chimneyToSplit, clickPos) {
+    console.log('🔥 splitChimneyAtClickPosition called', {
+        chimney: chimneyToSplit,
+        clickPos,
+        segments: chimneyToSplit?.segments?.length
+    });
+
     if (!chimneyToSplit || !chimneyToSplit.segments || chimneyToSplit.segments.length === 0) {
+        console.warn('⚠️ Baca bölme iptal - geçersiz baca veya segment yok');
         return;
     }
 
     // Bacayı böl
     const result = chimneyToSplit.splitAt(clickPos);
+    console.log('🔥 splitAt result:', result);
 
     if (result) {
+        console.log('✅ Baca başarıyla bölündü:', result);
         // Başarılı bölme - render'ı güncelle
         requestRender();
         setState({ selectedObject: null });
@@ -1235,5 +1245,7 @@ function splitChimneyAtClickPosition(chimneyToSplit, clickPos) {
         if (window.undoRedoManager) {
             window.undoRedoManager.recordState();
         }
+    } else {
+        console.warn('❌ Baca bölme başarısız - splitAt null döndü');
     }
 }

--- a/plumbing_v2/interactions/component-placement.js
+++ b/plumbing_v2/interactions/component-placement.js
@@ -139,7 +139,7 @@ export function placeComponent(point) {
                 else if (component.isDrawing) {
                     saveState();
 
-                    // 15° açı snapping - HER ZAMAN AKTİF
+                    // Eksen snap - Sadece X/Y eksenlerine 15° içindeyse snap
                     let snappedPoint = point;
                     if (component.currentSegmentStart) {
                         const dx = point.x - component.currentSegmentStart.x;
@@ -150,14 +150,27 @@ export function placeComponent(point) {
                             let angleRad = Math.atan2(dy, dx);
                             let angleDeg = angleRad * 180 / Math.PI;
 
-                            const SNAP_ANGLE = 15;
-                            const snappedAngleDeg = Math.round(angleDeg / SNAP_ANGLE) * SNAP_ANGLE;
-                            const snappedAngleRad = snappedAngleDeg * Math.PI / 180;
+                            // Eksenlere snap (0°, 90°, 180°, -90°)
+                            const SNAP_TOLERANCE = 15;
+                            let snappedAngle = null;
 
-                            snappedPoint = {
-                                x: component.currentSegmentStart.x + distance * Math.cos(snappedAngleRad),
-                                y: component.currentSegmentStart.y + distance * Math.sin(snappedAngleRad)
-                            };
+                            if (Math.abs(angleDeg) <= SNAP_TOLERANCE) {
+                                snappedAngle = 0;
+                            } else if (Math.abs(angleDeg - 90) <= SNAP_TOLERANCE) {
+                                snappedAngle = 90;
+                            } else if (Math.abs(Math.abs(angleDeg) - 180) <= SNAP_TOLERANCE) {
+                                snappedAngle = 180;
+                            } else if (Math.abs(angleDeg + 90) <= SNAP_TOLERANCE) {
+                                snappedAngle = -90;
+                            }
+
+                            if (snappedAngle !== null) {
+                                const snappedAngleRad = snappedAngle * Math.PI / 180;
+                                snappedPoint = {
+                                    x: component.currentSegmentStart.x + distance * Math.cos(snappedAngleRad),
+                                    y: component.currentSegmentStart.y + distance * Math.sin(snappedAngleRad)
+                                };
+                            }
                         }
                     }
 

--- a/plumbing_v2/objects/chimney.js
+++ b/plumbing_v2/objects/chimney.js
@@ -106,7 +106,7 @@ export class Baca {
     getGhostSegment(mouseX, mouseY) {
         if (!this.isDrawing) return null;
 
-        // 15° açı snapping - HER ZAMAN AKTİF
+        // Eksen snap - Sadece X/Y eksenlerine 15° içindeyse snap
         let endX = mouseX;
         let endY = mouseY;
 
@@ -115,16 +115,36 @@ export class Baca {
             const dy = mouseY - this.currentSegmentStart.y;
             const distance = Math.hypot(dx, dy);
 
-            if (distance >= 10) { // Minimum mesafe kontrolü
+            if (distance >= 10) {
                 let angleRad = Math.atan2(dy, dx);
                 let angleDeg = angleRad * 180 / Math.PI;
 
-                const SNAP_ANGLE = 15; // Her zaman 15 derece
-                const snappedAngleDeg = Math.round(angleDeg / SNAP_ANGLE) * SNAP_ANGLE;
-                const snappedAngleRad = snappedAngleDeg * Math.PI / 180;
+                // Eksenlere snap (0°, 90°, 180°, -90° = 270°)
+                const SNAP_TOLERANCE = 15; // ±15 derece tolerans
+                let snappedAngle = null;
 
-                endX = this.currentSegmentStart.x + distance * Math.cos(snappedAngleRad);
-                endY = this.currentSegmentStart.y + distance * Math.sin(snappedAngleRad);
+                // 0° (sağ - X pozitif)
+                if (Math.abs(angleDeg) <= SNAP_TOLERANCE) {
+                    snappedAngle = 0;
+                }
+                // 90° (yukarı - Y negatif)
+                else if (Math.abs(angleDeg - 90) <= SNAP_TOLERANCE) {
+                    snappedAngle = 90;
+                }
+                // 180° veya -180° (sol - X negatif)
+                else if (Math.abs(Math.abs(angleDeg) - 180) <= SNAP_TOLERANCE) {
+                    snappedAngle = 180;
+                }
+                // -90° (aşağı - Y pozitif)
+                else if (Math.abs(angleDeg + 90) <= SNAP_TOLERANCE) {
+                    snappedAngle = -90;
+                }
+
+                if (snappedAngle !== null) {
+                    const snappedAngleRad = snappedAngle * Math.PI / 180;
+                    endX = this.currentSegmentStart.x + distance * Math.cos(snappedAngleRad);
+                    endY = this.currentSegmentStart.y + distance * Math.sin(snappedAngleRad);
+                }
             }
         }
 

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1232,7 +1232,7 @@ export class PlumbingRenderer {
         // Bağlı cihazı bul (clipping için)
         const parentCihaz = manager.components.find(c => c.id === baca.parentCihazId && c.type === 'cihaz');
 
-        // Segment'leri çiz - GRADIENT İLE
+        // Segment'leri çiz - GRADIENT İLE + MITER
         baca.segments.forEach((segment, index) => {
             const dx = segment.x2 - segment.x1;
             const dy = segment.y2 - segment.y1;
@@ -1270,14 +1270,20 @@ export class PlumbingRenderer {
                 gradient.addColorStop(1, BACA_CONFIG.fillColorLight);
 
                 ctx.fillStyle = gradient;
-                ctx.strokeStyle = BACA_CONFIG.strokeColor;
-                ctx.lineWidth = 0.8 / zoom;
 
                 // Köşe overlap ile çiz
                 const drawStart = startOffset - startExtension;
                 const drawLength = length - startOffset + startExtension + endExtension;
 
                 ctx.fillRect(drawStart, -BACA_CONFIG.genislik / 2, drawLength, BACA_CONFIG.genislik);
+
+                // Miter outline ekle (köşeleri düzgün göstermek için)
+                ctx.strokeStyle = BACA_CONFIG.strokeColor;
+                ctx.lineWidth = 0.8 / zoom;
+                ctx.lineJoin = 'miter';
+                ctx.lineCap = 'square';
+                ctx.miterLimit = 10;
+                ctx.strokeRect(drawStart, -BACA_CONFIG.genislik / 2, drawLength, BACA_CONFIG.genislik);
             }
 
             ctx.restore();


### PR DESCRIPTION
1. GRADIENT + MITER ✅
   - Gradient fill GERİ GETİRİLDİ (açık→orta→açık gri)
   - Miter outline EKLENDİ (lineJoin, lineCap, strokeRect)
   - Köşeler artık hem gradient hem miter ile düzgün

2. EKSEN SNAP (15° tolerans) ✅
   - SADECE X/Y eksenlerine yakınsa snap
   - 15° dışındaysa SERBEST yön
   - Önceki: Her 15° katına snap (0°, 15°, 30°... yanlış!)
   - Şimdi: Sadece 0°, 90°, 180°, -90° eksenlere snap

3. SPLIT DEBUG LOGLARI ✅
   - Double-click handler'a console.log eklendi
   - splitChimneyAtClickPosition'a detaylı log eklendi
   - splitAt sonucunu logluyor
   - Kullanıcı test edebilir ve console'dan görebilir

Değişiklikler:
- plumbing-renderer.js: strokeRect + miter settings eklendi
- chimney.js: Eksen snap logic (±15° tolerance)
- component-placement.js: Eksen snap logic (aynı)
- input.js: Debug console.log'ları eklendi

Test için:
1. Baca çiz → 15° içinde eksene snap olmalı
2. Bacaya çift tıkla → Console'da log'ları kontrol et
3. Gradient + miter → Köşeler düzgün görünmeli