### PR TITLE
UI layout düzeltmesi: UI panelini en üste taşı

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -63,6 +63,7 @@ body.light-mode {
     height: 100vh;
     gap: 0;
     padding: 1px;
+    padding-top: 70px;
     box-sizing: border-box;
 }
 
@@ -196,11 +197,16 @@ canvas {
 }
 
 #ui {
-    margin-top: 50px;
-    position: relative;
-    z-index: 10;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    z-index: 1000;
     pointer-events: none;
     /* UI container'a tıklanmasın, sadece çocuklar */
+    padding: 10px 10px 0 10px;
+    box-sizing: border-box;
 }
 
 /* Sürüklenebilir Buton Grubu Container */

--- a/index.html
+++ b/index.html
@@ -18,8 +18,7 @@
   </div>
 
   <div class="main" id="main-container">
-    <div id="p2d" class="panel">
-      <div id="ui">
+    <div id="ui">
 
         <!-- ═══════════════════════════════════════════════════════════════ -->
         <!-- GENEL İŞLEMLER -->
@@ -257,8 +256,9 @@
           </button>
 
         </div>
-        <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none" />
       </div>
+    <div id="p2d" class="panel">
+        <input type="file" id="file-input" accept=".json, .pdf, .xml" style="display: none" />
 
       <button id="settings-btn" class="btn">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"


### PR DESCRIPTION
- id="ui" div'ini p2d panelinin dışına çıkarıldı
- UI paneli artık tüm panellerin üzerinde (z-index: 1000)
- UI paneli ekranın genişliği boyunca uzanıyor
- p3d ve pIso panelleri UI'nin altında kalacak şekilde düzenlendi
- .main container'a padding-top eklendi

Bu değişiklik, 3D görünüm veya İzometri panelleri açıldığında UI'nin üzerinde kalmamaları sorununu çözüyor.