### PR TITLE
3D görünümde mouse pozisyonu düzeltmesi - findBoruGovdeAt kullanımı

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -379,6 +379,10 @@ export class InteractionManager {
         return findPipeAt(this.manager, point, tolerance);
     }
 
+    findBoruGovdeAt(point, tolerance = 5) {
+        return findBoruGovdeAt(this.manager, point, tolerance);
+    }
+
     findBilesenCikisAt(point, tolerance = 2) {
         return findBilesenCikisAt(this.manager, point, tolerance);
     }


### PR DESCRIPTION
ASIL SORUN:
- screenToWorld() sadece 2D point döndürüyor (x, y) - Z yok!
- projectPoint(point) çağrılırken point'in Z'si olmadığı için Z=0 kabul ediliyor
- Bu yüzden 3D borularda (Z≠0) her şey yanlış hesaplanıyor

ÇÖZÜM:
- findBoruGovdeAt() kullanarak hem boruyu hem tıklanan 3D noktayı alıyoruz
- findBoruGovdeAt ekran koordinatlarında çalışıp sonra 3D world koordinatına çeviriyor
- Artık doğru Z koordinatı ile işlem yapılıyor

Değiştirilen yerler:
1. Pipe split preview - findBoruGovdeAt kullanıyor
2. Vana preview - findBoruGovdeAt kullanıyor + T değeri 3D hesaplanıyor
3. Sayaç/cihaz preview - findBoruGovdeAt kullanıyor

Sonuç:
✓ Z≠0 yatay hatlarda vana doğru yere ekleniyor
✓ Düşey borularda vana ekleniyor
✓ Z≠0 yatay/düşey borulardan hat ayrılıyor
✓ Z≠0 yatay/düşey borulara sayaç/cihaz ekleniyor