### PR TITLE
fix: Revert incorrect 3D renderer approach for isometric view

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -578,29 +578,8 @@ export function draw2D() {
     drawCameraViewIndicator(ctx2d, zoom);
 
     // 13. TESİSAT SİSTEMİ (v2) - En üstte render edilir
-    if (state.is3DPerspectiveActive) {
-        // İzometrik görünümde: Z koordinatlarıyla boru çizimi
-        // Transformation matrix'i bypass et
-        ctx2d.save();
-
-        // Identity transform (transformation'ı sıfırla)
-        ctx2d.setTransform(dpr, 0, 0, dpr, 0, 0);
-
-        // Merkezi hesapla ve viewport ayarla
-        const centerX = c2d.width / (2 * dpr);
-        const centerY = c2d.height / (2 * dpr);
-        ctx2d.translate(centerX, centerY);
-        ctx2d.scale(zoom, zoom);
-        ctx2d.translate(panOffset.x / zoom, panOffset.y / zoom);
-
-        // İzometrik boruları çiz (Z koordinatlarıyla)
-        drawIsometricPipes(ctx2d);
-
-        ctx2d.restore();
-    } else {
-        // Normal 2D görünümde: Standart plumbing renderer
-        plumbingManager.render(ctx2d);
-    }
+    // Transform zaten izometrik, plumbingRenderer state.is3DPerspectiveActive'i kullanır
+    plumbingManager.render(ctx2d);
 
     // 14. Referans Çizgileri (Rehberler)
     drawGuides(ctx2d, state);

--- a/general-files/main.js
+++ b/general-files/main.js
@@ -12,7 +12,7 @@ import { fitDrawingToScreen } from '../draw/zoom.js';
 // --- DEĞİŞİKLİK BURADA ---
 import { updateFirstPersonCamera, setupFirstPersonMouseControls, isFPSMode } from '../scene3d/scene3d-camera.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
-import { init3D, renderer as renderer3d, camera as camera3d, controls as controls3d, scene as scene3d, renderer2d3d, controls2d3d, resize2D3DView } from '../scene3d/scene3d-core.js';
+import { init3D, renderer as renderer3d, camera as camera3d, controls as controls3d, scene as scene3d } from '../scene3d/scene3d-core.js';
 // --- DEĞİŞİKLİK SONU ---
 import { createWallPanel } from '../wall/wall-panel.js';
 import { createFloorPanel, showFloorPanel, renderMiniPanel } from '../floor/floor-panel.js';
@@ -493,7 +493,6 @@ export const dom = {
     p2d: document.getElementById("p2d"),
     c2d: document.getElementById("c2d"),
     ctx2d: document.getElementById("c2d").getContext("2d"),
-    c2d3d: document.getElementById("c2d3d"), // 3D perspektif görünüm canvas'ı
     p3d: document.getElementById("p3d"),
     c3d: document.getElementById("c3d"),
     pIso: document.getElementById("pIso"),
@@ -922,10 +921,6 @@ export function resize() {
         }
     }
 
-    // 2D paneldeki 3D görünümü resize et
-    if (state.is3DPerspectiveActive && resize2D3DView) {
-        resize2D3DView();
-    }
 }
 
 let lastTime = performance.now();
@@ -1002,16 +997,6 @@ function animate() {
     // İzometrik görünümü çiz
     if (dom.mainContainer.classList.contains('show-iso')) {
         drawIsoView();
-    }
-
-    // 2D paneldeki 3D görünümü render et
-    if (state.is3DPerspectiveActive && renderer2d3d && scene3d && camera3d) {
-        // Kontrolleri güncelle
-        if (controls2d3d && controls2d3d.update) {
-            controls2d3d.update();
-        }
-
-        renderer2d3d.render(scene3d, camera3d);
     }
 }
 // --- GÜNCELLEME SONU ---

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -10,7 +10,7 @@ import { worldToScreen } from '../draw/geometry.js';
 import { applyStretchModification } from '../draw/geometry.js';
 import { toggleCameraMode } from '../scene3d/scene3d-camera.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
-import { updateSceneBackground, init2D3DView, resize2D3DView, renderer2d3d } from '../scene3d/scene3d-core.js';
+import { updateSceneBackground } from '../scene3d/scene3d-core.js';
 import { processWalls } from '../wall/wall-processor.js';
 import { findAvailableSegmentAt } from '../wall/wall-item-utils.js';
 import { renderIsometric } from '../scene3d/scene-isometric.js';
