### PR TITLE
fix: 3D görünümde düşey boruları doğru çiz

### DIFF
--- a/scene3d/scene3d-update.js
+++ b/scene3d/scene3d-update.js
@@ -308,7 +308,8 @@ export function update3DScene() {
         plumbingPipes.forEach(pipe => {
             const m = createPlumbingPipeMesh(pipe, pipeMaterial);
             if (m) {
-                m.position.y = getFloorElevation(pipe.floorId);
+                // Kat yüksekliğini mevcut Y pozisyonuna ekle (relative + absolute)
+                m.position.y += getFloorElevation(pipe.floorId);
                 sceneObjects.add(m);
             }
 


### PR DESCRIPTION
- Z koordinatlarını boru uzunluğu hesaplamasına ekle
- Düşey boru tespiti için kontrol ekle (dx, dy ≈ 0, dz > 0)
- Düşey borular için doğru yönlendirme (Y ekseni)
- Yatay/eğik borular için quaternion rotasyonu kullan
- Kat yüksekliğini relative pozisyona ekle

İzometrik görünümde zaten doğru çalışıyordu, şimdi 3D görünüm penceresinde de düşey borular dikey olarak görüntüleniyor.

Değiştirilen:
- scene3d/scene3d-plumbing.js: createPlumbingPipeMesh
- scene3d/scene3d-update.js: Kat yüksekliği