### PR TITLE
Kapama sembolü görsel ve sürükleme iyileştirmeleri

### DIFF
--- a/plumbing_v2/objects/valve.js
+++ b/plumbing_v2/objects/valve.js
@@ -417,9 +417,28 @@ export class Vana {
         this.y = newPos.y;
         this.rotation = pipe.aciDerece;
 
-        // fixedDistance'ı temizle (artık serbest hareket ediyor)
-        this.fixedDistance = null;
-        this.fromEnd = null;
+        // Boru ucuna yakınsa fromEnd ve fixedDistance'ı tekrar set et
+        const END_THRESHOLD_CM = 10; // 10 cm içindeyse uç sayılır
+        const VANA_GENISLIGI = 8;
+        const BORU_UCU_BOSLUK = 1;
+        const fixedDistanceFromEnd = VANA_GENISLIGI / 2 + BORU_UCU_BOSLUK; // 5 cm
+
+        const distToP1 = newT * pipeLength;
+        const distToP2 = (1 - newT) * pipeLength;
+
+        if (distToP2 < END_THRESHOLD_CM) {
+            // p2 ucuna yakın
+            this.fromEnd = 'p2';
+            this.fixedDistance = fixedDistanceFromEnd;
+        } else if (distToP1 < END_THRESHOLD_CM) {
+            // p1 ucuna yakın
+            this.fromEnd = 'p1';
+            this.fixedDistance = fixedDistanceFromEnd;
+        } else {
+            // Ortada, serbest
+            this.fixedDistance = null;
+            this.fromEnd = null;
+        }
 
         // Not: updateEndCapStatus burada çağrılmaz çünkü manager'a erişimimiz yok
         // Drag işleminden sonra çağrılmalı

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -1441,9 +1441,9 @@ export class PlumbingRenderer {
             ctx.shadowBlur = 0;
 
             // Kapama pozisyonu: vananın sağ tarafı (çıkış)
-            const capX = halfSize + 1; // 1 cm boşluk
-            const capWidth = 3; // cm
-            const capHeight = 5; // cm
+            const capX = halfSize + 0.5; // 0.5 cm boşluk
+            const capWidth = 1.5; // cm - daha ince
+            const capHeight = size + 2; // cm - vanadan 2cm daha geniş (daha görünür)
 
             // Boruyla aynı renkte kapama çiz
             // Palette'in ilk rengini kullan (beyaz hariç, sonraki renk)


### PR DESCRIPTION
🎨 Görsel İyileştirmeler:
- Kapama sembolü daha ince yapıldı (3cm -> 1.5cm genişlik)
- Kapama sembolü daha geniş yapıldı (5cm -> 11.6cm yükseklik, vanadan 2cm daha uzun)
- Daha belirgin ve görünür

🔧 Sürükleme Davranışı Düzeltildi:
- Vana boru ucuna sürüklendiğinde artık kapama sembolü tekrar görünür
- 10cm eşik mesafesi: Boru ucuna 10cm içindeyse fromEnd ve fixedDistance otomatik set edilir
- Vana ortaya sürüklendiğinde kapama kaybolur (serbest mod)
- Vana tekrar uca sürüklendiğinde kapama geri gelir

📝 Teknik:
- moveAlongPipe() metoduna akıllı uç algılama eklendi
- P1 veya P2'ye yakınsa (10cm) fromEnd otomatik set edilir
- fixedDistance her zaman 5cm (vana genişliği/2 + 1cm)