### PR TITLE
fix: Update splitter references for dual splitter support

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -561,7 +561,8 @@ export const dom = {
     roomNamePopup: document.getElementById("room-name-popup"),
     roomNameSelect: document.getElementById("room-name-select"),
     roomNameInput: document.getElementById("room-name-input"),
-    splitter: document.getElementById("splitter"),
+    splitter3d: document.getElementById("splitter-3d"),
+    splitterIso: document.getElementById("splitter-iso"),
     bSymmetry: document.getElementById("bSymmetry"), // YENİ SATIR
     stairPopup: document.getElementById("stair-popup"),
     stairNameInput: document.getElementById("stair-name"),

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -967,10 +967,11 @@ function onSplitterPointerMove(e) {
     if (p2dWidth < min2DWidth) p2dWidth = min2DWidth;
 
     // 3D panel için minimum kontrol (2D panel maksimum genişliği)
-    const max2DWidth = mainRect.width - min3DWidth - dom.splitter.offsetWidth - 20;
+    const splitterWidth = dom.splitter3d?.offsetWidth || 4;
+    const max2DWidth = mainRect.width - min3DWidth - splitterWidth - 20;
     if (p2dWidth > max2DWidth) p2dWidth = max2DWidth;
 
-    let p3dWidth = mainRect.width - p2dWidth - dom.splitter.offsetWidth - 20;
+    let p3dWidth = mainRect.width - p2dWidth - splitterWidth - 20;
 
     p2dPanel.style.flex = `1 1 ${p2dWidth}px`;
     p3dPanel.style.flex = `1 1 ${p3dWidth}px`;
@@ -1373,7 +1374,8 @@ export function setupUIListeners() {
     dom.roomNameInput.addEventListener('input', filterRoomNameList);
     dom.roomNameSelect.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); confirmRoomNameChange(); } });
     dom.roomNameInput.addEventListener('keydown', (e) => { if (e.key === 'ArrowDown') { e.preventDefault(); dom.roomNameSelect.focus(); } else if (e.key === 'Enter') { e.preventDefault(); confirmRoomNameChange(); } });
-    dom.splitter.addEventListener('pointerdown', onSplitterPointerDown);
+    dom.splitter3d?.addEventListener('pointerdown', onSplitterPointerDown);
+    dom.splitterIso?.addEventListener('pointerdown', onSplitterPointerDown);
     dom.lengthInput.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); confirmLengthEdit(); } else if (e.key === "Escape") { cancelLengthEdit(); } });
     dom.lengthInput.addEventListener("blur", cancelLengthEdit);
 


### PR DESCRIPTION
- Changed elements.splitter to elements.splitter3d and elements.splitterIso
- Updated ui.js to use optional chaining for splitter references
- Fixed offsetWidth calculations to use splitter3d
- Added event listeners for both splitter-3d and splitter-iso
- Resolves: Uncaught TypeError: Cannot read properties of null