### PR TITLE
Sayaç/cihaz ghost connection tolerance azaltıldı (boru ortasına eklem…

### DIFF
--- a/plumbing_v2/interactions/ghost-updater.js
+++ b/plumbing_v2/interactions/ghost-updater.js
@@ -23,7 +23,8 @@ export function updateGhostPosition(ghost, point, snap) {
     // Cihaz için: boru ucuna snap yap, fleks etrafında mouse ile hareket et
     if (ghost.type === 'cihaz') {
         // En yakın SERBEST boru ucunu bul (T-junction'ları atla)
-        const boruUcu = this.findBoruUcuAt(point, 72, true); // onlyFreeEndpoints = true
+        // DÜZELTME: Tolerance 72 → 15 (boru ortasına ekleme için)
+        const boruUcu = this.findBoruUcuAt(point, 15, true); // onlyFreeEndpoints = true
 
         if (boruUcu && boruUcu.boru) {
             // Cihaz rotation'u sabit - tutamacı her zaman kuzeyde
@@ -134,7 +135,8 @@ export function updateGhostPosition(ghost, point, snap) {
         }
     }
     else if (ghost.type === 'sayac') {
-        const boruUcu = this.findBoruUcuAt(point, 72, true);
+        // DÜZELTME: Tolerance 72 → 15 (boru ortasına ekleme için)
+        const boruUcu = this.findBoruUcuAt(point, 15, true);
 
         if (boruUcu && boruUcu.boru) {
             const boru = boruUcu.boru;


### PR DESCRIPTION
…e için)

SORUN:
- Sayaç/cihaz eklenemiyor (boru ortasına)
- Ghost connection tolerance çok büyük (72 cm)
- Hemen hemen her yerde boru ucuna snap yapıyor
- ghostConnectionInfo aktif olduğunda boru ortasına ekleme preview'ı gösterilmiyor

ÇÖZÜM:
- Tolerance 72 → 15 cm
- Artık sadece gerçekten boru ucuna çok yakın olduğunda snap yapıyor
- Boru ortasında iken componentOnPipePreview gösteriliyor

SONUÇ:
✓ Sayaç/cihaz boru ortasına eklenebilir
✓ Boru ucuna ekleme hala çalışıyor (15 cm içinde)