### PR TITLE
fix: 2D→3D animasyonu için viewBlendFactor başlangıç değeri

### DIFF
--- a/general-files/ui.js
+++ b/general-files/ui.js
@@ -303,6 +303,7 @@ export function toggle3DPerspective() {
     const targetIsActive = !state.is3DPerspectiveActive;
 
     console.log(`[Double CTRL] Geçiş Başlıyor: ${targetIsActive ? '2D -> 3D' : '3D -> 2D'}`);
+    console.log(`[Double CTRL] Başlangıç viewBlendFactor: ${state.viewBlendFactor}, is3DActive: ${state.is3DPerspectiveActive}`);
 
     // Animasyon Hedefleri
     const targetBlend = targetIsActive ? 1 : 0; // 3D için 1, 2D için 0
@@ -311,9 +312,9 @@ export function toggle3DPerspective() {
     // Orbit kontrolleri kilitle (çatışmayı önlemek için)
     if(orbitControls) orbitControls.enabled = false;
 
-    // Animasyon Objesi
+    // Animasyon Objesi - viewBlendFactor'den başla (0 da geçerli bir değer!)
     const animObj = {
-        blend: state.viewBlendFactor || (targetIsActive ? 0 : 1),
+        blend: (typeof state.viewBlendFactor === 'number') ? state.viewBlendFactor : (targetIsActive ? 0 : 1),
         angle: orbitControls ? orbitControls.getPolarAngle() : 0
     };
 
@@ -331,6 +332,11 @@ export function toggle3DPerspective() {
         onUpdate: () => {
             // 1. 2D Çizim Değişkenini Güncelle
             state.viewBlendFactor = animObj.blend;
+
+            // Debug: Her 10 frame'de bir log
+            if (Math.random() < 0.1) {
+                console.log(`[Anim] blend: ${animObj.blend.toFixed(3)}, angle: ${animObj.angle.toFixed(3)}`);
+            }
 
             // 2. 3D Kamerayı Güncelle
             if (camera && orbitControls) {


### PR DESCRIPTION
2D→3D geçişinde animasyon çalışmıyordu çünkü:
- state.viewBlendFactor = 0 olduğunda
- animObj.blend = state.viewBlendFactor || (...) ifadesi
- JavaScript'te 0 falsy olduğu için || sağ tarafa geçiyordu

Düzeltme:
- typeof kontrolü ile 0'ı da geçerli değer olarak kabul et
- Debug log'lar ekle animasyon değerlerini görmek için