### PR TITLE
feat: Switch 3D view to isometric camera mode instead of 2D transform…

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -286,36 +286,11 @@ export function draw2D() {
     // Apply combined transform matrix for DPR, zoom, and pan
     // This is equivalent to: scale(dpr) -> translate(panOffset) -> scale(zoom)
     // But done correctly so mouse coordinates work properly
-
-    if (state.is3DPerspectiveActive) {
-        // İzometrik projeksiyon: scene-isometric.js ile aynı formül
-        // isoX = (x + y) * cos(30°)
-        // isoY = (y - x) * sin(30°) - z
-        //
-        // Matrix formunda (z=0 için):
-        // x' = x * cos(30°) + y * cos(30°)
-        // y' = -x * sin(30°) + y * sin(30°)
-
-        const angle = Math.PI / 6; // 30 derece
-        const cosAngle = Math.cos(angle); // ≈ 0.866
-        const sinAngle = Math.sin(angle); // = 0.5
-
-        ctx2d.setTransform(
-            dpr * zoom * cosAngle,      // a: X için X bileşeni
-            dpr * zoom * -sinAngle,     // b: X için Y bileşeni
-            dpr * zoom * cosAngle,      // c: Y için X bileşeni
-            dpr * zoom * sinAngle,      // d: Y için Y bileşeni
-            dpr * panOffset.x,          // e: X offset (normal gibi)
-            dpr * panOffset.y           // f: Y offset (normal gibi)
-        );
-    } else {
-        // Normal 2D görünüm
-        ctx2d.setTransform(
-            dpr * zoom, 0,
-            0, dpr * zoom,
-            dpr * panOffset.x, dpr * panOffset.y
-        );
-    }
+    ctx2d.setTransform(
+        dpr * zoom, 0,
+        0, dpr * zoom,
+        dpr * panOffset.x, dpr * panOffset.y
+    );
 
     ctx2d.lineWidth = 1 / zoom;
 

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -8,7 +8,7 @@ import { isSpaceForWindow } from '../architectural-objects/window-handler.js';
 import { recalculateStepCount, updateConnectedStairElevations } from '../architectural-objects/stairs.js';
 import { worldToScreen } from '../draw/geometry.js';
 import { applyStretchModification } from '../draw/geometry.js';
-import { toggleCameraMode } from '../scene3d/scene3d-camera.js';
+import { toggleCameraMode, setIsometricCamera, resetToOrbitCamera } from '../scene3d/scene3d-camera.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
 import { updateSceneBackground } from '../scene3d/scene3d-core.js';
 import { processWalls } from '../wall/wall-processor.js';
@@ -286,8 +286,18 @@ export function toggleIsoView() {
 export function toggle3DPerspective() {
     setState({ is3DPerspectiveActive: !state.is3DPerspectiveActive });
 
-    // Buton görünümünü güncelle
+    // Buton görünümünü güncelle ve 3D sahneyi aç/kapat
     if (state.is3DPerspectiveActive) {
+        // 3D görünümü aç
+        if (!dom.mainContainer.classList.contains('show-3d')) {
+            toggle3DView(); // 3D sahneyi aç
+        }
+
+        // Kamerayı izometrik açıya ayarla
+        setTimeout(() => {
+            setIsometricCamera();
+        }, 100);
+
         dom.b3DPerspective.classList.add('active');
         dom.b3DPerspective.innerHTML = `
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -296,9 +306,12 @@ export function toggle3DPerspective() {
               <rect x="9" y="9" width="6" height="6" fill="none"></rect>
               <path d="M9 9L3 3M15 9L21 3M9 15L3 21M15 15L21 21"></path>
             </svg>
-            2D Görünüm
+            Normal Görünüm
         `;
     } else {
+        // Normal kamera pozisyonuna dön
+        resetToOrbitCamera();
+
         dom.b3DPerspective.classList.remove('active');
         dom.b3DPerspective.innerHTML = `
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -307,7 +320,7 @@ export function toggle3DPerspective() {
               <rect x="9" y="9" width="6" height="6" fill="none"></rect>
               <path d="M9 9L3 3M15 9L21 3M9 15L3 21M15 15L21 21"></path>
             </svg>
-            3D Görünüm
+            İzometrik Görünüm
         `;
     }
 }

--- a/scene3d/scene3d-camera.js
+++ b/scene3d/scene3d-camera.js
@@ -458,3 +458,52 @@ export function setupFirstPersonMouseControls() {
         }
     }, false);
 }
+
+/**
+ * Kamerayı izometrik görünüm açısına ayarlar
+ * İzometrik projeksiyon: 45° yatay dönüş, 30° yukarıdan bakış
+ */
+export function setIsometricCamera() {
+    if (!camera || !orbitControls) return;
+
+    // Sahne merkezini hesapla
+    const center = new THREE.Vector3();
+    if (sceneObjects && sceneObjects.children.length > 0) {
+        const boundingBox = new THREE.Box3();
+        sceneObjects.children.forEach(obj => {
+            if (obj.material !== floorMaterial) {
+                boundingBox.expandByObject(obj);
+            }
+        });
+        if (!boundingBox.isEmpty()) {
+            boundingBox.getCenter(center);
+        }
+    }
+
+    // İzometrik açılar: 45° yatay (azimuth), 30° yukarıdan (elevation)
+    const azimuthAngle = Math.PI / 4; // 45 derece
+    const elevationAngle = Math.PI / 6; // 30 derece
+
+    // Kamera mesafesi (sahne boyutuna göre)
+    const distance = 2000;
+
+    // Kamera pozisyonunu hesapla
+    const x = center.x + distance * Math.cos(elevationAngle) * Math.sin(azimuthAngle);
+    const y = center.y + distance * Math.sin(elevationAngle);
+    const z = center.z + distance * Math.cos(elevationAngle) * Math.cos(azimuthAngle);
+
+    camera.position.set(x, y, z);
+    orbitControls.target.copy(center);
+    orbitControls.update();
+}
+
+/**
+ * Kamerayı varsayılan orbit pozisyonuna geri döndürür
+ */
+export function resetToOrbitCamera() {
+    if (!camera || !orbitControls) return;
+
+    camera.position.set(1500, 1800, 1500);
+    orbitControls.target.set(0, WALL_HEIGHT / 2, 0);
+    orbitControls.update();
+}


### PR DESCRIPTION
…ation

- Revert 2D canvas to normal top-down view (no transformation)
- Add setIsometricCamera() function to set 3D camera to isometric angle
- Add resetToOrbitCamera() function to restore normal camera position
- Update toggle3DPerspective() to open 3D view and switch camera modes
- Isometric camera uses 45° azimuth and 30° elevation angle
- Users can now view and interact with vertical pipes in 3D isometric view

This allows users to see vertical plumbing elements from an isometric perspective in the actual 3D scene, while keeping 2D view unchanged.