### PR TITLE
fix: İzometrik görünümde zoom'da mouse koordinatlarını doğru hesapla

### DIFF
--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -429,8 +429,12 @@ export function setupIsometricControls() {
         e.preventDefault();
 
         const rect = dom.cIso.getBoundingClientRect();
-        const mouseX = e.clientX - rect.left;
-        const mouseY = e.clientY - rect.top;
+        const mouseXInRect = e.clientX - rect.left;
+        const mouseYInRect = e.clientY - rect.top;
+
+        // Canvas internal koordinatlarına dönüştür (CSS boyutu farklı olabilir)
+        const mouseX = (mouseXInRect / rect.width) * dom.cIso.width;
+        const mouseY = (mouseYInRect / rect.height) * dom.cIso.height;
 
         // Canvas merkezi
         const centerX = dom.cIso.width / 2;


### PR DESCRIPTION
Canvas'ın CSS boyutu ile internal boyutu farklı olduğunda mouse koordinatları yanlış hesaplanıyordu. Bu zoom yaparken mouse'un altındaki noktanın kaymasına ve spiral gibi davranışa yol açıyordu.

Mouse koordinatları artık canvas internal koordinatlarına dönüştürülüyor:
- rect.getBoundingClientRect() ile CSS boyutunu al
- Mouse pozisyonunu oranla canvas.width/height'a dönüştür

Bu sayede zoom her zaman mouse'un üzerinde olduğu noktada yapılıyor.