### PR TITLE
FIX: Children köşeli parantezlerini kaldır

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1940,7 +1940,7 @@ export class PlumbingRenderer {
             if (pipeData) {
                 const parent = pipeData.parent || '';
                 const self = pipeData.label;
-                const children = pipeData.children.length > 0 ? `[${pipeData.children.join(',')}]` : '';
+                const children = pipeData.children.length > 0 ? pipeData.children.join(',') : '';
 
                 // Yazı pozisyonları hesapla
                 ctx.textAlign = "center";

--- a/scene3d/scene-isometric.js
+++ b/scene3d/scene-isometric.js
@@ -391,7 +391,7 @@ function drawPipeLabels(ctx, pipeHierarchy) {
         // Etiket metnini oluştur
         const parent = pipeData.parent || '';
         const self = pipeData.label;
-        const children = pipeData.children.length > 0 ? `[${pipeData.children.join(',')}]` : '';
+        const children = pipeData.children.length > 0 ? pipeData.children.join(',') : '';
         const labelText = `${parent}:${self}:${children}`;
 
         // Boru ortasını izometrik koordinatlara dönüştür


### PR DESCRIPTION
- Etiket formatı: A:B:[C,D] -> A:B:C,D
- Köşeli parantezler kaldırıldı, sadece virgül ile ayrım
- Hem 2D plan hem izometrik görünümde güncellendi