### PR TITLE
fix: Katı model açılmadan aynı sahne içinde kamera dönüşü

### DIFF
--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -195,14 +195,9 @@ export function onPointerMove(e) {
         // Eğer fare 5 pikselden fazla hareket ettiyse sürükleme olarak kabul et
         if (distance > 5 && !state.ctrl3DToggleMoved) {
             setState({ ctrl3DToggleMoved: true });
-
-            // 3D görünüm kapalıysa aç
-            if (!dom.mainContainer.classList.contains('show-3d')) {
-                toggle3DView();
-            }
         }
 
-        // Eğer sürükleme başladıysa kamerayı döndür
+        // Eğer sürükleme başladıysa kamerayı döndür (katı model AÇILMAZ, sadece kamera döner)
         if (state.ctrl3DToggleMoved && orbitControls && camera) {
             // movementX/Y kullan (fare hareketinin anlık deltası)
             const movementX = e.movementX || 0;

--- a/pointer/pointer-up.js
+++ b/pointer/pointer-up.js
@@ -15,15 +15,10 @@ export function onPointerUp(e) {
         return;
     }
 
-    // CTRL + Orta tuş ile 2D/3D geçiş
+    // CTRL + Orta tuş ile 2D/3D geçiş (aynı sahne içinde sadece kamera dönüşü)
     if (state.isCtrl3DToggling) {
         // Eğer sürükleme olmadıysa (sadece tıklama) -> 1 saniyelik animasyon
         if (!state.ctrl3DToggleMoved) {
-            // 3D görünüm kapalıysa aç
-            if (!dom.mainContainer.classList.contains('show-3d')) {
-                toggle3DView();
-            }
-
             if (camera && orbitControls) {
                 // Kameranın şu anki polar açısını al
                 const currentPolarAngle = orbitControls.getPolarAngle();
@@ -39,7 +34,7 @@ export function onPointerUp(e) {
                     targetPolarAngle = 0;
                 }
 
-                // 1 saniyelik animasyon
+                // 1 saniyelik animasyon (katı model AÇILMAZ, sadece kamera döner)
                 const duration = 1000; // ms
                 const startTime = Date.now();
                 const startPolarAngle = currentPolarAngle;


### PR DESCRIPTION
- toggle3DView() çağrıları kaldırıldı
- Artık katı model açılmaz, sadece kamera döner
- CTRL + orta tuş sürükleme: Kamerayı elle döndürme (2D ↔ 3D)
- CTRL + orta tuş tıklama: 1s animasyonla 2D ↔ 3D geçiş