### PR TITLE
fix: CTRL + orta tuş sürükleme artık çalışıyor

### DIFF
--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -54,8 +54,10 @@ export function onPointerDown(e) {
             setState({
                 isCtrl3DToggling: true,
                 ctrl3DToggleStart: { x: e.clientX, y: e.clientY },
+                ctrl3DToggleLastPos: { x: e.clientX, y: e.clientY }, // Son pozisyonu da kaydet
                 ctrl3DToggleMoved: false
             });
+            e.preventDefault(); // Varsayılan davranışı engelle
             return;
         }
         // CTRL basılı değilse normal pan

--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -198,17 +198,28 @@ export function onPointerMove(e) {
         }
 
         // Eğer sürükleme başladıysa kamerayı döndür (katı model AÇILMAZ, sadece kamera döner)
-        if (state.ctrl3DToggleMoved && orbitControls && camera) {
-            // movementX/Y kullan (fare hareketinin anlık deltası)
-            const movementX = e.movementX || 0;
-            const movementY = e.movementY || 0;
+        if (state.ctrl3DToggleMoved) {
+            if (!orbitControls || !camera) {
+                console.warn('OrbitControls veya camera henüz başlatılmadı');
+                return;
+            }
+
+            // Son pozisyonla şimdiki pozisyon arasındaki farkı hesapla
+            const deltaX = e.clientX - state.ctrl3DToggleLastPos.x;
+            const deltaY = e.clientY - state.ctrl3DToggleLastPos.y;
 
             const azimuthSpeed = 0.005;
             const polarSpeed = 0.005;
 
-            orbitControls.rotateLeft(movementX * azimuthSpeed);
-            orbitControls.rotateUp(-movementY * polarSpeed); // Negative: mouse down = camera rotates down
+            orbitControls.rotateLeft(deltaX * azimuthSpeed);
+            orbitControls.rotateUp(-deltaY * polarSpeed); // Negative: mouse down = camera rotates down
             orbitControls.update();
+
+            // 3D sahneyi güncelle (render et)
+            update3DScene();
+
+            // Son pozisyonu güncelle
+            setState({ ctrl3DToggleLastPos: { x: e.clientX, y: e.clientY } });
         }
 
         updateMouseCursor();

--- a/pointer/pointer-up.js
+++ b/pointer/pointer-up.js
@@ -6,6 +6,7 @@ import { wallExists } from '../wall/wall-handler.js'; // <-- YENİ
 import { plumbingManager } from '../plumbing_v2/plumbing-manager.js';
 import { toggle3DView } from '../general-files/ui.js';
 import { orbitControls, camera } from '../scene3d/scene3d-core.js';
+import { update3DScene } from '../scene3d/scene3d-update.js';
 import * as THREE from 'three';
 
 export function onPointerUp(e) {
@@ -52,6 +53,9 @@ export function onPointerUp(e) {
                     orbitControls.setPolarAngle(newPolarAngle);
                     orbitControls.update();
 
+                    // 3D sahneyi güncelle (render et)
+                    update3DScene();
+
                     if (progress < 1) {
                         requestAnimationFrame(animate);
                     }
@@ -66,6 +70,7 @@ export function onPointerUp(e) {
         setState({
             isCtrl3DToggling: false,
             ctrl3DToggleStart: null,
+            ctrl3DToggleLastPos: null,
             ctrl3DToggleMoved: false
         });
         return;


### PR DESCRIPTION
Sorunlar:
- movementX/Y sadece pointer lock ile çalışır, biz kullanmıyorduk
- Delta hesaplaması yanlıştı
- update3DScene() çağrılmıyordu, render olmuyordu

Çözümler:
- ctrl3DToggleLastPos state'i eklendi
- Her frame'de clientX/Y ile delta hesaplanıyor
- update3DScene() her rotasyondan sonra çağrılıyor
- preventDefault() eklendi
- Hata kontrolü eklendi

Artık CTRL + orta tuş SÜRÜKLEME ile:
- 2D'den 3D'ye yavaşça geçiş çalışıyor
- 3D'den 2D'ye geri dönüş çalışıyor
- Aynı sahne içinde sadece kamera dönüyor