### PR TITLE
fix: Add mouse coordinate transformation and vertical pipe rendering

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -7,6 +7,7 @@ import {
     drawBeam, drawStairs, drawGuides
 } from './renderer2d.js';
 import { plumbingManager } from '../plumbing_v2/plumbing-manager.js';
+import { drawIsometricPipes } from '../scene3d/scene-isometric.js';
 import {
     drawObjectPlacementPreviews, drawDragPreviews, drawSelectionFeedback,
     drawDrawingPreviews, drawSnapFeedback
@@ -577,8 +578,29 @@ export function draw2D() {
     drawCameraViewIndicator(ctx2d, zoom);
 
     // 13. TESİSAT SİSTEMİ (v2) - En üstte render edilir
-    // İzometrik perspektif aktifse de normal render eder (transformation matrix otomatik uygulanır)
-    plumbingManager.render(ctx2d);
+    if (state.is3DPerspectiveActive) {
+        // İzometrik görünümde: Z koordinatlarıyla boru çizimi
+        // Transformation matrix'i bypass et
+        ctx2d.save();
+
+        // Identity transform (transformation'ı sıfırla)
+        ctx2d.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+        // Merkezi hesapla ve viewport ayarla
+        const centerX = c2d.width / (2 * dpr);
+        const centerY = c2d.height / (2 * dpr);
+        ctx2d.translate(centerX, centerY);
+        ctx2d.scale(zoom, zoom);
+        ctx2d.translate(panOffset.x / zoom, panOffset.y / zoom);
+
+        // İzometrik boruları çiz (Z koordinatlarıyla)
+        drawIsometricPipes(ctx2d);
+
+        ctx2d.restore();
+    } else {
+        // Normal 2D görünümde: Standart plumbing renderer
+        plumbingManager.render(ctx2d);
+    }
 
     // 14. Referans Çizgileri (Rehberler)
     drawGuides(ctx2d, state);

--- a/draw/geometry.js
+++ b/draw/geometry.js
@@ -58,11 +58,39 @@ export function distToArcWallSquared(point, wall, tolerance = 1.0) {
 }
 
 export function screenToWorld(sx, sy) {
-    const { zoom, panOffset } = state;
-    return {
-        x: (sx - panOffset.x) / zoom,
-        y: (sy - panOffset.y) / zoom
-    };
+    const { zoom, panOffset, is3DPerspectiveActive } = state;
+
+    if (is3DPerspectiveActive) {
+        // İzometrik görünümde inverse transformation uygula
+        const angle = Math.PI / 6; // 30 derece
+        const cosAngle = Math.cos(angle); // ≈ 0.866
+        const sinAngle = Math.sin(angle); // = 0.5
+
+        // Önce pan ve zoom'u geri al
+        const screenX = (sx - panOffset.x) / zoom;
+        const screenY = (sy - panOffset.y) / zoom;
+
+        // İzometrik inverse transformation matrix
+        // det = 2 * cosAngle * sinAngle
+        const det = 2 * cosAngle * sinAngle;
+
+        // Inverse matrix elementleri
+        const a_inv = sinAngle / det;    // = 1/(2*cosAngle)
+        const b_inv = sinAngle / det;    // = 1/(2*cosAngle)
+        const c_inv = -cosAngle / det;   // = -1/(2*sinAngle)
+        const d_inv = cosAngle / det;    // = 1/(2*sinAngle)
+
+        return {
+            x: screenX * a_inv + screenY * c_inv,
+            y: screenX * b_inv + screenY * d_inv
+        };
+    } else {
+        // Normal 2D görünüm
+        return {
+            x: (sx - panOffset.x) / zoom,
+            y: (sy - panOffset.y) / zoom
+        };
+    }
 }
 
 export function worldToScreen(wx, wy) {

--- a/scene3d/scene-isometric.js
+++ b/scene3d/scene-isometric.js
@@ -273,10 +273,10 @@ renderIsometric = ((oldRender) => {
 })(renderIsometric);
 
 /**
- * Boruları izometrik perspektifte çizer
+ * Boruları izometrik perspektifte çizer (Z koordinatlarıyla)
  * @param {CanvasRenderingContext2D} ctx - Canvas context
  */
-function drawIsometricPipes(ctx) {
+export function drawIsometricPipes(ctx) {
     if (!plumbingManager || !plumbingManager.pipes) return;
     if (!state) return;
 


### PR DESCRIPTION
- Fix screenToWorld() to apply inverse isometric transformation
- Mouse clicks now work correctly in isometric view mode
- Export drawIsometricPipes() to render pipes with Z coordinates
- In isometric mode, pipes render with proper Z elevation
- Vertical pipes (same x,y, different z) now visible in 3D view
- Architectural elements use transformation matrix (angle view)
- Plumbing elements render with toIsometric() (includes Z coords)

Users can now click and interact with elements in isometric view, and vertical plumbing pipes are properly visible with elevation.