### PR TITLE
feat: 3D Görünüm butonunu kaldır ve özelliklerini Katı Model ile birl…

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -578,9 +578,8 @@ export const dom = {
     stairShowRailingCheckbox: document.getElementById("stair-show-railing"), // <-- YENİ SATIR BURAYA EKLENECEK
     confirmStairPopupButton: document.getElementById("confirm-stair-popup"),
     cancelStairPopupButton: document.getElementById("cancel-stair-popup"),
-    b3d: document.getElementById("b3d"), // Katı Model butonu
+    b3d: document.getElementById("b3d"), // 3D butonu
     bIso: document.getElementById("bIso"), // İzometri Göster butonu
-    b3DPerspective: document.getElementById("b3DPerspective"), // 3D Perspektif Görünüm butonu
 };
 
 // Proje modu butonlarını kurar (MİMARİ, TESİSAT, KARMA)

--- a/general-files/style.css
+++ b/general-files/style.css
@@ -1274,50 +1274,6 @@ body.light-mode .btn.active svg {
 }
 
 
-/* 3D Perspektif Görünüm Butonu */
-.btn-show-3d-perspective {
-    position: fixed;
-    top: 10px;
-    right: 215px; /* İzometri butonunun soluna yerleştir */
-    z-index: 100;
-    padding: 7px 10px;
-    font-size: 11px;
-    font-weight: 500;
-    min-width: auto;
-    white-space: nowrap;
-    background: #3c4043;
-    border: 1px solid #5f6368;
-    color: #e8eaed;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.btn-show-3d-perspective svg {
-    width: 18px;
-    height: 18px;
-    stroke: currentColor;
-    fill: none;
-    stroke-width: 2;
-}
-
-.btn-show-3d-perspective:hover {
-    background: #5f6368;
-    border-color: #87CEEB;
-    box-shadow: 0 2px 8px rgba(135, 206, 235, 0.3);
-}
-
-.btn-show-3d-perspective.active {
-    background: rgba(100, 149, 237, 0.4);
-    color: #87CEEB;
-    border-color: #87CEEB;
-    box-shadow: 0 0 8px rgba(135, 206, 235, 0.5);
-}
-
 /* 3D Opacity Kontrolleri */
 #opacity-controls-container {
     position: absolute;
