### PR TITLE
fix: 3D sahnede zoom'u daha smooth yap

### DIFF
--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -440,8 +440,8 @@ export function setupIsometricControls() {
         const worldBeforeX = (mouseX - centerX - state.isoPanOffset.x) / state.isoZoom;
         const worldBeforeY = (mouseY - centerY - state.isoPanOffset.y) / state.isoZoom;
 
-        // Zoom faktörü
-        const zoomDelta = e.deltaY > 0 ? 0.9 : 1.1;
+        // Zoom faktörü - daha smooth geçişler için küçük adımlar
+        const zoomDelta = e.deltaY > 0 ? 0.95 : 1.05;
         const newZoom = Math.max(0.1, Math.min(5, state.isoZoom * zoomDelta));
 
         // Zoom sonrası mouse pozisyonunun world koordinatları (yeni zoom ile)

--- a/scene3d/scene3d-core.js
+++ b/scene3d/scene3d-core.js
@@ -73,7 +73,7 @@ export function init3D(canvasElement) {
     orbitControls = new OrbitControls(camera, renderer.domElement);
     orbitControls.target.set(0, WALL_HEIGHT / 2, 0);
     orbitControls.minDistance = 1;
-    orbitControls.zoomSpeed = 1;
+    orbitControls.zoomSpeed = 0.5; // Daha smooth zoom için düşürüldü
     orbitControls.update();
 
     // --- YENİ EKLENDİ: Mouse tuş atamaları (İsteğinize göre güncellendi) ---


### PR DESCRIPTION
Hem izometrik görünümde hem de 3D orbit modunda zoom çok atlamalıydı.

İzometrik görünüm:
- Zoom faktörü 0.9/1.1'den 0.95/1.05'e düşürüldü (%5 adım)

3D Orbit modu:
- OrbitControls zoomSpeed 1'den 0.5'e düşürüldü

Bu değişiklikler zoom'u daha smooth ve kontrol edilebilir yapıyor.