### PR TITLE
2D sahnede düşey hareket ve preview düzeltmeleri

### DIFF
--- a/plumbing_v2/interactions/pipe-drawing.js
+++ b/plumbing_v2/interactions/pipe-drawing.js
@@ -362,44 +362,50 @@ export function applyMeasurement(interactionManager) {
             return;
         }
 
-        // DEĞİŞİKLİK: 3D Vektör Hesabı
         const startPt = interactionManager.boruBaslangic.nokta;
         const startZ = startPt.z || 0;
 
-        // Hedef nokta, handlePointerMove içinde hesaplanan geçici nokta (mouse yönü)
-        let targetPt = interactionManager.geciciBoruBitis;
+        // View mode kontrolü: 2D mi 3D mi?
+        const t = state.viewBlendFactor || 0;
+        const is3DMode = t >= 0.5;
 
-        if (!targetPt) {
-            // Eğer fare hiç hareket etmediyse varsayılan olarak Z ekseninde ekle (düşey)
-            targetPt = { x: startPt.x, y: startPt.y, z: startZ + height };
-        } else {
-            const dx = targetPt.x - startPt.x;
-            const dy = targetPt.y - startPt.y;
-            const dz = (targetPt.z || 0) - startZ;
+        let targetPt;
 
-            // 3D uzunluk hesapla
-            const currentLength = Math.hypot(dx, dy, dz);
+        if (is3DMode) {
+            // 3D MODDA: Mouse'un baktığı yöne göre uzat (mevcut davranış)
+            targetPt = interactionManager.geciciBoruBitis;
 
-            if (currentLength > 0.001) {
-                const factor = height / currentLength;
-                targetPt = {
-                    x: startPt.x + dx * factor,
-                    y: startPt.y + dy * factor,
-                    z: startZ + dz * factor
-                };
-            } else {
-                // Yön yoksa Z+ varsay (düşey)
+            if (!targetPt) {
+                // Eğer fare hiç hareket etmediyse varsayılan olarak Z ekseninde ekle (düşey)
                 targetPt = { x: startPt.x, y: startPt.y, z: startZ + height };
-            }
-        }
+            } else {
+                const dx = targetPt.x - startPt.x;
+                const dy = targetPt.y - startPt.y;
+                const dz = (targetPt.z || 0) - startZ;
 
-        // // Düşey boru oluştur
-        // const startPoint = interactionManager.boruBaslangic.nokta;
-        // const endPoint = {
-        //     x: startPoint.x,
-        //     y: startPoint.y,
-        //     z: (startPoint.z || 0) + height
-        // };
+                // 3D uzunluk hesapla
+                const currentLength = Math.hypot(dx, dy, dz);
+
+                if (currentLength > 0.001) {
+                    const factor = height / currentLength;
+                    targetPt = {
+                        x: startPt.x + dx * factor,
+                        y: startPt.y + dy * factor,
+                        z: startZ + dz * factor
+                    };
+                } else {
+                    // Yön yoksa Z+ varsay (düşey)
+                    targetPt = { x: startPt.x, y: startPt.y, z: startZ + height };
+                }
+            }
+        } else {
+            // 2D MODDA: Sadece Y ekseninde (düşey) hareket ettir
+            targetPt = {
+                x: startPt.x,
+                y: startPt.y + height,
+                z: startZ
+            };
+        }
 
         handleBoruClick(interactionManager, targetPt);
         interactionManager.measurementInput = '';

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -2692,10 +2692,12 @@ export class PlumbingRenderer {
         const { point } = preview;
         const zoom = state.zoom || 1;
 
-        // 3D offset uygula
+        // 3D offset sadece 3D modunda uygula
+        const t = state.viewBlendFactor || 0;
+        const is3DMode = t >= 0.5;
         const z = point.z || 0;
-        const screenX = point.x + z;
-        const screenY = point.y - z;
+        const screenX = is3DMode ? (point.x + z) : point.x;
+        const screenY = is3DMode ? (point.y - z) : point.y;
 
         ctx.save();
 
@@ -2734,10 +2736,12 @@ export class PlumbingRenderer {
         const size = 8;
         const halfSize = size / 2;
 
-        // 3D offset uygula
+        // 3D offset sadece 3D modunda uygula
+        const t = state.viewBlendFactor || 0;
+        const is3DMode = t >= 0.5;
         const z = point.z || 0;
-        const adjustedX = point.x + z;
-        const adjustedY = point.y - z;
+        const adjustedX = is3DMode ? (point.x + z) : point.x;
+        const adjustedY = is3DMode ? (point.y - z) : point.y;
 
         ctx.save();
         ctx.translate(adjustedX, adjustedY);
@@ -2770,10 +2774,12 @@ export class PlumbingRenderer {
         const { point, componentType } = preview;
         const zoom = state.zoom || 1;
 
-        // 3D offset uygula
+        // 3D offset sadece 3D modunda uygula
+        const t = state.viewBlendFactor || 0;
+        const is3DMode = t >= 0.5;
         const z = point.z || 0;
-        const screenX = point.x + z;
-        const screenY = point.y - z;
+        const screenX = is3DMode ? (point.x + z) : point.x;
+        const screenY = is3DMode ? (point.y - z) : point.y;
 
         ctx.save();
 


### PR DESCRIPTION
SORUN:
- 3D sahne için yapılan "baktığı yöne göre uzat" mantığı 2D'de de çalışıyordu
- 2D sahnede +200/-100 gibi değerler fare yönüne göre uzatıyordu
- Preview'lerdeki 3D offset'ler 2D'de de uygulanıyordu
- 2D'de yukarı (Y ekseni) hareket edemiyorduk

ÇÖZÜM:
1. pipe-drawing.js: applyMeasurement fonksiyonunda view mode kontrolü
   - 3D modda (viewBlendFactor >= 0.5): Fare yönüne göre uzat (mevcut davranış)
   - 2D modda (viewBlendFactor < 0.5): Sadece Y ekseninde (düşey) hareket ettir

2. plumbing-renderer.js: Preview fonksiyonlarında 3D offset kontrolü
   - drawPipeSplitPreview: 3D offset sadece 3D modunda
   - drawVanaPreview: 3D offset sadece 3D modunda
   - drawComponentOnPipePreview: 3D offset sadece 3D modunda

SONUÇ:
✓ 3D sahnede fare yönüne göre uzatma çalışıyor (değişmedi) ✓ 2D sahnede +200/-100 değerleri sadece Y ekseninde hareket ettiriyor ✓ Preview'ler 2D'de doğru konumda gösteriliyor
✓ 2D'de yukarı/aşağı (düşey) hareket artık mümkün