### PR TITLE
fix: Remove Z-coordinate rendering, keep only isometric viewing angle

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -7,7 +7,6 @@ import {
     drawBeam, drawStairs, drawGuides
 } from './renderer2d.js';
 import { plumbingManager } from '../plumbing_v2/plumbing-manager.js';
-import { drawIsometricPipes } from '../scene3d/scene-isometric.js';
 import {
     drawObjectPlacementPreviews, drawDragPreviews, drawSelectionFeedback,
     drawDrawingPreviews, drawSnapFeedback
@@ -578,29 +577,8 @@ export function draw2D() {
     drawCameraViewIndicator(ctx2d, zoom);
 
     // 13. TESİSAT SİSTEMİ (v2) - En üstte render edilir
-    if (state.is3DPerspectiveActive) {
-        // İzometrik görünümde: Z koordinatlarıyla boru çizimi
-        // Mevcut izometrik transformation'ı kaydet
-        ctx2d.save();
-
-        // Transformation'ı sıfırla ve sadece base transform uygula
-        ctx2d.setTransform(dpr, 0, 0, dpr, 0, 0);
-
-        // Merkez ve zoom uygula (izometrik canvas gibi)
-        const centerX = c2d.width / (2 * dpr);
-        const centerY = c2d.height / (2 * dpr);
-        ctx2d.translate(centerX + panOffset.x, centerY + panOffset.y);
-        ctx2d.scale(zoom, zoom);
-
-        // İzometrik boruları çiz (Z koordinatlarıyla)
-        drawIsometricPipes(ctx2d);
-
-        // Transformation'ı geri yükle
-        ctx2d.restore();
-    } else {
-        // Normal 2D görünümde: Standart plumbing renderer
-        plumbingManager.render(ctx2d);
-    }
+    // İzometrik perspektif aktifse de normal render eder (transformation matrix otomatik uygulanır)
+    plumbingManager.render(ctx2d);
 
     // 14. Referans Çizgileri (Rehberler)
     drawGuides(ctx2d, state);

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -8,7 +8,7 @@ import { isSpaceForWindow } from '../architectural-objects/window-handler.js';
 import { recalculateStepCount, updateConnectedStairElevations } from '../architectural-objects/stairs.js';
 import { worldToScreen } from '../draw/geometry.js';
 import { applyStretchModification } from '../draw/geometry.js';
-import { toggleCameraMode, setIsometricCamera, resetToOrbitCamera } from '../scene3d/scene3d-camera.js';
+import { toggleCameraMode } from '../scene3d/scene3d-camera.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
 import { updateSceneBackground } from '../scene3d/scene3d-core.js';
 import { processWalls } from '../wall/wall-processor.js';

--- a/scene3d/scene-isometric.js
+++ b/scene3d/scene-isometric.js
@@ -276,7 +276,7 @@ renderIsometric = ((oldRender) => {
  * Boruları izometrik perspektifte çizer
  * @param {CanvasRenderingContext2D} ctx - Canvas context
  */
-export function drawIsometricPipes(ctx) {
+function drawIsometricPipes(ctx) {
     if (!plumbingManager || !plumbingManager.pipes) return;
     if (!state) return;
 


### PR DESCRIPTION
- Remove drawIsometricPipes import and special Z-coordinate rendering
- Use normal plumbingManager.render() with isometric transformation
- Isometric view now only changes VIEWING ANGLE, not drawing method
- All elements (walls, rooms, pipes) render normally but appear rotated
- This is a proper 2D drawing area with isometric perspective view
- Users can draw normally and toggle viewing angle for better visibility

The 3D view mode now only applies an isometric transformation matrix to the 2D canvas, allowing normal drawing operations while viewing from a tilted angle similar to isometric projection.