### PR TITLE
FEAT: İzometrik görünüm zoom, pan ve 3D hacim eklendi

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import { saveState } from './history.js';
 import { setupFileIOListeners } from './file-io.js';
 import { setupInputListeners, handleDelete } from './input.js';
-import { setupUIListeners, initializeSettings, toggle3DView, toggleIsoView, drawIsoView } from './ui.js';
+import { setupUIListeners, initializeSettings, toggle3DView, toggleIsoView, drawIsoView, setupIsometricControls } from './ui.js';
 import { draw2D } from '../draw/draw2d.js';
 import { initGuideContextMenu } from '../menu/guide-menu.js';
 import { initFloorOperationsMenu } from '../menu/floor-operations-menu.js';
@@ -445,8 +445,15 @@ export let state = {
     // --- OPACITY AYARLARI SONU ---
 
     // --- PENCERE YERLEŞTIRME AŞAMASI ---
-    windowPlacementStage: 0 // 0: ilk tıklama (en geniş duvarlara), 1: ikinci tıklama (kalan duvarlara)
+    windowPlacementStage: 0, // 0: ilk tıklama (en geniş duvarlara), 1: ikinci tıklama (kalan duvarlara)
     // --- PENCERE YERLEŞTIRME SONU ---
+
+    // --- İZOMETRİK GÖRÜNÜM ---
+    isoZoom: 0.5,
+    isoPanOffset: { x: 0, y: 0 },
+    isoPanning: false,
+    isoPanStart: { x: 0, y: 0 },
+    // --- İZOMETRİK GÖRÜNÜM SONU ---
 };
 
 export function setState(newState) {
@@ -1236,6 +1243,7 @@ function initialize() {
     setupUIListeners();
     setupInputListeners();
     setupFileIOListeners();
+    setupIsometricControls(); // İzometrik zoom ve pan kontrollerini kur
     createWallPanel();
     initializeDefaultFloors(); // Önce katları initialize et
     createFloorPanel(); // Sonra paneli oluştur

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -1106,6 +1106,21 @@ body.light-mode .btn.active svg {
     height: 100%;
 }
 
+/* İzometri Overlay: Ekran Bölme Oranı Butonları */
+#iso-ratio-buttons {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 100;
+    display: flex;
+    gap: 4px;
+    background: var(--bg-menu);
+    padding: 4px;
+    border-radius: 6px;
+    border: 1px solid var(--border-menu);
+    backdrop-filter: blur(4px);
+}
+
 /* Katı/Binayı Göster Butonu (dikdörtgen) */
 .floor-view-btn {
     padding: 6px 12px;

--- a/index.html
+++ b/index.html
@@ -650,6 +650,40 @@
     </div>
     <div id="pIso" class="panel">
       <canvas id="cIso"></canvas>
+      <!-- İzometri Overlay: Ekran Bölme Oranı Butonları (Sağ Üst) -->
+      <div id="iso-ratio-buttons" style="display: none;">
+        <button id="iso-100" class="split-btn" data-ratio="100" title="Tam Ekran İzometri">
+          <svg viewBox="0 0 24 24" width="24" height="24">
+            <rect x="2" y="2" width="20" height="20" fill="#FFB74D" stroke="#666" stroke-width="1" />
+          </svg>
+        </button>
+        <button id="iso-75" class="split-btn" data-ratio="75" title="75% İzometri">
+          <svg viewBox="0 0 24 24" width="24" height="24">
+            <rect x="2" y="2" width="5" height="20" fill="#999" stroke="#666" stroke-width="1" />
+            <rect x="7" y="2" width="15" height="20" fill="#FFB74D" stroke="#666" stroke-width="1" />
+          </svg>
+        </button>
+        <button id="iso-50" class="split-btn" data-ratio="50" title="50% İzometri / 50% 2D">
+          <svg viewBox="0 0 24 24" width="24" height="24">
+            <rect x="2" y="2" width="10" height="20" fill="#999" stroke="#666" stroke-width="1" />
+            <rect x="12" y="2" width="10" height="20" fill="#FFB74D" stroke="#666" stroke-width="1" />
+          </svg>
+        </button>
+        <button id="iso-25" class="split-btn" data-ratio="25" title="25% İzometri">
+          <svg viewBox="0 0 24 24" width="24" height="24">
+            <rect x="2" y="2" width="15" height="20" fill="#999" stroke="#666" stroke-width="1" />
+            <rect x="17" y="2" width="5" height="20" fill="#FFB74D" stroke="#666" stroke-width="1" />
+          </svg>
+        </button>
+        <button id="iso-0" class="split-btn" data-ratio="0" title="İzometri Kapalı">
+          <svg viewBox="0 0 24 24" width="24" height="24">
+            <rect x="2" y="2" width="20" height="20" fill="#999" stroke="#666" stroke-width="1" />
+            <!-- × işareti (Close/Kapalı) -->
+            <line x1="8" y1="8" x2="16" y2="16" stroke="#fff" stroke-width="2" stroke-linecap="round" />
+            <line x1="16" y1="8" x2="8" y2="16" stroke="#fff" stroke-width="2" stroke-linecap="round" />
+          </svg>
+        </button>
+      </div>
     </div>
   </div>
 

--- a/scene3d/scene-isometric.js
+++ b/scene3d/scene-isometric.js
@@ -186,119 +186,213 @@ function drawIsometricComponents(ctx) {
 }
 
 /**
- * Servis kutusunu izometrik perspektifte çizer
+ * İzometrik kutu (3D blok) çizer
  * @param {CanvasRenderingContext2D} ctx - Canvas context
+ * @param {number} width - Genişlik (X ekseni)
+ * @param {number} depth - Derinlik (Y ekseni)
+ * @param {number} height - Yükseklik (Z ekseni)
+ * @param {string} fillColor - Dolgu rengi
+ * @param {string} strokeColor - Kenar rengi
  */
-function drawServisKutusuIso(ctx) {
-    const size = 40;
-    ctx.fillStyle = document.body.classList.contains('light-mode') ? '#4CAF50' : '#66BB6A';
-    ctx.strokeStyle = document.body.classList.contains('light-mode') ? '#388E3C' : '#81C784';
-    ctx.lineWidth = 2;
+function drawIsometricBox(ctx, width, depth, height, fillColor, strokeColor) {
+    const angle = Math.PI / 6; // 30 derece
 
-    // Dikdörtgen
-    ctx.fillRect(-size / 2, -size / 2, size, size);
-    ctx.strokeRect(-size / 2, -size / 2, size, size);
+    // Taban köşe noktaları (düzlem üzerinde)
+    const frontLeft = { x: -width / 2, y: 0 };
+    const frontRight = { x: width / 2, y: 0 };
+    const backLeft = { x: -width / 2 + depth * Math.cos(angle), y: -depth * Math.sin(angle) };
+    const backRight = { x: width / 2 + depth * Math.cos(angle), y: -depth * Math.sin(angle) };
 
-    // Metin
-    ctx.fillStyle = '#fff';
-    ctx.font = 'bold 12px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('SK', 0, 0);
-}
+    // Üst köşe noktaları
+    const topFrontLeft = { x: frontLeft.x, y: frontLeft.y - height };
+    const topFrontRight = { x: frontRight.x, y: frontRight.y - height };
+    const topBackLeft = { x: backLeft.x, y: backLeft.y - height };
+    const topBackRight = { x: backRight.x, y: backRight.y - height };
 
-/**
- * Sayacı izometrik perspektifte çizer
- * @param {CanvasRenderingContext2D} ctx - Canvas context
- */
-function drawSayacIso(ctx) {
-    const size = 30;
-    ctx.fillStyle = document.body.classList.contains('light-mode') ? '#2196F3' : '#64B5F6';
-    ctx.strokeStyle = document.body.classList.contains('light-mode') ? '#1976D2' : '#90CAF9';
-    ctx.lineWidth = 2;
+    ctx.lineWidth = 1.5;
 
-    // Dikdörtgen
-    ctx.fillRect(-size / 2, -size / 2, size, size);
-    ctx.strokeRect(-size / 2, -size / 2, size, size);
-
-    // Metin
-    ctx.fillStyle = '#fff';
-    ctx.font = 'bold 10px sans-serif';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('G4', 0, 0);
-}
-
-/**
- * Vanayı izometrik perspektifte çizer
- * @param {CanvasRenderingContext2D} ctx - Canvas context
- */
-function drawVanaIso(ctx) {
-    const size = 20;
-    ctx.fillStyle = document.body.classList.contains('light-mode') ? '#FF9800' : '#FFB74D';
-    ctx.strokeStyle = document.body.classList.contains('light-mode') ? '#F57C00' : '#FFA726';
-    ctx.lineWidth = 2;
-
-    // Üçgen (vana simgesi)
+    // Üst yüzey (en açık)
+    ctx.fillStyle = fillColor;
+    ctx.strokeStyle = strokeColor;
     ctx.beginPath();
-    ctx.moveTo(-size / 2, size / 2);
-    ctx.lineTo(0, -size / 2);
-    ctx.lineTo(size / 2, size / 2);
+    ctx.moveTo(topFrontLeft.x, topFrontLeft.y);
+    ctx.lineTo(topFrontRight.x, topFrontRight.y);
+    ctx.lineTo(topBackRight.x, topBackRight.y);
+    ctx.lineTo(topBackLeft.x, topBackLeft.y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+
+    // Sol yüzey (orta ton)
+    const leftColor = shadeColor(fillColor, -20);
+    ctx.fillStyle = leftColor;
+    ctx.beginPath();
+    ctx.moveTo(frontLeft.x, frontLeft.y);
+    ctx.lineTo(topFrontLeft.x, topFrontLeft.y);
+    ctx.lineTo(topBackLeft.x, topBackLeft.y);
+    ctx.lineTo(backLeft.x, backLeft.y);
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+
+    // Sağ yüzey (en koyu)
+    const rightColor = shadeColor(fillColor, -40);
+    ctx.fillStyle = rightColor;
+    ctx.beginPath();
+    ctx.moveTo(frontRight.x, frontRight.y);
+    ctx.lineTo(topFrontRight.x, topFrontRight.y);
+    ctx.lineTo(topBackRight.x, topBackRight.y);
+    ctx.lineTo(backRight.x, backRight.y);
     ctx.closePath();
     ctx.fill();
     ctx.stroke();
 }
 
 /**
- * Cihazı (kombi, ocak vb.) izometrik perspektifte çizer
+ * Rengi koyulaştırır veya açar
+ * @param {string} color - Hex renk (#RRGGBB)
+ * @param {number} percent - % koyulaştırma/açma (-100 ile 100 arası)
+ * @returns {string} Yeni hex renk
+ */
+function shadeColor(color, percent) {
+    // Hex rengi RGB'ye çevir
+    let R = parseInt(color.substring(1, 3), 16);
+    let G = parseInt(color.substring(3, 5), 16);
+    let B = parseInt(color.substring(5, 7), 16);
+
+    // % uygula
+    R = parseInt(R * (100 + percent) / 100);
+    G = parseInt(G * (100 + percent) / 100);
+    B = parseInt(B * (100 + percent) / 100);
+
+    // Sınırla
+    R = (R < 255) ? R : 255;
+    G = (G < 255) ? G : 255;
+    B = (B < 255) ? B : 255;
+
+    R = (R > 0) ? R : 0;
+    G = (G > 0) ? G : 0;
+    B = (B > 0) ? B : 0;
+
+    const RR = ((R.toString(16).length === 1) ? "0" + R.toString(16) : R.toString(16));
+    const GG = ((G.toString(16).length === 1) ? "0" + G.toString(16) : G.toString(16));
+    const BB = ((B.toString(16).length === 1) ? "0" + B.toString(16) : B.toString(16));
+
+    return "#" + RR + GG + BB;
+}
+
+/**
+ * Servis kutusunu izometrik perspektifte çizer (3D blok)
+ * @param {CanvasRenderingContext2D} ctx - Canvas context
+ */
+function drawServisKutusuIso(ctx) {
+    const width = 40;
+    const depth = 40;
+    const height = 50;
+    const fillColor = document.body.classList.contains('light-mode') ? '#4CAF50' : '#66BB6A';
+    const strokeColor = document.body.classList.contains('light-mode') ? '#388E3C' : '#81C784';
+
+    // 3D kutu çiz
+    drawIsometricBox(ctx, width, depth, height, fillColor, strokeColor);
+
+    // Metin (üst yüzeyde)
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 12px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('SK', 0, -height);
+}
+
+/**
+ * Sayacı izometrik perspektifte çizer (3D blok)
+ * @param {CanvasRenderingContext2D} ctx - Canvas context
+ */
+function drawSayacIso(ctx) {
+    const width = 30;
+    const depth = 30;
+    const height = 35;
+    const fillColor = document.body.classList.contains('light-mode') ? '#2196F3' : '#64B5F6';
+    const strokeColor = document.body.classList.contains('light-mode') ? '#1976D2' : '#90CAF9';
+
+    // 3D kutu çiz
+    drawIsometricBox(ctx, width, depth, height, fillColor, strokeColor);
+
+    // Metin (üst yüzeyde)
+    ctx.fillStyle = '#fff';
+    ctx.font = 'bold 10px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('G4', 0, -height);
+}
+
+/**
+ * Vanayı izometrik perspektifte çizer (3D silindir benzeri)
+ * @param {CanvasRenderingContext2D} ctx - Canvas context
+ */
+function drawVanaIso(ctx) {
+    const width = 20;
+    const depth = 20;
+    const height = 25;
+    const fillColor = document.body.classList.contains('light-mode') ? '#FF9800' : '#FFB74D';
+    const strokeColor = document.body.classList.contains('light-mode') ? '#F57C00' : '#FFA726';
+
+    // 3D kutu çiz (küçük silindir gibi)
+    drawIsometricBox(ctx, width, depth, height, fillColor, strokeColor);
+
+    // Üst yüzeye çizgi ekle (vana simgesi)
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(-width / 3, -height);
+    ctx.lineTo(width / 3, -height);
+    ctx.stroke();
+}
+
+/**
+ * Cihazı (kombi, ocak vb.) izometrik perspektifte çizer (3D blok)
  * @param {CanvasRenderingContext2D} ctx - Canvas context
  * @param {object} component - Cihaz bileşeni
  */
 function drawCihazIso(ctx, component) {
-    const size = 35;
-    const color = component.cihazTipi === 'KOMBI'
+    const width = 40;
+    const depth = 40;
+    const height = 60;
+    const fillColor = component.cihazTipi === 'KOMBI'
         ? (document.body.classList.contains('light-mode') ? '#9C27B0' : '#BA68C8')
         : (document.body.classList.contains('light-mode') ? '#F44336' : '#E57373');
+    const strokeColor = document.body.classList.contains('light-mode') ? '#000' : '#fff';
 
-    ctx.fillStyle = color;
-    ctx.strokeStyle = document.body.classList.contains('light-mode') ? '#000' : '#fff';
-    ctx.lineWidth = 2;
+    // 3D kutu çiz
+    drawIsometricBox(ctx, width, depth, height, fillColor, strokeColor);
 
-    // Daire
-    ctx.beginPath();
-    ctx.arc(0, 0, size / 2, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
-
-    // Metin
+    // Metin (üst yüzeyde)
     ctx.fillStyle = '#fff';
-    ctx.font = 'bold 10px sans-serif';
+    ctx.font = 'bold 12px sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(component.cihazTipi === 'KOMBI' ? 'K' : 'O', 0, 0);
+    ctx.fillText(component.cihazTipi === 'KOMBI' ? 'K' : 'O', 0, -height);
 }
 
 /**
- * Bacayı izometrik perspektifte çizer
+ * Bacayı izometrik perspektifte çizer (3D ince ve uzun blok)
  * @param {CanvasRenderingContext2D} ctx - Canvas context
  */
 function drawBacaIso(ctx) {
-    const width = 25;
-    const height = 50;
-    ctx.fillStyle = document.body.classList.contains('light-mode') ? '#795548' : '#A1887F';
-    ctx.strokeStyle = document.body.classList.contains('light-mode') ? '#5D4037' : '#8D6E63';
-    ctx.lineWidth = 2;
+    const width = 15;
+    const depth = 15;
+    const height = 80;
+    const fillColor = document.body.classList.contains('light-mode') ? '#795548' : '#A1887F';
+    const strokeColor = document.body.classList.contains('light-mode') ? '#5D4037' : '#8D6E63';
 
-    // Dikdörtgen (baca)
-    ctx.fillRect(-width / 2, -height / 2, width, height);
-    ctx.strokeRect(-width / 2, -height / 2, width, height);
+    // 3D kutu çiz (ince ve uzun)
+    drawIsometricBox(ctx, width, depth, height, fillColor, strokeColor);
 
-    // Metin
+    // Metin (orta yükseklikte)
     ctx.fillStyle = '#fff';
     ctx.font = 'bold 10px sans-serif';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText('B', 0, 0);
+    ctx.fillText('B', 0, -height / 2);
 }
 
 /**


### PR DESCRIPTION
- Zoom desteği eklendi (mouse wheel ile 0.1x - 5x arası)
- Pan desteği eklendi (orta/sağ tuş ile sürükleme)
- İzometri kapatma ve oran butonları eklendi (%0, %25, %50, %75, %100)
- Nesneler 3D hacim olarak render ediliyor:
  * Servis kutusu: 40x40x50 3D blok (yeşil)
  * Sayaç: 30x30x35 3D blok (mavi)
  * Vana: 20x20x25 3D blok (turuncu)
  * Cihaz: 40x40x60 3D blok (mor/kırmızı)
  * Baca: 15x15x80 ince ve uzun blok (kahverengi)
- Gölgelendirme algoritması: Üst yüzey açık, yan yüzeyler koyu
- İzometrik kontroller: setupIsometricControls() ile kurulum
- State yönetimi: isoZoom, isoPanOffset, isoPanning