### PR TITLE
feat: CTRL + mouse orta tuş ile 2D/3D görünüm geçişi

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -48,7 +48,17 @@ function markAllDownstreamPipesAsConnected(startPipe) {
 
 export function onPointerDown(e) {
     if (e.target !== dom.c2d) return; // Sadece canvas üzerindeki tıklamaları işle
-    if (e.button === 1) { // Orta tuş ile pan
+    if (e.button === 1) { // Orta tuş ile pan veya CTRL ile 2D/3D geçiş
+        // CTRL basılıysa 2D/3D geçiş modu
+        if (currentModifierKeys.ctrl) {
+            setState({
+                isCtrl3DToggling: true,
+                ctrl3DToggleStart: { x: e.clientX, y: e.clientY },
+                ctrl3DToggleMoved: false
+            });
+            return;
+        }
+        // CTRL basılı değilse normal pan
         setState({ isPanning: true, panStart: { x: e.clientX, y: e.clientY } });
         dom.p2d.classList.add('panning'); // Pan cursor'ı ekle
         return;


### PR DESCRIPTION
- CTRL + orta tuş tıklama: 2D ve 3D görünümler arasında geçiş yapar
- CTRL + orta tuş sürükleme: Kamerayı döndürerek 2D'den 3D'ye kademeli geçiş sağlar
- 3D'den 2D'ye geçerken kamera 0-5° arasında üstten bakışta ise otomatik olarak 0°'ye sabitlenir

Değişiklikler:
- pointer-down.js: CTRL + orta tuş algılaması eklendi
- pointer-move.js: Orbit kontrolü ile kamera rotasyonu eklendi
- pointer-up.js: Tıklama/sürükleme ayrımı ve görünüm geçişi eklendi