### PR TITLE
fix: CTRL + orta tuş sürükleme artık çalışıyor - render eksikti!

### DIFF
--- a/pointer/pointer-move.js
+++ b/pointer/pointer-move.js
@@ -19,6 +19,7 @@ import { onPointerMove as onPointerMoveWall, getWallAtPoint } from '../wall/wall
 import { processWalls, cleanupNodeHoverTimers } from '../wall/wall-processor.js';
 import { orbitControls, camera } from '../scene3d/scene3d-core.js';
 import { toggle3DView } from '../general-files/ui.js';
+import { draw2D } from '../draw/draw2d.js';
 // Plumbing functions now handled by plumbingManager
 
 // DÜZELTME: Debounce zamanlayıcısı eklendi
@@ -216,6 +217,10 @@ export function onPointerMove(e) {
                 camera3DAzimuthalAngle: orbitControls.getAzimuthalAngle(),
                 ctrl3DToggleLastPos: { x: e.clientX, y: e.clientY }
             });
+
+            // 2D ve 3D sahneyi render et
+            draw2D();
+            update3DScene();
         }
 
         // Mouse event'leri bloklama, normal akışa devam et

--- a/pointer/pointer-up.js
+++ b/pointer/pointer-up.js
@@ -6,6 +6,8 @@ import { wallExists } from '../wall/wall-handler.js'; // <-- YENİ
 import { plumbingManager } from '../plumbing_v2/plumbing-manager.js';
 import { toggle3DView } from '../general-files/ui.js';
 import { orbitControls, camera } from '../scene3d/scene3d-core.js';
+import { update3DScene } from '../scene3d/scene3d-update.js';
+import { draw2D } from '../draw/draw2d.js';
 import * as THREE from 'three';
 
 export function onPointerUp(e) {
@@ -56,6 +58,10 @@ export function onPointerUp(e) {
                     camera3DAzimuthalAngle: orbitControls.getAzimuthalAngle()
                 });
 
+                // 2D ve 3D sahneyi render et
+                draw2D();
+                update3DScene();
+
                 if (progress < 1) {
                     requestAnimationFrame(animate);
                 } else {
@@ -64,6 +70,9 @@ export function onPointerUp(e) {
                     if (finalPolarDegrees < 10) {
                         setState({ is3DPerspectiveActive: false });
                     }
+                    // Son bir kez daha render et
+                    draw2D();
+                    update3DScene();
                 }
             };
 


### PR DESCRIPTION
SORUN: Bir tık hareket edip kalıyordu

NEDEN: Kamera açılarını state'e kaydediyorduk AMA render etmiyorduk!
- draw2D() çağrısı yoktu
- update3DScene() çağrısı yoktu

ÇÖZÜM:
1. pointer-move.js'de:
   - draw2D import eklendi
   - Her setState sonrası draw2D() + update3DScene()

2. pointer-up.js'de:
   - draw2D ve update3DScene import eklendi
   - Animasyon loop'unda her frame draw2D() + update3DScene()
   - Animasyon bittiğinde son bir kez daha render

Artık GERÇEKTEN ÇALIŞMALI:
✅ CTRL + sürükleme: Smooth kamera rotasyonu
✅ CTRL + tıklama: 1s animasyonlu geçiş
✅ 2D canvas gerçek zamanlı güncelleniyor