### PR TITLE
fix: UI layout - move UI bar to top above all panels

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -59,11 +59,18 @@ body.light-mode {
 
 .main {
     display: flex;
+    flex-direction: column;
     width: 100vw;
     height: 100vh;
     gap: 0;
     padding: 1px;
     box-sizing: border-box;
+}
+
+.panels-container {
+    display: flex;
+    flex: 1;
+    gap: 0;
 }
 
 .panel {
@@ -183,6 +190,20 @@ canvas {
 }
 
 #ui {
+    width: 100%;
+    height: 60px;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 20px;
+    box-sizing: border-box;
+    background: var(--bg-group);
+    border-bottom: 1px solid var(--border-group);
+    z-index: 100;
+}
+
+#toolbar {
     margin-top: 50px;
     position: relative;
     z-index: 10;
@@ -268,7 +289,7 @@ body.light-mode .group-label {
 }
 
 /* YENİ KURAL: UI içindeki butonları sadece ikon göster (küçük ikon modu) */
-#ui.display-small-icon .btn {
+#toolbar.display-small-icon .btn {
     width: auto;
     /* Otomatik genişlik */
     min-width: 28px;
@@ -289,14 +310,14 @@ body.light-mode .group-label {
 }
 
 /* UI içindeki buton iconları (küçük ikon modu) */
-#ui.display-small-icon .btn svg {
+#toolbar.display-small-icon .btn svg {
     width: 16px;
     /* Kat çubuğu ile uyumlu boyut */
     height: 16px;
 }
 
 /* Display Mode: Küçük İkon + Metin */
-#ui.display-small-icon-text .btn {
+#toolbar.display-small-icon-text .btn {
     font-size: 14px;
     /* Metni göster */
     gap: 8px;
@@ -308,13 +329,13 @@ body.light-mode .group-label {
     /* Sola dayalı */
 }
 
-#ui.display-small-icon-text .btn svg {
+#toolbar.display-small-icon-text .btn svg {
     width: 16px;
     height: 16px;
 }
 
 /* Display Mode: Büyük İkon */
-#ui.display-big-icon .btn {
+#toolbar.display-big-icon .btn {
     min-width: 42px;
     /* 28 * 1.5 */
     height: 42px;
@@ -328,14 +349,14 @@ body.light-mode .group-label {
     /* İkonu ortala */
 }
 
-#ui.display-big-icon .btn svg {
+#toolbar.display-big-icon .btn svg {
     width: 24px;
     /* 16 * 1.5 */
     height: 24px;
 }
 
 /* Display Mode: Büyük İkon + Metin */
-#ui.display-big-icon-text .btn {
+#toolbar.display-big-icon-text .btn {
     font-size: 14px;
     /* Küçük ikonla aynı font boyutu */
     gap: 8px;
@@ -348,7 +369,7 @@ body.light-mode .group-label {
     /* Sola dayalı */
 }
 
-#ui.display-big-icon-text .btn svg {
+#toolbar.display-big-icon-text .btn svg {
     width: 24px;
     /* 16 * 1.5 */
     height: 24px;
@@ -382,8 +403,8 @@ body.light-mode .btn.active svg {
     background: var(--bg-button-hover);
 }
 
-/* UI içindeki butonlar için gelişmiş hover efekti */
-#ui .btn:hover:not(.active) {
+/* Toolbar içindeki butonlar için gelişmiş hover efekti */
+#toolbar .btn:hover:not(.active) {
     background: var(--bg-button-hover);
     border-color: #87CEEB;
     box-shadow: 0 2px 8px rgba(135, 206, 235, 0.3);
@@ -1165,22 +1186,16 @@ body.light-mode .btn.active svg {
     backdrop-filter: blur(4px);
 }
 
