### PR TITLE
fix: Katı model açılmadan aynı sahne içinde kamera dönüşü

### DIFF
--- a/draw/draw2d.js
+++ b/draw/draw2d.js
@@ -289,25 +289,25 @@ export function draw2D() {
     // But done correctly so mouse coordinates work properly
 
     if (state.is3DPerspectiveActive) {
-        // İzometrik projeksiyon: scene-isometric.js ile aynı formül
-        // isoX = (x + y) * cos(30°)
-        // isoY = (y - x) * sin(30°) - z
-        //
-        // Matrix formunda (z=0 için 2D elemanlar):
-        // x' = x * cos(30°) + y * cos(30°)
-        // y' = -x * sin(30°) + y * sin(30°)
+        // Kamera açılarına göre dinamik projeksiyon
+        const polarAngle = state.camera3DPolarAngle || (Math.PI / 6); // Varsayılan 30°
+        const azimuthalAngle = state.camera3DAzimuthalAngle || 0;
 
-        const angle = Math.PI / 6; // 30 derece
-        const cosAngle = Math.cos(angle); // ≈ 0.866
-        const sinAngle = Math.sin(angle); // = 0.5
+        // Polar açı: 0° = üstten, 90° = yandan
+        const verticalScale = Math.cos(polarAngle); // Perspektif etkisi
 
+        // Azimuthal açı: yatay dönüş
+        const cosAz = Math.cos(azimuthalAngle);
+        const sinAz = Math.sin(azimuthalAngle);
+
+        // Projeksiyon matrix
         ctx2d.setTransform(
-            dpr * zoom * cosAngle,      // a: X için X bileşeni
-            dpr * zoom * -sinAngle,     // b: X için Y bileşeni
-            dpr * zoom * cosAngle,      // c: Y için X bileşeni
-            dpr * zoom * sinAngle,      // d: Y için Y bileşeni
-            dpr * panOffset.x,          // e: X offset
-            dpr * panOffset.y           // f: Y offset
+            dpr * zoom * cosAz,                    // X rotasyonu
+            dpr * zoom * sinAz,                    // Y rotasyonu
+            dpr * zoom * -sinAz * verticalScale,   // Perspektifli X
+            dpr * zoom * cosAz * verticalScale,    // Perspektifli Y
+            dpr * panOffset.x,
+            dpr * panOffset.y
         );
     } else {
         // Normal 2D görünüm

--- a/pointer/pointer-down.js
+++ b/pointer/pointer-down.js
@@ -49,15 +49,20 @@ function markAllDownstreamPipesAsConnected(startPipe) {
 export function onPointerDown(e) {
     if (e.target !== dom.c2d) return; // Sadece canvas üzerindeki tıklamaları işle
     if (e.button === 1) { // Orta tuş ile pan veya CTRL ile 2D/3D geçiş
-        // CTRL basılıysa 2D/3D geçiş modu
+        // CTRL basılıysa 2D/3D geçiş modu (AYNI SAHNE İÇİNDE!)
         if (currentModifierKeys.ctrl) {
+            // is3DPerspectiveActive'i aç (2D canvas'ta perspektif için)
+            if (!state.is3DPerspectiveActive) {
+                setState({ is3DPerspectiveActive: true });
+            }
+
             setState({
                 isCtrl3DToggling: true,
                 ctrl3DToggleStart: { x: e.clientX, y: e.clientY },
                 ctrl3DToggleLastPos: { x: e.clientX, y: e.clientY },
                 ctrl3DToggleMoved: false
             });
-            e.preventDefault();
+            // e.preventDefault() KALDIRILDI - mouse event'leri bloklamıyor
             return;
         }
         // CTRL basılı değilse normal pan

--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -186,7 +186,7 @@ export function onPointerMove(e) {
     }
     // --- Yeni Tesisat Sistemi Sonu ---
 
-    // CTRL + Orta tuş ile 2D/3D geçiş
+    // CTRL + Orta tuş ile 2D/3D geçiş (AYNI SAHNE İÇİNDE, KATI MODEL AÇILMAZ!)
     if (state.isCtrl3DToggling) {
         const deltaX = e.clientX - state.ctrl3DToggleStart.x;
         const deltaY = e.clientY - state.ctrl3DToggleStart.y;
@@ -195,20 +195,10 @@ export function onPointerMove(e) {
         // Eğer fare 5 pikselden fazla hareket ettiyse sürükleme olarak kabul et
         if (distance > 5 && !state.ctrl3DToggleMoved) {
             setState({ ctrl3DToggleMoved: true });
-
-            // 3D panel kapalıysa aç
-            if (!dom.mainContainer.classList.contains('show-3d')) {
-                toggle3DView();
-            }
         }
 
-        // Eğer sürükleme başladıysa ve 3D panel açıksa kamerayı döndür
-        if (state.ctrl3DToggleMoved && dom.mainContainer.classList.contains('show-3d')) {
-            if (!orbitControls || !camera) {
-                console.warn('OrbitControls veya camera henüz başlatılmadı');
-                return;
-            }
-
+        // Eğer sürükleme başladıysa kamerayı döndür
+        if (state.ctrl3DToggleMoved && orbitControls && camera) {
             // Son pozisyonla şimdiki pozisyon arasındaki farkı hesapla
             const deltaX = e.clientX - state.ctrl3DToggleLastPos.x;
             const deltaY = e.clientY - state.ctrl3DToggleLastPos.y;
@@ -220,15 +210,17 @@ export function onPointerMove(e) {
             orbitControls.rotateUp(-deltaY * polarSpeed);
             orbitControls.update();
 
-            // 3D sahneyi güncelle (render et)
-            update3DScene();
-
-            // Son pozisyonu güncelle
-            setState({ ctrl3DToggleLastPos: { x: e.clientX, y: e.clientY } });
+            // Kamera açılarını state'e kaydet
+            setState({
+                camera3DPolarAngle: orbitControls.getPolarAngle(),
+                camera3DAzimuthalAngle: orbitControls.getAzimuthalAngle(),
+                ctrl3DToggleLastPos: { x: e.clientX, y: e.clientY }
+            });
         }
 
-        updateMouseCursor();
-        return;
+        // Mouse event'leri bloklama, normal akışa devam et
+        // updateMouseCursor();
+        // return; KALDIRILDI - diğer event'lerin de çalışmasına izin ver
     }
 
     // Oda ismi sürükleme


### PR DESCRIPTION
SORUN: toggle3DView() katı modeli açıyordu, ama kullanıcı bunu istemiyor!

ÇÖZÜM:
1. toggle3DView() çağrıları TAMAMEN KALDIRILDI
2. is3DPerspectiveActive kullanarak 2D canvas'ta perspektif
3. e.preventDefault() KALDIRILDI - mouse event'leri bloklamıyor
4. return KALDIRILDI pointer-move'dan - diğer event'ler de çalışabilir

CTRL + orta tuş TIKLAMA:
- 1s animasyonla kamera 2D (0°) ↔ 3D (60°) geçiş
- is3DPerspectiveActive açılır/kapanır
- Kamera açıları state'e kaydedilir

CTRL + orta tuş SÜRÜKLEME:
- Kamerayı döndürür (orbitControls)
- Kamera açıları state'e kaydedilir
- 2D canvas kamera açısına göre render edilir

draw2D.js:
- Kamera açılarını kullanarak dinamik projeksiyon
- Polar açı: perspektif etkisi
- Azimuthal açı: yatay dönüş