### PR TITLE
feat: Add resizable splitter to isometric panel

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -567,6 +567,7 @@ export const dom = {
     roomNameSelect: document.getElementById("room-name-select"),
     roomNameInput: document.getElementById("room-name-input"),
     splitter: document.getElementById("splitter"),
+    isoSplitter: document.getElementById("isoSplitter"),
     bSymmetry: document.getElementById("bSymmetry"), // YENİ SATIR
     stairPopup: document.getElementById("stair-popup"),
     stairNameInput: document.getElementById("stair-name"),

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -172,6 +172,19 @@ body.light-mode {
     border-radius: 5px;
 }
 
+/* İzometri splitter - splitter ile aynı stil */
+#isoSplitter {
+    flex: 0 0 4px;
+    cursor: col-resize;
+    background-color: var(--border-panel);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='30' viewBox='0 0 4 30'%3E%3Cpath d='M1,10 L1,20 M3,10 L3,20' stroke='%23888' stroke-width='1'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center;
+    display: none;
+    margin: 0 3px;
+    border-radius: 5px;
+}
+
 .main.show-3d #splitter {
     display: block;
 }

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -260,6 +260,9 @@ export function toggleIsoView() {
         const isoButtons = document.getElementById('iso-ratio-buttons');
         if (isoButtons) isoButtons.style.display = 'flex';
 
+        // İzometri splitter'ını göster
+        dom.isoSplitter.style.display = 'block';
+
         // İzometrik canvas boyutunu ayarla
         resizeIsoCanvas();
 
@@ -272,6 +275,9 @@ export function toggleIsoView() {
         // İzometri ratio butonlarını gizle
         const isoButtons = document.getElementById('iso-ratio-buttons');
         if (isoButtons) isoButtons.style.display = 'none';
+
+        // İzometri splitter'ını gizle
+        dom.isoSplitter.style.display = 'none';
     }
 
     setTimeout(() => {
@@ -1029,6 +1035,8 @@ export function setSplitRatio(ratio) {
 
 // Splitter fonksiyonları
 let isResizing = false;
+let isIsoResizing = false;
+
 function onSplitterPointerDown(e) { isResizing = true; dom.p2d.style.pointerEvents = 'none'; dom.p3d.style.pointerEvents = 'none'; document.body.style.cursor = 'col-resize'; window.addEventListener('pointermove', onSplitterPointerMove); window.addEventListener('pointerup', onSplitterPointerUp); }
 function onSplitterPointerMove(e) {
     if (!isResizing) return;
@@ -1058,6 +1066,55 @@ function onSplitterPointerMove(e) {
     resize();
 }
 function onSplitterPointerUp() { isResizing = false; dom.p2d.style.pointerEvents = 'auto'; dom.p3d.style.pointerEvents = 'auto'; document.body.style.cursor = 'default'; window.removeEventListener('pointermove', onSplitterPointerMove); window.removeEventListener('pointerup', onSplitterPointerUp); }
+
+// İzometri Splitter fonksiyonları
+function onIsoSplitterPointerDown(e) {
+    isIsoResizing = true;
+    dom.p2d.style.pointerEvents = 'none';
+    dom.pIso.style.pointerEvents = 'none';
+    document.body.style.cursor = 'col-resize';
+    window.addEventListener('pointermove', onIsoSplitterPointerMove);
+    window.addEventListener('pointerup', onIsoSplitterPointerUp);
+}
+
+function onIsoSplitterPointerMove(e) {
+    if (!isIsoResizing) return;
+
+    const mainRect = dom.mainContainer.getBoundingClientRect();
+    const p2dPanel = document.getElementById('p2d');
+    const pIsoPanel = document.getElementById('pIso');
+
+    let p2dWidth = e.clientX - mainRect.left;
+
+    // Minimum genişlikler
+    const min2DWidth = 150; // 2D paneli en az 150px olmalı
+    const minIsoWidth = 150; // İzometri paneli en az 150px olmalı
+
+    // 2D panel için minimum kontrol
+    if (p2dWidth < min2DWidth) p2dWidth = min2DWidth;
+
+    // İzometri panel için minimum kontrol (2D panel maksimum genişliği)
+    const max2DWidth = mainRect.width - minIsoWidth - dom.isoSplitter.offsetWidth - 20;
+    if (p2dWidth > max2DWidth) p2dWidth = max2DWidth;
+
+    let pIsoWidth = mainRect.width - p2dWidth - dom.isoSplitter.offsetWidth - 20;
+
+    p2dPanel.style.flex = `1 1 ${p2dWidth}px`;
+    pIsoPanel.style.flex = `1 1 ${pIsoWidth}px`;
+
+    resize();
+    resizeIsoCanvas();
+    drawIsoView();
+}
+
+function onIsoSplitterPointerUp() {
+    isIsoResizing = false;
+    dom.p2d.style.pointerEvents = 'auto';
+    dom.pIso.style.pointerEvents = 'auto';
+    document.body.style.cursor = 'default';
+    window.removeEventListener('pointermove', onIsoSplitterPointerMove);
+    window.removeEventListener('pointerup', onIsoSplitterPointerUp);
+}
 
 
 // Duvar boyutlandırma fonksiyonu
@@ -1454,6 +1511,7 @@ export function setupUIListeners() {
     dom.roomNameSelect.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); confirmRoomNameChange(); } });
     dom.roomNameInput.addEventListener('keydown', (e) => { if (e.key === 'ArrowDown') { e.preventDefault(); dom.roomNameSelect.focus(); } else if (e.key === 'Enter') { e.preventDefault(); confirmRoomNameChange(); } });
     dom.splitter.addEventListener('pointerdown', onSplitterPointerDown);
+    dom.isoSplitter.addEventListener('pointerdown', onIsoSplitterPointerDown);
     dom.lengthInput.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); confirmLengthEdit(); } else if (e.key === "Escape") { cancelLengthEdit(); } });
     dom.lengthInput.addEventListener("blur", cancelLengthEdit);
 

--- a/index.html
+++ b/index.html
@@ -719,6 +719,7 @@
       </div>
       <!-- Mod Göstergesi (Her Zaman Görünür) -->
     </div>
+    <div id="isoSplitter" style="display: none;"></div>
     <div id="pIso" class="panel">
       <canvas id="cIso"></canvas>
       <!-- İzometri Overlay: Ekran Bölme Oranı Butonları (Sağ Üst) -->


### PR DESCRIPTION
Added draggable splitter between 2D and isometric panels to allow users to resize the panels by dragging, similar to the 3D panel splitter.

Changes:
- Added #isoSplitter element in HTML before pIso panel
- Added isoSplitter to DOM elements
- Implemented onIsoSplitterPointerDown/Move/Up event handlers
- Added CSS styling for isoSplitter (same as main splitter)
- Show/hide isoSplitter when toggling isometric view
- Minimum panel widths: 150px for both 2D and isometric panels

Now users can:
- Click and drag the left edge of isometric panel to resize
- Dynamically adjust 2D vs isometric panel ratio
- Automatic canvas resize and redraw on drag