### PR TITLE
FEAT: İzometrik boru ucu sürükleme ve reset butonu eklendi

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -453,6 +453,11 @@ export let state = {
     isoPanOffset: { x: 0, y: 0 },
     isoPanning: false,
     isoPanStart: { x: 0, y: 0 },
+    // Sürükleme ile değiştirilen boru offsetleri (görsel değişiklikler, projeyi etkilemez)
+    isoPipeOffsets: {}, // { pipeId: { dx: number, dy: number } }
+    isoDragging: false,
+    isoDraggedPipe: null,
+    isoDraggedEndpoint: null, // 'start' veya 'end'
     // --- İZOMETRİK GÖRÜNÜM SONU ---
 };
 

--- a/index.html
+++ b/index.html
@@ -652,6 +652,15 @@
       <canvas id="cIso"></canvas>
       <!-- İzometri Overlay: Ekran Bölme Oranı Butonları (Sağ Üst) -->
       <div id="iso-ratio-buttons" style="display: none;">
+        <button id="iso-reset" class="split-btn" title="Orijinal Boyut" style="margin-right: 8px;">
+          <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2">
+            <!-- Reset/Refresh icon -->
+            <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"></path>
+            <path d="M21 3v5h-5"></path>
+            <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"></path>
+            <path d="M3 21v-5h5"></path>
+          </svg>
+        </button>
         <button id="iso-100" class="split-btn" data-ratio="100" title="Tam Ekran İzometri">
           <svg viewBox="0 0 24 24" width="24" height="24">
             <rect x="2" y="2" width="20" height="20" fill="#FFB74D" stroke="#666" stroke-width="1" />


### PR DESCRIPTION
- Boru uç noktalarından sürükleme özelliği:
  * Sol tuş ile boru uçlarını sürükleyebilme
  * Sürükleme offsetleri state.isoPipeOffsets'te saklanıyor
  * İzometri kapansa bile değişiklikler korunuyor
  * Sadece görsel değişiklik, projeyi etkilemiyor

- Orijinal Boyut reset butonu:
  * Tüm zoom, pan ve offset değerlerini sıfırlar
  * Refresh ikonu ile görselleştirildi

- Hit detection sistemi:
  * getIsoEndpointAtMouse() fonksiyonu ile boru uçları tespit ediliyor
  * Zoom'a göre ayarlanmış hit radius
  * Endpoint pozisyonları her render'da güncelleniyor

- Kullanıcı arayüzü güncellemeleri:
  * Sol tuş: Boru uçlarını sürükle
  * Sağ tuş: Pan (kaydırma)
  * Mouse wheel: Zoom
  * Bilgi metinleri eklendi