@@ -294,7 +294,6 @@ export function toggle3DPerspective() {
 
     // Buton görünümünü güncelle
     if (state.is3DPerspectiveActive) {
-        // 3D görünüme geç
         dom.b3DPerspective.classList.add('active');
         dom.b3DPerspective.innerHTML = `
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -305,23 +304,7 @@ export function toggle3DPerspective() {
             </svg>
             2D Görünüm
         `;
-
-        // 2D canvas'ı gizle, 3D canvas'ı göster
-        dom.c2d.style.display = 'none';
-        dom.c2d3d.style.display = 'block';
-
-        // İlk kez aktif ediliyorsa renderer'ı başlat
-        if (!renderer2d3d) {
-            init2D3DView();
-        }
-
-        // Resize et
-        resize2D3DView();
-
-        // 3D sahneyi güncelle
-        update3DScene();
     } else {
-        // 2D görünüme dön
         dom.b3DPerspective.classList.remove('active');
         dom.b3DPerspective.innerHTML = `
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
@@ -332,13 +315,6 @@ export function toggle3DPerspective() {
             </svg>
             3D Görünüm
         `;
-
-        // 3D canvas'ı gizle, 2D canvas'ı göster
-        dom.c2d3d.style.display = 'none';
-        dom.c2d.style.display = 'block';
-
-        // 2D'yi yeniden çiz
-        resize();
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -543,7 +543,6 @@
         </div>
       </div>
       <canvas id="c2d"></canvas>
-      <canvas id="c2d3d" style="display: none;"></canvas>
 
       <!-- Düşey Yükseklik Paneli -->
       <div id="vertical-height-panel" class="vertical-panel" style="display: none;">

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -439,9 +439,18 @@ export class PlumbingRenderer {
             // Çizim moduna göre renk ayarla
             const adjustedColor = getAdjustedColor(config.color, 'boru');
 
-            // Boru geometrisi
-            const dx = pipe.p2.x - pipe.p1.x;
-            const dy = pipe.p2.y - pipe.p1.y;
+            // Z koordinatlarını al (3D görünüm için)
+            const z1 = (state.is3DPerspectiveActive && pipe.p1.z) ? pipe.p1.z : 0;
+            const z2 = (state.is3DPerspectiveActive && pipe.p2.z) ? pipe.p2.z : 0;
+
+            // Boru geometrisi (Z koordinatlarını Y'den çıkararak izometrik çizim)
+            const x1 = pipe.p1.x;
+            const y1 = pipe.p1.y - z1;
+            const x2 = pipe.p2.x;
+            const y2 = pipe.p2.y - z2;
+
+            const dx = x2 - x1;
+            const dy = y2 - y1;
             const length = Math.hypot(dx, dy);
             const angle = Math.atan2(dy, dx);
 
@@ -460,8 +469,8 @@ export class PlumbingRenderer {
                 ctx.setLineDash([]);
             }
 
-            // Koordinat sistemini borunun başlangıcına taşı ve döndür
-            ctx.translate(pipe.p1.x, pipe.p1.y);
+            // Koordinat sistemini borunun başlangıcına taşı ve döndür (Z dahil)
+            ctx.translate(x1, y1);
             ctx.rotate(angle);
 
             if (pipe.isSelected) {

--- a/scene3d/scene3d-core.js
+++ b/scene3d/scene3d-core.js
@@ -12,8 +12,6 @@ export let orbitControls, pointerLockControls;
 export let cameraMode = 'orbit'; // 'orbit' veya 'firstPerson'
 export let sceneObjects;
 export let textureLoader; // <-- Resim çerçeveleri için eklendi
-export let renderer2d3d; // 2D paneldeki 3D görünüm için ayrı renderer
-export let controls2d3d; // 2D paneldeki 3D görünüm için ayrı kontroller
 
 // --- Malzemeler (Materials) ---
 export let wallMaterial, doorMaterial, windowMaterial, columnMaterial, beamMaterial,
@@ -375,48 +373,4 @@ export function fit3DViewToScreen() {
     controls.target.copy(center);
     camera.position.copy(newPosition);
     controls.update();
-}
-
-/**
- * 2D panel içindeki 3D görünüm renderer'ını başlatır
- */
-export function init2D3DView() {
-    if (!dom.c2d3d || !scene || !camera) {
-        console.error("init2D3DView: Gerekli elemanlar bulunamadı");
-        return;
-    }
-
-    // Yeni bir renderer oluştur (c2d3d canvas'ı için)
-    renderer2d3d = new THREE.WebGLRenderer({
-        antialias: true,
-        canvas: dom.c2d3d,
-    });
-
-    // OrbitControls'ü bu renderer için de oluştur
-    controls2d3d = new OrbitControls(camera, renderer2d3d.domElement);
-    controls2d3d.target.set(0, WALL_HEIGHT / 2, 0);
-    controls2d3d.minDistance = 1;
-    controls2d3d.zoomSpeed = 1;
-    controls2d3d.update();
-
-    // Mouse tuş atamaları
-    controls2d3d.mouseButtons = {
-        LEFT: THREE.MOUSE.ROTATE,   // Sol Tuş = Döndürme
-        MIDDLE: THREE.MOUSE.PAN,    // Orta Tuş = Pan (Kaydırma)
-        RIGHT: THREE.MOUSE.PAN,     // Sağ Tuş = Pan
-    };
-
-    console.log("2D panel içi 3D görünüm başlatıldı");
-}
-
-/**
- * 2D panel içindeki 3D görünümü resize eder
- */
-export function resize2D3DView() {
-    if (!renderer2d3d || !dom.c2d3d || !camera) return;
-
-    const rect = dom.p2d.getBoundingClientRect();
-    renderer2d3d.setSize(rect.width, rect.height);
-    camera.aspect = rect.width / rect.height;
-    camera.updateProjectionMatrix();
 }


### PR DESCRIPTION
Reverted the incorrect THREE.js renderer2d3d implementation and fixed the isometric view to work correctly on the 2D canvas as originally intended.

Changes:
- Removed c2d3d canvas element and all related renderer2d3d code
- Removed init2D3DView() and resize2D3DView() functions
- Cleaned up unused imports from ui.js and main.js
- Fixed plumbing rendering to support Z coordinates in isometric mode
- Isometric projection now works correctly using canvas transform matrix

The '3D Görünüm' button now properly toggles the 2D canvas between top-down and isometric views while maintaining full interactivity for all elements (walls, doors, stairs, plumbing).