### PR TITLE
feat: Add 3D perspective view mode with toggle button

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -286,11 +286,29 @@ export function draw2D() {
     // Apply combined transform matrix for DPR, zoom, and pan
     // This is equivalent to: scale(dpr) -> translate(panOffset) -> scale(zoom)
     // But done correctly so mouse coordinates work properly
-    ctx2d.setTransform(
-        dpr * zoom, 0,
-        0, dpr * zoom,
-        dpr * panOffset.x, dpr * panOffset.y
-    );
+
+    if (state.is3DPerspectiveActive) {
+        // 3D Perspektif mod: 30° eğim ve 30° soldan bakış
+        // Dimetrik projeksiyon kullan
+        const cos30 = Math.cos(30 * Math.PI / 180); // ≈ 0.866
+        const sin30 = Math.sin(30 * Math.PI / 180); // = 0.5
+
+        ctx2d.setTransform(
+            dpr * zoom * cos30,      // X ekseni yatay bileşeni (cos 30°)
+            dpr * zoom * sin30,      // X ekseni dikey bileşeni (sin 30°)
+            dpr * zoom * -sin30,     // Y ekseni yatay bileşeni (-sin 30°)
+            dpr * zoom * cos30,      // Y ekseni dikey bileşeni (cos 30°)
+            dpr * (c2d.width / (2 * dpr) + panOffset.x),  // X offset (merkezi ayarla)
+            dpr * (c2d.height / (2 * dpr) + panOffset.y)  // Y offset (merkezi ayarla)
+        );
+    } else {
+        // Normal 2D görünüm
+        ctx2d.setTransform(
+            dpr * zoom, 0,
+            0, dpr * zoom,
+            dpr * panOffset.x, dpr * panOffset.y
+        );
+    }
 
     ctx2d.lineWidth = 1 / zoom;
 

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -459,6 +459,10 @@ export let state = {
     isoDraggedPipe: null,
     isoDraggedEndpoint: null, // 'start' veya 'end'
     // --- İZOMETRİK GÖRÜNÜM SONU ---
+
+    // --- 3D PERSPEKTİF GÖRÜNÜM ---
+    is3DPerspectiveActive: false, // 3D perspektif modu aktif mi?
+    // --- 3D PERSPEKTİF GÖRÜNÜM SONU ---
 };
 
 export function setState(newState) {
@@ -575,6 +579,7 @@ export const dom = {
     cancelStairPopupButton: document.getElementById("cancel-stair-popup"),
     b3d: document.getElementById("b3d"), // 3D Göster butonu
     bIso: document.getElementById("bIso"), // İzometri Göster butonu
+    b3DPerspective: document.getElementById("b3DPerspective"), // 3D Perspektif Görünüm butonu
 };
 
 // Proje modu butonlarını kurar (MİMARİ, TESİSAT, KARMA)

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -1265,6 +1265,50 @@ body.light-mode .btn.active svg {
     display: none;
 }
 
+/* 3D Perspektif Görünüm Butonu */
+.btn-show-3d-perspective {
+    position: absolute;
+    top: 10px;
+    right: 265px; /* İzometri butonunun soluna yerleştir */
+    z-index: 100;
+    padding: 7px 10px;
+    font-size: 14px;
+    font-weight: 500;
+    min-width: auto;
+    white-space: nowrap;
+    background: #3c4043;
+    border: 1px solid #5f6368;
+    color: #e8eaed;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.btn-show-3d-perspective svg {
+    width: 18px;
+    height: 18px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 2;
+}
+
+.btn-show-3d-perspective:hover {
+    background: #5f6368;
+    border-color: #87CEEB;
+    box-shadow: 0 2px 8px rgba(135, 206, 235, 0.3);
+}
+
+.btn-show-3d-perspective.active {
+    background: #87CEEB;
+    color: #202124;
+    border-color: #87CEEB;
+    font-weight: 600;
+}
+
 /* 3D Opacity Kontrolleri */
 #opacity-controls-container {
     position: absolute;
@@ -1602,6 +1646,17 @@ body.light-mode #bToggle3D.active {
 body.light-mode .btn-show-3d {
     color: #3c4043;
     background: #e8eaed;
+}
+
+body.light-mode .btn-show-3d-perspective {
+    color: #3c4043;
+    background: #e8eaed;
+}
+
+body.light-mode .btn-show-3d-perspective.active {
+    background: #87CEEB;
+    color: #ffffff;
+    border-color: #87CEEB;
 }
 
 /* ═══════════════════════════════════════════════════════════════ */

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -283,6 +283,35 @@ export function toggleIsoView() {
     }, 10);
 }
 
