### PR TITLE
Fix remaining chimney issues: clean miter outline and prevent body drag

### DIFF
--- a/general-files/input.js
+++ b/general-files/input.js
@@ -974,9 +974,18 @@ export function setupInputListeners() {
         const clickPos = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
         const object = getObjectAtPoint(clickPos);
 
+        console.log('🔍 DOUBLE-CLICK EVENT:', {
+            clickPos,
+            object,
+            type: object?.type,
+            handle: object?.handle,
+            interactable: object ? isObjectInteractable(object.type) : null
+        });
+
         // Nesneye çift tıklama için interaktif olup olmadığını kontrol et
         if (object && !isObjectInteractable(object.type)) {
             // TESİSAT modunda mimari nesnelere çift tıklanamaz
+            console.warn('⚠️ Object not interactable:', object.type);
             return;
         }
 

--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -1449,6 +1449,13 @@ export function handleDrag(interactionManager, point) {
         return;
     }
 
+    // Baca body taşıma engellendi - sadece endpoint'lerden taşınabilir
+    if (interactionManager.dragObject.type === 'baca') {
+        // Baca body drag yapılamaz, sadece endpoint drag
+        console.warn('⚠️ Baca body taşınamaz - lütfen uç noktalardan taşıyın');
+        return;
+    }
+
     // Diğer objeler için normal taşıma
     if (interactionManager.dragObject.type !== 'boru') {
         const result = interactionManager.dragObject.move(point.x, point.y);

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1232,7 +1232,7 @@ export class PlumbingRenderer {
         // Bağlı cihazı bul (clipping için)
         const parentCihaz = manager.components.find(c => c.id === baca.parentCihazId && c.type === 'cihaz');
 
-        // Segment'leri çiz - GRADIENT İLE + MITER
+        // ADIM 1: Önce tüm segmentlerin gradient dolgusunu çiz
         baca.segments.forEach((segment, index) => {
             const dx = segment.x2 - segment.x1;
             const dy = segment.y2 - segment.y1;
@@ -1266,23 +1266,99 @@ export class PlumbingRenderer {
 
                 ctx.fillStyle = gradient;
 
-                // Normal çizim - overlap YOK
+                // Sadece dolgu çiz
                 const drawStart = startOffset;
                 const drawLength = length - startOffset;
-
                 ctx.fillRect(drawStart, -BACA_CONFIG.genislik / 2, drawLength, BACA_CONFIG.genislik);
-
-                // Miter outline - köşeleri temiz gösterir
-                ctx.strokeStyle = BACA_CONFIG.strokeColor;
-                ctx.lineWidth = 1.2 / zoom;
-                ctx.lineJoin = 'miter';
-                ctx.lineCap = 'square';
-                ctx.miterLimit = 10;
-                ctx.strokeRect(drawStart, -BACA_CONFIG.genislik / 2, drawLength, BACA_CONFIG.genislik);
             }
 
             ctx.restore();
         });
+
+        // ADIM 2: Tüm segmentlerin outline'ını tek bir path olarak çiz (TEMİZ MİTER İÇİN)
+        if (baca.segments.length > 0) {
+            const halfWidth = BACA_CONFIG.genislik / 2;
+
+            // Üst ve alt kenarları oluştur
+            const topEdge = [];
+            const bottomEdge = [];
+
+            baca.segments.forEach((segment, index) => {
+                const dx = segment.x2 - segment.x1;
+                const dy = segment.y2 - segment.y1;
+                const length = Math.hypot(dx, dy);
+                const angle = Math.atan2(dy, dx);
+                const perpAngle = angle + Math.PI / 2;
+
+                // Clipping offset
+                let startOffset = 0;
+                if (parentCihaz && index === 0) {
+                    const cihazRadius = Math.max(parentCihaz.config.width, parentCihaz.config.height) / 2;
+                    const distFromCenter = Math.hypot(
+                        segment.x1 - parentCihaz.x,
+                        segment.y1 - parentCihaz.y
+                    );
+                    if (distFromCenter < cihazRadius) {
+                        startOffset = cihazRadius - distFromCenter;
+                    }
+                }
+
+                // Başlangıç noktası (startOffset ile)
+                const startX = segment.x1 + Math.cos(angle) * startOffset;
+                const startY = segment.y1 + Math.sin(angle) * startOffset;
+
+                // Üst ve alt köşe noktaları
+                const topStart = {
+                    x: startX + Math.cos(perpAngle) * halfWidth,
+                    y: startY + Math.sin(perpAngle) * halfWidth
+                };
+                const bottomStart = {
+                    x: startX - Math.cos(perpAngle) * halfWidth,
+                    y: startY - Math.sin(perpAngle) * halfWidth
+                };
+                const topEnd = {
+                    x: segment.x2 + Math.cos(perpAngle) * halfWidth,
+                    y: segment.y2 + Math.sin(perpAngle) * halfWidth
+                };
+                const bottomEnd = {
+                    x: segment.x2 - Math.cos(perpAngle) * halfWidth,
+                    y: segment.y2 - Math.sin(perpAngle) * halfWidth
+                };
+
+                if (index === 0) {
+                    topEdge.push(topStart);
+                    bottomEdge.push(bottomStart);
+                }
+                topEdge.push(topEnd);
+                bottomEdge.push(bottomEnd);
+            });
+
+            // Outline path'ini çiz
+            ctx.beginPath();
+            // Üst kenar
+            topEdge.forEach((pt, i) => {
+                if (i === 0) ctx.moveTo(pt.x, pt.y);
+                else ctx.lineTo(pt.x, pt.y);
+            });
+            // Sağ uç
+            if (bottomEdge.length > 0) {
+                ctx.lineTo(bottomEdge[bottomEdge.length - 1].x, bottomEdge[bottomEdge.length - 1].y);
+            }
+            // Alt kenar (ters sırada)
+            for (let i = bottomEdge.length - 2; i >= 0; i--) {
+                ctx.lineTo(bottomEdge[i].x, bottomEdge[i].y);
+            }
+            // Sol uç
+            ctx.closePath();
+
+            // Miter outline - TEMİZ KÖŞELER
+            ctx.strokeStyle = BACA_CONFIG.strokeColor;
+            ctx.lineWidth = 1.2 / zoom;
+            ctx.lineJoin = 'miter';
+            ctx.lineCap = 'square';
+            ctx.miterLimit = 10;
+            ctx.stroke();
+        }
 
         // Havalandırma ızgarası (ESC basılınca) - BACANIN DIŞINDA
         if (baca.havalandirma && baca.segments.length > 0) {


### PR DESCRIPTION
- Rewrite chimney outline rendering as continuous path for clean miter corners (no overlap)
- Prevent chimney body dragging to keep connection with device (only endpoint drag allowed)
- Add debug logs to double-click handler to investigate split detection