### PR TITLE
feat: Make isometric and 3D view buttons independent from toolbar

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -1165,12 +1165,12 @@ body.light-mode .btn.active svg {
     backdrop-filter: blur(4px);
 }
 
-/* 3D Göster Butonu - 2D Ekranın Sağ Üst Köşesi */
+/* 3D Göster Butonu - Sağ Üst Köşe (Araç çubuğundan bağımsız) */
 .btn-show-3d {
-    position: absolute;
+    position: fixed;
     top: 10px;
     right: 10px;
-    z-index: 100;
+    z-index: 10000;
     padding: 7px 10px;
     /* %25 büyütüldü: 5px 8px -> 7px 10px */
     font-size: 14px;
@@ -1216,12 +1216,12 @@ body.light-mode .btn.active svg {
     display: none;
 }
 
-/* İzometri Göster Butonu - 3D Göster butonunun yanında */
+/* İzometri Göster Butonu - 3D Göster butonunun yanında (Araç çubuğundan bağımsız) */
 .btn-show-iso {
-    position: absolute;
+    position: fixed;
     top: 10px;
     right: 130px; /* 3D butonunun soluna yerleştir */
-    z-index: 100;
+    z-index: 10000;
     padding: 7px 10px;
     font-size: 14px;
     font-weight: 500;

--- a/index.html
+++ b/index.html
@@ -260,6 +260,30 @@
         <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none" />
       </div>
 
+      <!-- İzometri ve 3D Göster butonları - Araç çubuğundan bağımsız -->
+      <button id="bIso" class="btn btn-show-iso">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <!-- İzometrik kutu ikonu -->
+          <path d="M12 2L4 7v10l8 5 8-5V7z"></path>
+          <path d="M12 22v-10"></path>
+          <path d="M4 7l8 5 8-5"></path>
+          <path d="M12 2v10"></path>
+        </svg>
+        İzometri
+      </button>
+      <button id="b3d" class="btn btn-show-3d">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <path
+            d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z">
+          </path>
+          <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
+          <line x1="12" y1="22.08" x2="12" y2="12"></line>
+        </svg>
+        3D Göster
+      </button>
+
       <button id="settings-btn" class="btn">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
           stroke-linejoin="round">
@@ -582,28 +606,6 @@
       </div>
 
       <input type="text" id="length-input" />
-      <button id="b3d" class="btn btn-show-3d">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-          stroke-linejoin="round">
-          <path
-            d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z">
-          </path>
-          <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
-          <line x1="12" y1="22.08" x2="12" y2="12"></line>
-        </svg>
-        3D Göster
-      </button>
-      <button id="bIso" class="btn btn-show-iso">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-          stroke-linejoin="round">
-          <!-- İzometrik kutu ikonu -->
-          <path d="M12 2L4 7v10l8 5 8-5V7z"></path>
-          <path d="M12 22v-10"></path>
-          <path d="M4 7l8 5 8-5"></path>
-          <path d="M12 2v10"></path>
-        </svg>
-        İzometri
-      </button>
     </div>
     <div id="splitter"></div>
     <div id="p3d" class="panel">


### PR DESCRIPTION
- Moved #bIso and #b3d buttons outside of #ui div to make them independent
- Changed position from 'absolute' to 'fixed' in CSS for persistent placement
- Increased z-index to 10000 to ensure buttons stay on top
- Buttons now remain in top-right corner regardless of toolbar scrolling