### PR TITLE
fix: floorId undefined olan borular için 3D render düzeltmesi

### DIFF
--- a/scene3d/scene3d-update.js
+++ b/scene3d/scene3d-update.js
@@ -98,7 +98,9 @@ export function update3DScene() {
     // 'floor' modunda sadece aktif kat, 'building' modunda tüm katlar görünür
     const shouldShowFloor = (floorId) => {
         if (viewMode === 'building') return true; // Tüm katlar
-        // Sadece currentFloorId ve floorId eşleşiyorsa göster (floorId olmayan öğeleri gösterme!)
+        // floorId undefined ise mevcut kata ait kabul et (geriye dönük uyumluluk)
+        if (!floorId) return true;
+        // Sadece currentFloorId ve floorId eşleşiyorsa göster
         return currentFloorId && floorId === currentFloorId;
     };
 


### PR DESCRIPTION
shouldShowFloor() fonksiyonu floorId=undefined olan boruları filtreliyordu ve hiçbir boru render edilmiyordu.

Düzeltme: floorId undefined ise mevcut kata ait kabul et (geriye dönük uyumluluk için).

Bu, eski borular (floorId atanmamış) için 3D görünümün çalışmasını sağlar.