### PR TITLE
FIX: Boru silindiğinde parent'ı seçme eksikliği düzeltildi

### DIFF
--- a/plumbing_v2/interactions/selection-manager.js
+++ b/plumbing_v2/interactions/selection-manager.js
@@ -257,10 +257,16 @@ export function deleteSelectedObject(interactionManager) {
             return;
         }
     } else {
-        interactionManager.removeObject(obj);
+        const pipeToSelect = interactionManager.removeObject(obj);
         interactionManager.manager.saveToState();
-        // Boru için deselectObject çağırma - removeObject içinde zaten akıllı seçim yapılıyor
-        if (obj.type !== 'boru') {
+
+        // Boru silindiyse ve parent varsa onu seç
+        if (obj.type === 'boru' && pipeToSelect) {
+            selectObject(interactionManager, pipeToSelect);
+        } else if (obj.type !== 'boru') {
+            deselectObject(interactionManager);
+        } else {
+            // Boru silindi ama seçilecek parent yok
             deselectObject(interactionManager);
         }
     }


### PR DESCRIPTION
- removeObject'in döndüğü pipeToSelect değeri artık kullanılıyor
- Boru silindikten sonra parent otomatik seçiliyor
- Parent bulunamazsa seçim kaldırılıyor
- selection-manager.js'de eksik implementasyon tamamlandı