### PR TITLE
feat: Üst buton alanını çizim ekranından ayır

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -63,6 +63,7 @@ body.light-mode {
     height: 100vh;
     gap: 0;
     padding: 1px;
+    padding-top: 50px;
     box-sizing: border-box;
 }
 
@@ -142,7 +143,7 @@ body.light-mode {
 
 .main.fullscreen-3d #p2d {
     position: fixed !important;
-    top: 10px;
+    top: 60px;
     right: 10px;
     width: calc(100vw / 5);
     height: calc(100vh / 3);
@@ -196,7 +197,7 @@ canvas {
 }
 
 #ui {
-    margin-top: 0;
+    margin-top: 50px;
     position: relative;
     z-index: 10;
     pointer-events: none;


### PR DESCRIPTION
- .main container'a padding-top: 50px ekle
- #ui margin-top'u 50px'e geri döndür
- Fullscreen-3d mini-map top değerini 60px'e güncelle

Değişiklikler:
- Üstteki butonlar (Mimari, Tesisat, Karma, Katı Model, İzometri, 3D) artık sabit bir alanda kalıyor
- Çizim ekranları (2D, 3D, İzometri) üst buton alanına karışmıyor
- Proje butonları (UI içindeki button-group'lar) yukarı taşmıyor