### PR TITLE
FIX: Baca endpoint rigid transform + gradient düzeltmesi

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -686,8 +686,8 @@ export function handleDrag(interactionManager, point) {
             }
         }
 
-        // Endpoint'i snapped pozisyona taşı
-        baca.moveEndpoint(endpoint.segmentIndex, endpoint.endpoint, snappedX, snappedY);
+        // Endpoint'i snapped pozisyona taşı - rigid transform ile (sonraki segment'ler de taşınır)
+        baca.moveEndpointRigid(endpoint.segmentIndex, endpoint.endpoint, snappedX, snappedY);
 
         // Endpoint referansını güncelle (mouse pozisyonu için)
         endpoint.x = snappedX;

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1269,12 +1269,30 @@ export class PlumbingRenderer {
 
         // 1. Ana dolgu - gradient (tek segment) veya düz renk (çoklu)
         if (baca.segments.length === 1) {
-            // Tek segment - gradient
+            // Tek segment - gradient (clipping hesabı dahil)
             const seg = baca.segments[0];
-            const dx = seg.x2 - seg.x1;
-            const dy = seg.y2 - seg.y1;
-            const midX = (seg.x1 + seg.x2) / 2;
-            const midY = (seg.y1 + seg.y2) / 2;
+
+            // Gerçek başlangıç noktası (clipping varsa ayarlanmış)
+            let startX = seg.x1;
+            let startY = seg.y1;
+
+            if (parentCihaz) {
+                const cihazRadius = Math.max(parentCihaz.config.width, parentCihaz.config.height) / 2;
+                const distFromCenter = Math.hypot(seg.x1 - parentCihaz.x, seg.x1 - parentCihaz.y);
+                if (distFromCenter < cihazRadius) {
+                    const dx = seg.x2 - seg.x1;
+                    const dy = seg.y2 - seg.y1;
+                    const angle = Math.atan2(dy, dx);
+                    const startOffset = cihazRadius - distFromCenter;
+                    startX = seg.x1 + Math.cos(angle) * startOffset;
+                    startY = seg.y1 + Math.sin(angle) * startOffset;
+                }
+            }
+
+            const dx = seg.x2 - startX;
+            const dy = seg.y2 - startY;
+            const midX = (startX + seg.x2) / 2;
+            const midY = (startY + seg.y2) / 2;
             const angle = Math.atan2(dy, dx);
             const perpAngle = angle + Math.PI / 2;
 


### PR DESCRIPTION
- Endpoint taşırken sonraki segment'ler de rigid body gibi hareket eder
- Önceki segment'ler sabit kalır (kullanıcının istediği davranış)
- Tek segment gradient clipping hesabı ile düzeltildi
- moveEndpointRigid() metodu eklendi