### PR TITLE
Fix chimney issues: clean miter rendering, drag support, and split de…

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -767,8 +767,8 @@ export function isObjectInteractable(objectType) {
 
     // Tesisat nesneleri listesi - GÜNCELLENDİ
     const plumbingObjects = [
-        'plumbing', 'pipe', 'boru', 'servis_kutusu', 'sayac', 'vana', 'cihaz', 
-        'plumbingPipe', 'plumbingComponent', 'plumbingBlock', 'valve' // <-- 'plumbingBlock' ve 'valve' EKLENDİ
+        'plumbing', 'pipe', 'boru', 'servis_kutusu', 'sayac', 'vana', 'cihaz',
+        'plumbingPipe', 'plumbingComponent', 'plumbingBlock', 'valve', 'baca' // <-- 'baca' EKLENDİ
     ];
 
     const isArchitectural = architecturalObjects.includes(objectType);

--- a/plumbing_v2/objects/chimney.js
+++ b/plumbing_v2/objects/chimney.js
@@ -269,6 +269,39 @@ export class Baca {
     }
 
     /**
+     * Tüm bacayı taşı (delta ile)
+     * @param {number} newX - Yeni başlangıç X koordinatı
+     * @param {number} newY - Yeni başlangıç Y koordinatı
+     */
+    move(newX, newY) {
+        // Delta hesapla (startX, startY referans noktası)
+        const deltaX = newX - this.startX;
+        const deltaY = newY - this.startY;
+
+        // Başlangıç noktasını güncelle
+        this.startX = newX;
+        this.startY = newY;
+
+        // Tüm segmentleri taşı
+        this.segments.forEach(seg => {
+            seg.x1 += deltaX;
+            seg.y1 += deltaY;
+            seg.x2 += deltaX;
+            seg.y2 += deltaY;
+        });
+
+        // Current segment start'ı taşı
+        this.currentSegmentStart.x += deltaX;
+        this.currentSegmentStart.y += deltaY;
+
+        // Havalandırma varsa onu da taşı
+        if (this.havalandirma) {
+            this.havalandirma.x += deltaX;
+            this.havalandirma.y += deltaY;
+        }
+    }
+
+    /**
      * Segment endpoint'i taşı
      * @param {number} segmentIndex - Segment indexi
      * @param {string} endpoint - 'start' veya 'end'

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1257,11 +1257,6 @@ export class PlumbingRenderer {
                 }
             }
 
-            // Köşe overlap için uzatma - baca genişliğinin yarısı
-            const overlapExtension = BACA_CONFIG.genislik / 2;
-            let startExtension = (index > 0) ? overlapExtension : 0;
-            let endExtension = (index < baca.segments.length - 1) ? overlapExtension : 0;
-
             if (length > startOffset) {
                 // Gradient - açık → orta → açık
                 const gradient = ctx.createLinearGradient(0, -BACA_CONFIG.genislik / 2, 0, BACA_CONFIG.genislik / 2);
@@ -1271,15 +1266,15 @@ export class PlumbingRenderer {
 
                 ctx.fillStyle = gradient;
 
-                // Köşe overlap ile çiz
-                const drawStart = startOffset - startExtension;
-                const drawLength = length - startOffset + startExtension + endExtension;
+                // Normal çizim - overlap YOK
+                const drawStart = startOffset;
+                const drawLength = length - startOffset;
 
                 ctx.fillRect(drawStart, -BACA_CONFIG.genislik / 2, drawLength, BACA_CONFIG.genislik);
 
-                // Miter outline ekle (köşeleri düzgün göstermek için)
+                // Miter outline - köşeleri temiz gösterir
                 ctx.strokeStyle = BACA_CONFIG.strokeColor;
-                ctx.lineWidth = 0.8 / zoom;
+                ctx.lineWidth = 1.2 / zoom;
                 ctx.lineJoin = 'miter';
                 ctx.lineCap = 'square';
                 ctx.miterLimit = 10;


### PR DESCRIPTION
…tection

- Remove overlap extension in chimney rendering for clean miter joints
- Add move() method to Baca class to fix drag handler error
- Add 'baca' to plumbingObjects array to enable double-click split detection