### PR TITLE
fix: Tüm buton yerleşim sorunlarını düzelt

### DIFF
--- a/general-files/style.css
+++ b/general-files/style.css
@@ -222,6 +222,7 @@ canvas {
     pointer-events: auto;
     /* Gruplara tıklanabilsin */
     cursor: default;
+    z-index: 100;
 }
 
 /* Varsayılan pozisyonlar - yan yana */
@@ -1510,8 +1511,18 @@ body.light-mode .btn.active svg {
     border-left: 1px solid var(--border-group);
     border-bottom-left-radius: 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    z-index: 1234;
+    z-index: 10000;
     backdrop-filter: blur(4px);
+}
+
+/* viewing-mode-selector içindeki butonlar için eski kuralları override et */
+#viewing-mode-selector .btn-show-3d,
+#viewing-mode-selector .btn-show-iso,
+#viewing-mode-selector .btn-show-3d-perspective {
+    position: static;
+    top: auto;
+    right: auto;
+    z-index: auto;
 }
 
 


### PR DESCRIPTION
4 sorun düzeltildi:

1. Sol buton grupları başlık çubuğu altında kalıyordu → .draggable-group'a z-index: 100 eklendi

2. Ortada viewing-mode-selector butonları görünüyordu → #viewing-mode-selector içindeki butonlar position: static yapıldı → Eski fixed pozisyon kuralları override edildi

3. Sağdaki butonların border'ı görünmüyordu → #viewing-mode-selector z-index: 10000'e yükseltildi → İçindeki butonlar artık div içinde kalıyor

4. Sol ve sağ butonlar hizalı değildi → Her iki selector da z-index: 10000 (eşit) → Her ikisi de top: 0 (tavana dayalı)

Değişiklikler:
- #viewing-mode-selector z-index: 1234 → 10000
- #viewing-mode-selector .btn-* → position: static
- .draggable-group → z-index: 100 eklendi