### PR TITLE
feat: Implement real 3D view toggle in 2D panel

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -12,7 +12,7 @@ import { fitDrawingToScreen } from '../draw/zoom.js';
 // --- DEĞİŞİKLİK BURADA ---
 import { updateFirstPersonCamera, setupFirstPersonMouseControls, isFPSMode } from '../scene3d/scene3d-camera.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
-import { init3D, renderer as renderer3d, camera as camera3d, controls as controls3d, scene as scene3d } from '../scene3d/scene3d-core.js';
+import { init3D, renderer as renderer3d, camera as camera3d, controls as controls3d, scene as scene3d, renderer2d3d, controls2d3d, resize2D3DView } from '../scene3d/scene3d-core.js';
 // --- DEĞİŞİKLİK SONU ---
 import { createWallPanel } from '../wall/wall-panel.js';
 import { createFloorPanel, showFloorPanel, renderMiniPanel } from '../floor/floor-panel.js';
@@ -493,6 +493,7 @@ export const dom = {
     p2d: document.getElementById("p2d"),
     c2d: document.getElementById("c2d"),
     ctx2d: document.getElementById("c2d").getContext("2d"),
+    c2d3d: document.getElementById("c2d3d"), // 3D perspektif görünüm canvas'ı
     p3d: document.getElementById("p3d"),
     c3d: document.getElementById("c3d"),
     pIso: document.getElementById("pIso"),
@@ -919,6 +920,11 @@ export function resize() {
             dom.ctxIso.msImageSmoothingEnabled = false;
         }
     }
+
+    // 2D paneldeki 3D görünümü resize et
+    if (state.is3DPerspectiveActive && resize2D3DView) {
+        resize2D3DView();
+    }
 }
 
 let lastTime = performance.now();
@@ -995,6 +1001,16 @@ function animate() {
     // İzometrik görünümü çiz
     if (dom.mainContainer.classList.contains('show-iso')) {
         drawIsoView();
+    }
+
+    // 2D paneldeki 3D görünümü render et
+    if (state.is3DPerspectiveActive && renderer2d3d && scene3d && camera3d) {
+        // Kontrolleri güncelle
+        if (controls2d3d && controls2d3d.update) {
+            controls2d3d.update();
+        }
+
+        renderer2d3d.render(scene3d, camera3d);
     }
 }
 // --- GÜNCELLEME SONU ---

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -10,7 +10,7 @@ import { worldToScreen } from '../draw/geometry.js';
 import { applyStretchModification } from '../draw/geometry.js';
 import { toggleCameraMode } from '../scene3d/scene3d-camera.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
-import { updateSceneBackground } from '../scene3d/scene3d-core.js';
+import { updateSceneBackground, init2D3DView, resize2D3DView, renderer2d3d } from '../scene3d/scene3d-core.js';
 import { processWalls } from '../wall/wall-processor.js';
 import { findAvailableSegmentAt } from '../wall/wall-item-utils.js';
 import { renderIsometric } from '../scene3d/scene-isometric.js';
