### PR TITLE
refactor: Rename '3D Göster' button to 'Katı Model'

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -577,7 +577,7 @@ export const dom = {
     stairShowRailingCheckbox: document.getElementById("stair-show-railing"), // <-- YENİ SATIR BURAYA EKLENECEK
     confirmStairPopupButton: document.getElementById("confirm-stair-popup"),
     cancelStairPopupButton: document.getElementById("cancel-stair-popup"),
-    b3d: document.getElementById("b3d"), // 3D Göster butonu
+    b3d: document.getElementById("b3d"), // Katı Model butonu
     bIso: document.getElementById("bIso"), // İzometri Göster butonu
     b3DPerspective: document.getElementById("b3DPerspective"), // 3D Perspektif Görünüm butonu
 };

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -1165,7 +1165,7 @@ body.light-mode .btn.active svg {
     backdrop-filter: blur(4px);
 }
 
-/* 3D Göster Butonu - 2D Ekranın Sağ Üst Köşesi */
+/* Katı Model Butonu - 2D Ekranın Sağ Üst Köşesi */
 .btn-show-3d {
     position: absolute;
     top: 10px;
@@ -1216,7 +1216,7 @@ body.light-mode .btn.active svg {
     display: none;
 }
 
-/* İzometri Göster Butonu - 3D Göster butonunun yanında */
+/* İzometri Göster Butonu - Katı Model butonunun yanında */
 .btn-show-iso {
     position: absolute;
     top: 10px;
@@ -1613,7 +1613,7 @@ body.light-mode #floor-mini-list > div {
 }
 
 /* ═══════════════════════════════════════════════════════════════ */
-/* ÜST KONTROLLER - LIGHT MODE (Mimari/Tesisat/Karma, 3D Göster)*/
+/* ÜST KONTROLLER - LIGHT MODE (Mimari/Tesisat/Karma, Katı Model)*/
 /* ═══════════════════════════════════════════════════════════════ */
 
 /* Mimari/Tesisat/Karma butonları */
@@ -1629,7 +1629,7 @@ body.light-mode #drawing-mode-selector button.active {
     color: var(--color-button-active) !important;
 }
 
-/* 3D Göster butonu */
+/* Katı Model butonu */
 body.light-mode #bToggle3D {
     background: var(--bg-button) !important;
     border-color: var(--border-button) !important;

--- a/index.html
+++ b/index.html
@@ -591,7 +591,7 @@
           <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
           <line x1="12" y1="22.08" x2="12" y2="12"></line>
         </svg>
-        3D Göster
+        Katı Model
       </button>
       <button id="bIso" class="btn btn-show-iso">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"


### PR DESCRIPTION
Changed the label of the 3D view button from '3D Göster' to 'Katı Model' (Solid Model) to avoid confusion with the '3D Görünüm' (3D View) button.

- Updated button text in index.html
- Updated comments in main.js
- Updated comments in style.css