### PR TITLE
fix: Allow vertical panel keyboard input and adjust descending arrow …

### DIFF
--- a/plumbing_v2/interactions/keyboard-handler.js
+++ b/plumbing_v2/interactions/keyboard-handler.js
@@ -26,8 +26,11 @@ export function handleKeyDown(e) {
         activeElement.contentEditable === 'true'
     );
 
-    // Eğer kullanıcı bir input alanında yazıyorsa, ESC ve Delete dışındaki kısayolları devre dışı bırak
-    if (isTyping && e.key !== 'Escape' && e.key !== 'Delete') {
+    // Düşey panel aktifse, klavye girişine izin ver (readonly input olsa bile)
+    const isVerticalPanelInput = activeElement && activeElement.id === 'vertical-height-input';
+
+    // Eğer kullanıcı bir input alanında yazıyorsa (ama düşey panel değilse), ESC ve Delete dışındaki kısayolları devre dışı bırak
+    if (isTyping && !isVerticalPanelInput && e.key !== 'Escape' && e.key !== 'Delete') {
         return false;
     }
 

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -604,17 +604,18 @@ export class PlumbingRenderer {
                     const angle225 = 5 * Math.PI / 4; // 225 derece
                     const arrowHeadSize = 5;
 
-                    // Ok ucu çemberden 2px uzakta (merkeze yakın ama değmesin)
-                    const arrowTipX = centerX + (circleRadius + 2) * Math.cos(angle225);
-                    const arrowTipY = centerY - (circleRadius + 2) * Math.sin(angle225);
-
-                    // Ok çizgisi başlangıcı
+                    // Ok başlangıcı dışarıda
                     const arrowStartX = centerX + (circleRadius + arrowLength) * Math.cos(angle225);
                     const arrowStartY = centerY - (circleRadius + arrowLength) * Math.sin(angle225);
 
-                    // Ok çizgisi - ok başının arkasında biter (cubu görünmez)
-                    const lineEndX = arrowTipX - arrowHeadSize * Math.cos(angle225);
-                    const lineEndY = arrowTipY + arrowHeadSize * Math.sin(angle225);
+                    // Ok ucu tam çember kenarında (yükseliş oku gibi)
+                    const arrowTipX = centerX + circleRadius * Math.cos(angle225);
+                    const arrowTipY = centerY - circleRadius * Math.sin(angle225);
+
+                    // Ok çizgisi - ok başının arkasında biter (cubuk görünmez)
+                    const lineEndOffset = 3;
+                    const lineEndX = arrowTipX - lineEndOffset * Math.cos(angle225);
+                    const lineEndY = arrowTipY + lineEndOffset * Math.sin(angle225);
 
                     ctx.beginPath();
                     ctx.moveTo(arrowStartX, arrowStartY);


### PR DESCRIPTION
…position

Keyboard Handler Fix:
- Added exception for vertical-height-input in typing detection
- Panel can now receive keyboard input even though it has readonly input
- Users can type +/- and numbers to enter vertical height values

Descending Arrow Fix:
- Arrow tip now at circle edge (circleRadius) instead of +2px away
- Matches ascending arrow positioning for symmetry
- Shaft stops 3px before tip for clean arrow head visibility