+export function toggle3DPerspective() {
+    setState({ is3DPerspectiveActive: !state.is3DPerspectiveActive });
+
+    // Buton görünümünü güncelle
+    if (state.is3DPerspectiveActive) {
+        dom.b3DPerspective.classList.add('active');
+        dom.b3DPerspective.innerHTML = `
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+              stroke-linejoin="round">
+              <path d="M3 3l6 6M21 3l-6 6M3 21l6-6M21 21l-6-6"></path>
+              <rect x="9" y="9" width="6" height="6" fill="none"></rect>
+              <path d="M9 9L3 3M15 9L21 3M9 15L3 21M15 15L21 21"></path>
+            </svg>
+            2D Görünüm
+        `;
+    } else {
+        dom.b3DPerspective.classList.remove('active');
+        dom.b3DPerspective.innerHTML = `
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+              stroke-linejoin="round">
+              <path d="M3 3l6 6M21 3l-6 6M3 21l6-6M21 21l-6-6"></path>
+              <rect x="9" y="9" width="6" height="6" fill="none"></rect>
+              <path d="M9 9L3 3M15 9L21 3M9 15L3 21M15 15L21 21"></path>
+            </svg>
+            3D Görünüm
+        `;
+    }
+}
+
 // İzometri ekran bölme oranını ayarla
 export function setIsoRatio(ratio) {
     const p2dPanel = document.getElementById('p2d');
@@ -1506,6 +1535,13 @@ export function setupUIListeners() {
     dom.bIso.addEventListener('click', () => {
         toggleIsoView();
     });
+
+    // 3D PERSPEKTİF GÖRÜNÜM BUTONU LISTENER'I
+    if (dom.b3DPerspective) {
+        dom.b3DPerspective.addEventListener('click', () => {
+            toggle3DPerspective();
+        });
+    }
 
     // KATI GÖSTER / BİNAYI GÖSTER TOGGLE BUTONU
     if (dom.bFloorView) {

--- a/index.html
+++ b/index.html
@@ -604,6 +604,16 @@
         </svg>
         İzometri
       </button>
+      <button id="b3DPerspective" class="btn btn-show-3d-perspective">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <!-- 3D Perspektif ikonu -->
+          <path d="M3 3l6 6M21 3l-6 6M3 21l6-6M21 21l-6-6"></path>
+          <rect x="9" y="9" width="6" height="6" fill="none"></rect>
+          <path d="M9 9L3 3M15 9L21 3M9 15L3 21M15 15L21 21"></path>
+        </svg>
+        3D Görünüm
+      </button>
     </div>
     <div id="splitter"></div>
     <div id="p3d" class="panel">


### PR DESCRIPTION
- Add 3D perspective view toggle button in UI
- Implement dimetric projection with 30° tilt and 30° rotation
- Add state management for 3D perspective mode (is3DPerspectiveActive)
- Apply transformation matrix to 2D canvas when 3D mode is active
- Add CSS styling for button in both light and dark modes
- Button toggles between "3D Görünüm" and "2D Görünüm"

This allows users to view and edit the 2D drawing with a 3D-like perspective, making it easier to work with vertical elements like pipes.