@@ -1522,8 +1478,7 @@ body.light-mode .btn.active svg {
 
 /* viewing-mode-selector içindeki butonlar için eski kuralları override et */
 #viewing-mode-selector .btn-show-3d,
-#viewing-mode-selector .btn-show-iso,
-#viewing-mode-selector .btn-show-3d-perspective {
+#viewing-mode-selector .btn-show-iso {
     position: static;
     top: auto;
     right: auto;
@@ -1682,18 +1637,6 @@ body.light-mode .btn-show-iso {
 }
 
 body.light-mode .btn-show-iso.active {
-    background: #1a73e8;
-    color: #ffffff;
-    border-color: #1557b0;
-    box-shadow: 0 0 8px rgba(26, 115, 232, 0.5);
-}
-
-body.light-mode .btn-show-3d-perspective {
-    color: #3c4043;
-    background: #e8eaed;
-}
-
-body.light-mode .btn-show-3d-perspective.active {
     background: #1a73e8;
     color: #ffffff;
     border-color: #1557b0;

--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -222,6 +222,9 @@ export function toggle3DView() {
     if (dom.mainContainer.classList.contains('show-3d')) {
         setMode("select"); // 3D açılırken modu "select" yap
 
+        // 3D Perspektif modunu aktif et (2D canvas izometrik projeksiyon kullanacak)
+        setState({ is3DPerspectiveActive: true });
+
         // Split ratio butonlarını göster
         const splitButtons = document.getElementById('split-ratio-buttons');
         if (splitButtons) splitButtons.style.display = 'flex';
@@ -233,6 +236,9 @@ export function toggle3DView() {
         // Varsayılan split ratio'yu ayarla (25%)
         setSplitRatio(25);
     } else {
+        // 3D Perspektif modunu kapat (2D canvas normal görünüme dönecek)
+        setState({ is3DPerspectiveActive: false });
+
         // Split ratio butonlarını gizle
         const splitButtons = document.getElementById('split-ratio-buttons');
         if (splitButtons) splitButtons.style.display = 'none';
@@ -289,34 +295,6 @@ export function toggleIsoView() {
     }, 10);
 }
 
-export function toggle3DPerspective() {
-    setState({ is3DPerspectiveActive: !state.is3DPerspectiveActive });
-
-    // Buton görünümünü güncelle
-    if (state.is3DPerspectiveActive) {
-        dom.b3DPerspective.classList.add('active');
-        dom.b3DPerspective.innerHTML = `
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-              stroke-linejoin="round">
-              <path d="M3 3l6 6M21 3l-6 6M3 21l6-6M21 21l-6-6"></path>
-              <rect x="9" y="9" width="6" height="6" fill="none"></rect>
-              <path d="M9 9L3 3M15 9L21 3M9 15L3 21M15 15L21 21"></path>
-            </svg>
-            2D Görünüm
-        `;
-    } else {
-        dom.b3DPerspective.classList.remove('active');
-        dom.b3DPerspective.innerHTML = `
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-              stroke-linejoin="round">
-              <path d="M3 3l6 6M21 3l-6 6M3 21l6-6M21 21l-6-6"></path>
-              <rect x="9" y="9" width="6" height="6" fill="none"></rect>
-              <path d="M9 9L3 3M15 9L21 3M9 15L3 21M15 15L21 21"></path>
-            </svg>
-            3D Görünüm
-        `;
-    }
-}
 
 // İzometri ekran bölme oranını ayarla
 export function setIsoRatio(ratio) {
@@ -1651,13 +1629,6 @@ export function setupUIListeners() {
     dom.bIso.addEventListener('click', () => {
         toggleIsoView();
     });
-
-    // 3D PERSPEKTİF GÖRÜNÜM BUTONU LISTENER'I
-    if (dom.b3DPerspective) {
-        dom.b3DPerspective.addEventListener('click', () => {
-            toggle3DPerspective();
-        });
-    }
 
     // KATI GÖSTER / BİNAYI GÖSTER TOGGLE BUTONU
     if (dom.bFloorView) {

--- a/index.html
+++ b/index.html
@@ -21,9 +21,8 @@
 
 
   <div id="viewing-mode-selector">
-    <button id="b3d" class="mode-btn btn btn-show-3d">Katı Model</button>
+    <button id="b3d" class="mode-btn btn btn-show-3d">3D</button>
     <button id="bIso" class="mode-btn btn btn-show-iso">İzometri</button>
-    <button id="b3DPerspective" class="mode-btn btn btn-show-3d-perspective">3D Görünüm</button>
   </div>
 
 


### PR DESCRIPTION
…eştir

Değişiklikler:
1. HTML:
   - "3D Görünüm" butonu kaldırıldı
   - "Katı Model" butonu "3D" olarak yeniden adlandırıldı

2. JavaScript (ui.js):
   - toggle3DView() güncellendi: Artık hem 3D panelini açıyor hem de 2D canvas'ı izometrik projeksiyona geçiriyor (is3DPerspectiveActive)
   - toggle3DPerspective() fonksiyonu kaldırıldı (artık gereksiz)
   - b3DPerspective event listener kaldırıldı

3. JavaScript (main.js):
   - dom.b3DPerspective referansı kaldırıldı

4. CSS:
   - .btn-show-3d-perspective ve ilgili tüm stiller kaldırıldı
   - viewing-mode-selector'dan .btn-show-3d-perspective referansı kaldırıldı
   - Light mode'daki .btn-show-3d-perspective stiller kaldırıldı

Sonuç:
- Kullanıcı "3D" butonuna tıkladığında hem 3D panel açılır hem de 2D görünüm izometrik projeksiyona geçer
- Daha basit ve sezgisel UI
- 97 satır kod temizlendi