-/* 3D Göster Butonu - 2D Ekranın Sağ Üst Köşesi */
+/* 3D Göster Butonu - UI Bar içinde */
 .btn-show-3d {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    z-index: 100;
-    padding: 7px 10px;
-    /* %25 büyütüldü: 5px 8px -> 7px 10px */
+    padding: 7px 12px;
     font-size: 14px;
-    /* %25 büyütüldü: 11px -> 14px */
     font-weight: 500;
     min-width: auto;
     white-space: nowrap;
-    background: #3c4043;
-    border: 1px solid #5f6368;
-    color: #e8eaed;
+    background: var(--bg-button);
+    border: 1px solid var(--border-button);
+    color: var(--color-text);
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;
@@ -1211,25 +1226,24 @@ body.light-mode .btn.active svg {
     font-weight: 600;
 }
 
-/* 3D açıkken butonu gizle */
+/* 3D açıkken buton vurgusu */
 .main.show-3d .btn-show-3d {
-    display: none;
+    background: var(--bg-button-active);
+    color: var(--color-button-active);
+    border-color: var(--bg-button-active);
+    font-weight: 600;
 }
 
-/* İzometri Göster Butonu - 3D Göster butonunun yanında */
+/* İzometri Göster Butonu - UI Bar içinde */
 .btn-show-iso {
-    position: absolute;
-    top: 10px;
-    right: 130px; /* 3D butonunun soluna yerleştir */
-    z-index: 100;
-    padding: 7px 10px;
+    padding: 7px 12px;
     font-size: 14px;
     font-weight: 500;
     min-width: auto;
     white-space: nowrap;
-    background: #3c4043;
-    border: 1px solid #5f6368;
-    color: #e8eaed;
+    background: var(--bg-button);
+    border: 1px solid var(--border-button);
+    color: var(--color-text);
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;
@@ -1260,9 +1274,12 @@ body.light-mode .btn.active svg {
     font-weight: 600;
 }
 
-/* İzometri açıkken butonu gizle */
+/* İzometri açıkken buton vurgusu */
 .main.show-iso .btn-show-iso {
-    display: none;
+    background: var(--bg-button-active);
+    color: var(--color-button-active);
+    border-color: var(--bg-button-active);
+    font-weight: 600;
 }
 
 /* 3D Opacity Kontrolleri */

--- a/index.html
+++ b/index.html
@@ -18,8 +18,34 @@
   </div>
 
   <div class="main" id="main-container">
+    <div id="ui">
+      <button id="b3d" class="btn btn-show-3d">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <path
+            d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z">
+          </path>
+          <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
+          <line x1="12" y1="22.08" x2="12" y2="12"></line>
+        </svg>
+        3DGörünüm
+      </button>
+      <button id="bIso" class="btn btn-show-iso">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+          stroke-linejoin="round">
+          <!-- İzometrik kutu ikonu -->
+          <path d="M12 2L4 7v10l8 5 8-5V7z"></path>
+          <path d="M12 22v-10"></path>
+          <path d="M4 7l8 5 8-5"></path>
+          <path d="M12 2v10"></path>
+        </svg>
+        İzometri
+      </button>
+    </div>
+
+    <div class="panels-container">
     <div id="p2d" class="panel">
-      <div id="ui">
+      <div id="toolbar">
 
         <!-- ═══════════════════════════════════════════════════════════════ -->
         <!-- GENEL İŞLEMLER -->
@@ -582,28 +608,6 @@
       </div>
 
       <input type="text" id="length-input" />
-      <button id="b3d" class="btn btn-show-3d">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-          stroke-linejoin="round">
-          <path
-            d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z">
-          </path>
-          <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
-          <line x1="12" y1="22.08" x2="12" y2="12"></line>
-        </svg>
-        3D Göster
-      </button>
-      <button id="bIso" class="btn btn-show-iso">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-          stroke-linejoin="round">
-          <!-- İzometrik kutu ikonu -->
-          <path d="M12 2L4 7v10l8 5 8-5V7z"></path>
-          <path d="M12 22v-10"></path>
-          <path d="M4 7l8 5 8-5"></path>
-          <path d="M12 2v10"></path>
-        </svg>
-        İzometri
-      </button>
     </div>
     <div id="splitter"></div>
     <div id="p3d" class="panel">
@@ -753,6 +757,7 @@
           </svg>
         </button>
       </div>
+    </div>
     </div>
   </div>
 

--- a/menu/panel-display-menu.js
+++ b/menu/panel-display-menu.js
@@ -6,14 +6,14 @@
  * @param {string} mode - 'small-icon' | 'small-icon-text' | 'big-icon' | 'big-icon-text'
  */
 function setPanelDisplayMode(mode) {
-    const ui = document.getElementById('ui');
-    if (!ui) return;
+    const toolbar = document.getElementById('toolbar');
+    if (!toolbar) return;
 
     // Tüm mod sınıflarını kaldır
-    ui.classList.remove('display-small-icon', 'display-small-icon-text', 'display-big-icon', 'display-big-icon-text');
+    toolbar.classList.remove('display-small-icon', 'display-small-icon-text', 'display-big-icon', 'display-big-icon-text');
 
     // Yeni modu ekle
-    ui.classList.add(`display-${mode}`);
+    toolbar.classList.add(`display-${mode}`);
 
     // Tercihi localStorage'a kaydet
     localStorage.setItem('panelDisplayMode', mode);
@@ -97,12 +97,12 @@ export function initPanelDisplayMenu() {
         });
     });
 
-    // #ui elementine sağ tık event listener'ı ekle
-    const ui = document.getElementById('ui');
-    if (ui) {
-        ui.addEventListener('contextmenu', (e) => {
-            // Sadece #ui div'inin kendisine tıklandığında aç, butonlara değil
-            if (e.target.id === 'ui' || e.target.closest('#ui') === ui) {
+    // #toolbar elementine sağ tık event listener'ı ekle
+    const toolbar = document.getElementById('toolbar');
+    if (toolbar) {
+        toolbar.addEventListener('contextmenu', (e) => {
+            // Sadece #toolbar div'inin kendisine tıklandığında aç, butonlara değil
+            if (e.target.id === 'toolbar' || e.target.closest('#toolbar') === toolbar) {
                 e.preventDefault();
                 e.stopPropagation();
                 showPanelDisplayMenu(e.clientX, e.clientY);
@@ -112,10 +112,10 @@ export function initPanelDisplayMenu() {
 
     // Sayfa yüklendiğinde kaydedilmiş modu uygula
     const savedMode = localStorage.getItem('panelDisplayMode') || 'big-icon';
-    if (ui) {
-        ui.classList.remove('display-small-icon', 'display-small-icon-text', 'display-big-icon', 'display-big-icon-text');
+    if (toolbar) {
+        toolbar.classList.remove('display-small-icon', 'display-small-icon-text', 'display-big-icon', 'display-big-icon-text');
         // Varsayılan mod artık big-icon olduğu için herzaman sınıfı ekle
-        ui.classList.add(`display-${savedMode}`);
+        toolbar.classList.add(`display-${savedMode}`);
     }
 
     //console.log('Panel display menü başlatıldı. Aktif mod:', savedMode);


### PR DESCRIPTION
- Moved #ui element from inside #p2d to top of .main container
- Created .panels-container wrapper for p2d, p3d, pIso panels
- Moved 3D and Isometric buttons into #ui bar
- Renamed old #ui to #toolbar for button groups
- Updated CSS: .main flex-direction column, #ui as top bar
- Buttons now stay visible with active state instead of hiding
- Fixed JavaScript references from #ui to #toolbar