### PR TITLE
feat: Hide letter labels on pipes in isometric view

### DIFF
--- a/scene3d/scene-isometric.js
+++ b/scene3d/scene-isometric.js
@@ -211,7 +211,7 @@ export function renderIsometric(ctx, canvasWidth, canvasHeight, zoom = 1, offset
     drawIsometricComponents(ctx);
 
     // Parça etiketlerini çiz
-    drawPipeLabels(ctx, pipeHierarchy);
+    // drawPipeLabels(ctx, pipeHierarchy); // İzometrik görünümde harf etiketleri gizlendi
 
     ctx.restore();
 


### PR DESCRIPTION
İzometrik görünümde borulara verilen harf etiketleri (A, B, C, vb.) artık gösterilmiyor. Değişiklik: drawPipeLabels() fonksiyon çağrısı yorum satırı yapıldı.