@@ -288,6 +288,7 @@ export function toggle3DPerspective() {
 
     // Buton görünümünü güncelle
     if (state.is3DPerspectiveActive) {
+        // 3D görünüme geç
         dom.b3DPerspective.classList.add('active');
         dom.b3DPerspective.innerHTML = `
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -298,7 +299,23 @@ export function toggle3DPerspective() {
             </svg>
             2D Görünüm
         `;
+
+        // 2D canvas'ı gizle, 3D canvas'ı göster
+        dom.c2d.style.display = 'none';
+        dom.c2d3d.style.display = 'block';
+
+        // İlk kez aktif ediliyorsa renderer'ı başlat
+        if (!renderer2d3d) {
+            init2D3DView();
+        }
+
+        // Resize et
+        resize2D3DView();
+
+        // 3D sahneyi güncelle
+        update3DScene();
     } else {
+        // 2D görünüme dön
         dom.b3DPerspective.classList.remove('active');
         dom.b3DPerspective.innerHTML = `
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -309,6 +326,13 @@ export function toggle3DPerspective() {
             </svg>
             3D Görünüm
         `;
+
+        // 3D canvas'ı gizle, 2D canvas'ı göster
+        dom.c2d3d.style.display = 'none';
+        dom.c2d.style.display = 'block';
+
+        // 2D'yi yeniden çiz
+        resize();
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -543,6 +543,7 @@
         </div>
       </div>
       <canvas id="c2d"></canvas>
+      <canvas id="c2d3d" style="display: none;"></canvas>
 
       <!-- Düşey Yükseklik Paneli -->
       <div id="vertical-height-panel" class="vertical-panel" style="display: none;">

--- a/scene3d/scene3d-core.js
+++ b/scene3d/scene3d-core.js
@@ -12,6 +12,8 @@ export let orbitControls, pointerLockControls;
 export let cameraMode = 'orbit'; // 'orbit' veya 'firstPerson'
 export let sceneObjects;
 export let textureLoader; // <-- Resim çerçeveleri için eklendi
+export let renderer2d3d; // 2D paneldeki 3D görünüm için ayrı renderer
+export let controls2d3d; // 2D paneldeki 3D görünüm için ayrı kontroller
 
 // --- Malzemeler (Materials) ---
 export let wallMaterial, doorMaterial, windowMaterial, columnMaterial, beamMaterial,
@@ -373,4 +375,48 @@ export function fit3DViewToScreen() {
     controls.target.copy(center);
     camera.position.copy(newPosition);
     controls.update();
+}
+
+/**
+ * 2D panel içindeki 3D görünüm renderer'ını başlatır
+ */
+export function init2D3DView() {
+    if (!dom.c2d3d || !scene || !camera) {
+        console.error("init2D3DView: Gerekli elemanlar bulunamadı");
+        return;
+    }
+
+    // Yeni bir renderer oluştur (c2d3d canvas'ı için)
+    renderer2d3d = new THREE.WebGLRenderer({
+        antialias: true,
+        canvas: dom.c2d3d,
+    });
+
+    // OrbitControls'ü bu renderer için de oluştur
+    controls2d3d = new OrbitControls(camera, renderer2d3d.domElement);
+    controls2d3d.target.set(0, WALL_HEIGHT / 2, 0);
+    controls2d3d.minDistance = 1;
+    controls2d3d.zoomSpeed = 1;
+    controls2d3d.update();
+
+    // Mouse tuş atamaları
+    controls2d3d.mouseButtons = {
+        LEFT: THREE.MOUSE.ROTATE,   // Sol Tuş = Döndürme
+        MIDDLE: THREE.MOUSE.PAN,    // Orta Tuş = Pan (Kaydırma)
+        RIGHT: THREE.MOUSE.PAN,     // Sağ Tuş = Pan
+    };
+
+    console.log("2D panel içi 3D görünüm başlatıldı");
+}
+
+/**
+ * 2D panel içindeki 3D görünümü resize eder
+ */
+export function resize2D3DView() {
+    if (!renderer2d3d || !dom.c2d3d || !camera) return;
+
+    const rect = dom.p2d.getBoundingClientRect();
+    renderer2d3d.setSize(rect.width, rect.height);
+    camera.aspect = rect.width / rect.height;
+    camera.updateProjectionMatrix();
 }


### PR DESCRIPTION
Added ability to toggle between 2D top view and 3D perspective view in the same panel using the "3D Görünüm" button.

Changes:
- Added new canvas (c2d3d) in 2D panel for 3D rendering
- Created second THREE.js renderer (renderer2d3d) that shares scene and camera
- Implemented toggle logic to switch between 2D canvas and 3D canvas
- Updated render loop to render both views when active
- Added resize handling for 2D panel 3D view
- 3D view is fully interactive with OrbitControls

Now users can:
- Click "3D Görünüm" button to see 3D perspective in the same location
- View vertical pipes and all elements in 3D
- Interact with the 3D view (rotate, pan, zoom)
- Toggle back to 2D top view with same button