### PR TITLE
3D görünümde 2D mimari plan görünümü eklendi

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -463,6 +463,10 @@ export let state = {
     // --- 3D PERSPEKTİF GÖRÜNÜM ---
     is3DPerspectiveActive: false, // 3D perspektif modu aktif mi?
     // --- 3D PERSPEKTİF GÖRÜNÜM SONU ---
+
+    // --- 2D MİMARİ PLAN GÖRÜNÜMÜ (3D'de) ---
+    is2DPlanView: true, // 3D görünümde mimari planı 2D düzlemde göster (varsayılan: true)
+    // --- 2D MİMARİ PLAN GÖRÜNÜMÜ SONU ---
 };
 
 export function setState(newState) {

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -232,6 +232,12 @@ export function toggle3DView() {
 
         // Varsayılan split ratio'yu ayarla (25%)
         setSplitRatio(25);
+
+        // 2D plan görünümü butonunu başlangıçta aktif yap
+        const btn2DPlan = document.getElementById('b2DPlanView');
+        if (btn2DPlan && state.is2DPlanView) {
+            btn2DPlan.classList.add('active');
+        }
     } else {
         // Split ratio butonlarını gizle
         const splitButtons = document.getElementById('split-ratio-buttons');
@@ -246,8 +252,39 @@ export function toggle3DView() {
         resize();
         if (dom.mainContainer.classList.contains('show-3d')) {
             update3DScene();
+            // 2D plan görünümü aktifse kamerayı ayarla
+            if (state.is2DPlanView) {
+                import('../scene3d/scene3d-core.js').then(module => {
+                    module.set2DPlanView();
+                });
+            }
         }
     }, 10);
+}
+
+/**
+ * 2D plan görünümünü toggle eder
+ */
+export function toggle2DPlanView() {
+    setState({ is2DPlanView: !state.is2DPlanView });
+
+    // Butonu aktif/pasif yap
+    const btn = document.getElementById('b2DPlanView');
+    if (btn) {
+        btn.classList.toggle('active', state.is2DPlanView);
+    }
+
+    if (state.is2DPlanView) {
+        // 2D plan görünümüne geç
+        import('../scene3d/scene3d-core.js').then(module => {
+            module.set2DPlanView();
+        });
+    } else {
+        // Normal 3D görünüme geç
+        import('../scene3d/scene3d-core.js').then(module => {
+            module.fit3DViewToScreen();
+        });
+    }
 }
 
 export function toggleIsoView() {
@@ -1618,6 +1655,14 @@ export function setupUIListeners() {
         });
     });
     // MERDİVEN POPUP LISTENER'LARI SONU
+
+    // 2D PLAN GÖRÜNÜMÜ BUTONU LISTENER'I
+    const b2DPlanView = document.getElementById('b2DPlanView');
+    if (b2DPlanView) {
+        b2DPlanView.addEventListener('click', () => {
+            toggle2DPlanView();
+        });
+    }
 
     // FPS KAMERA BUTONU LISTENER'I
     dom.bFirstPerson.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -714,6 +714,7 @@
       <!-- FPS Kamera ve Koordinatlar (Sağ Alt) -->
       <div id="fps-camera-controls" style="display: none;">
         <span id="camera-coords" style="display: none;">x: 0, y: 0, z: 0</span>
+        <button id="b2DPlanView" class="fps-btn" title="2D Plan Görünümü">2D Plan</button>
         <button id="bFirstPerson" class="fps-btn" title="FPS Kamera">FPS Kamera</button>
       </div>
       <!-- Mod Göstergesi (Her Zaman Görünür) -->


### PR DESCRIPTION
- state'e is2DPlanView flag'i eklendi (varsayılan: true)
- scene3d-core.js'e set2DPlanView() fonksiyonu eklendi
  * Kamerayı top-down (yukarıdan) konumlandırır
  * Tüm 3D nesneleri zemin düzleminde gösterir
- ui.js'e toggle2DPlanView() fonksiyonu eklendi
- 3D kontrol paneline "2D Plan" butonu eklendi
- 3D görünüm açıldığında varsayılan olarak 2D plan görünümü aktif olur