### PR TITLE
fix: Enable vertical pipe creation with TAB panel and direct +/- input

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -108,6 +108,7 @@ export class InteractionManager {
         // Ölçü girişi
         this.measurementInput = '';
         this.measurementActive = false;
+        this.isVerticalMeasurement = false;  // +/- ile düşey ölçüm modu
 
         // Düşey (vertical) mod durumu
         this.verticalModeActive = false;  // TAB ile panel açıkken true

--- a/plumbing_v2/interactions/keyboard-handler.js
+++ b/plumbing_v2/interactions/keyboard-handler.js
@@ -88,6 +88,14 @@ export function handleKeyDown(e) {
             }
         } else {
             // Normal ölçü girişi (düşey panel kapalıyken)
+            // +/- ile düşey mod
+            if (e.key === '+' || e.key === '-') {
+                this.measurementInput = e.key;
+                this.measurementActive = true;
+                this.isVerticalMeasurement = true;
+                return true;
+            }
+
             // Rakam girişi (0-9)
             if (/^[0-9]$/.test(e.key)) {
                 this.measurementInput += e.key;
@@ -100,6 +108,7 @@ export function handleKeyDown(e) {
                 this.measurementInput = this.measurementInput.slice(0, -1);
                 if (this.measurementInput.length === 0) {
                     this.measurementActive = false;
+                    this.isVerticalMeasurement = false;
                 }
                 return true;
             }

--- a/plumbing_v2/interactions/pipe-drawing.js
+++ b/plumbing_v2/interactions/pipe-drawing.js
@@ -252,7 +252,15 @@ export function handleBoruClick(interactionManager, point) {
     if (!interactionManager.boruBaslangic) return;
     saveState();
 
-    if (isProtectedPoint(point, interactionManager.manager, null, null, null, false)) {
+    // Dikey boru kontrolü (aynı x,y, farklı z)
+    const isVerticalPipe = (
+        Math.abs(point.x - interactionManager.boruBaslangic.nokta.x) < 0.1 &&
+        Math.abs(point.y - interactionManager.boruBaslangic.nokta.y) < 0.1 &&
+        Math.abs((point.z || 0) - (interactionManager.boruBaslangic.nokta.z || 0)) > 0.1
+    );
+
+    // Dikey boru değilse normal koruma kontrolü
+    if (!isVerticalPipe && isProtectedPoint(point, interactionManager.manager, null, null, null, false)) {
         return;
     }
 
@@ -316,6 +324,33 @@ export function handleBoruClick(interactionManager, point) {
 export function applyMeasurement(interactionManager) {
     // ... existing code ...
     if (!interactionManager.boruBaslangic) return;
+
+    // Düşey ölçüm kontrolü (+/- ile başlıyorsa)
+    if (interactionManager.isVerticalMeasurement) {
+        const height = parseFloat(interactionManager.measurementInput);
+        if (isNaN(height) || height === 0) {
+            interactionManager.measurementInput = '';
+            interactionManager.measurementActive = false;
+            interactionManager.isVerticalMeasurement = false;
+            return;
+        }
+
+        // Düşey boru oluştur
+        const startPoint = interactionManager.boruBaslangic.nokta;
+        const endPoint = {
+            x: startPoint.x,
+            y: startPoint.y,
+            z: (startPoint.z || 0) + height
+        };
+
+        handleBoruClick(interactionManager, endPoint);
+        interactionManager.measurementInput = '';
+        interactionManager.measurementActive = false;
+        interactionManager.isVerticalMeasurement = false;
+        return;
+    }
+
+    // Normal yatay ölçüm
     const measurement = parseFloat(interactionManager.measurementInput);
     if (isNaN(measurement) || measurement <= 0) {
         interactionManager.measurementInput = '';


### PR DESCRIPTION
- Fixed isProtectedPoint blocking vertical pipes (same x,y, different z)
- Added direct vertical input: type +100 or -100 without TAB
- Modified applyMeasurement to handle vertical measurements
- Vertical pipes now work both with TAB panel and direct typing