### PR TITLE
fix: 3D butonuna basınca 2D ekranı normal tut, sadece 3D paneli aç

### DIFF
--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -222,9 +222,6 @@ export function toggle3DView() {
     if (dom.mainContainer.classList.contains('show-3d')) {
         setMode("select"); // 3D açılırken modu "select" yap
 
-        // 3D Perspektif modunu aktif et (2D canvas izometrik projeksiyon kullanacak)
-        setState({ is3DPerspectiveActive: true });
-
         // Split ratio butonlarını göster
         const splitButtons = document.getElementById('split-ratio-buttons');
         if (splitButtons) splitButtons.style.display = 'flex';
@@ -236,9 +233,6 @@ export function toggle3DView() {
         // Varsayılan split ratio'yu ayarla (25%)
         setSplitRatio(25);
     } else {
-        // 3D Perspektif modunu kapat (2D canvas normal görünüme dönecek)
-        setState({ is3DPerspectiveActive: false });
-
         // Split ratio butonlarını gizle
         const splitButtons = document.getElementById('split-ratio-buttons');
         if (splitButtons) splitButtons.style.display = 'none';


### PR DESCRIPTION
Değişiklik:
- toggle3DView()'dan is3DPerspectiveActive state değişiklikleri kaldırıldı
- 3D butonu artık sadece 3D paneli açıp kapatıyor
- 2D canvas normal görünümde kalıyor (izometrik projeksiyona geçmiyor)
- 3D panel'de 3D rendering yapılacak

Sonuç:
- 2D ekran yerinde duruyor (normal görünüm)
- 3D panel açılıyor ve orada 3D çizim gösteriliyor