### PR TITLE
3D görünümde boru bağlantı noktalarına yükseklik etiketleri eklendi

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -12,7 +12,7 @@ import { fitDrawingToScreen } from '../draw/zoom.js';
 // --- DEĞİŞİKLİK BURADA ---
 import { updateFirstPersonCamera, setupFirstPersonMouseControls, isFPSMode } from '../scene3d/scene3d-camera.js';
 import { update3DScene } from '../scene3d/scene3d-update.js';
-import { init3D, renderer as renderer3d, camera as camera3d, controls as controls3d, scene as scene3d } from '../scene3d/scene3d-core.js';
+import { init3D, renderer as renderer3d, camera as camera3d, controls as controls3d, scene as scene3d, labelRenderer } from '../scene3d/scene3d-core.js';
 // --- DEĞİŞİKLİK SONU ---
 import { createWallPanel } from '../wall/wall-panel.js';
 import { createFloorPanel, showFloorPanel, renderMiniPanel } from '../floor/floor-panel.js';
@@ -897,6 +897,11 @@ export function resize() {
         camera3d.updateProjectionMatrix();
         renderer3d.setPixelRatio(window.devicePixelRatio);
         renderer3d.setSize(r3d.width, r3d.height);
+
+        // CSS2DRenderer boyutunu güncelle
+        if (labelRenderer) {
+            labelRenderer.setSize(r3d.width, r3d.height);
+        }
     }
 
     // İzometrik canvas'ı resize et
@@ -986,6 +991,11 @@ function animate() {
         }
 
         renderer3d.render(scene3d, camera3d);
+
+        // CSS2DRenderer ile yükseklik etiketlerini render et
+        if (labelRenderer) {
+            labelRenderer.render(scene3d, camera3d);
+        }
     }
 
     // İzometrik görünümü çiz

--- a/scene3d/scene3d-core.js
+++ b/scene3d/scene3d-core.js
@@ -4,6 +4,8 @@
 import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { PointerLockControls } from "three/addons/controls/PointerLockControls.js";
+import { CSS2DRenderer, CSS2DObject as CSS2DObjectClass } from "three/addons/renderers/CSS2DRenderer.js";
+export { CSS2DObjectClass as CSS2DObject }; // Diğer dosyalarda kullanmak için export et
 import { state, WALL_HEIGHT, dom, setState } from "../general-files/main.js"; // <-- setState eklendi
 
 // --- Global Değişkenler ---
@@ -12,6 +14,7 @@ export let orbitControls, pointerLockControls;
 export let cameraMode = 'orbit'; // 'orbit' veya 'firstPerson'
 export let sceneObjects;
 export let textureLoader; // <-- Resim çerçeveleri için eklendi
+export let labelRenderer; // <-- Yükseklik etiketleri için CSS2DRenderer
 
 // --- Malzemeler (Materials) ---
 export let wallMaterial, doorMaterial, windowMaterial, columnMaterial, beamMaterial,
@@ -298,6 +301,21 @@ export function init3D(canvasElement) {
         opacity: solidOpacity, // solidOpacity'yi init3D içinden alır
         side: THREE.DoubleSide
     });
+
+    // CSS2DRenderer'ı başlat (yükseklik etiketleri için)
+    labelRenderer = new CSS2DRenderer();
+    labelRenderer.setSize(1, 1); // Başlangıçta boyutlandırılacak
+    labelRenderer.domElement.style.position = 'absolute';
+    labelRenderer.domElement.style.top = '0';
+    labelRenderer.domElement.style.left = '0';
+    labelRenderer.domElement.style.pointerEvents = 'none'; // Mouse olaylarını engelleme
+
+    // Canvas'ın parent container'ına ekle
+    const container = canvasElement.parentElement;
+    if (container) {
+        container.appendChild(labelRenderer.domElement);
+        container.style.position = 'relative'; // Absolute pozisyonlama için gerekli
+    }
 }
 
 /**


### PR DESCRIPTION
CSS2DRenderer ile 3D sahnede boru dirsek ve TEE noktalarında h:120 formatında yükseklik etiketleri gösteriliyor. İzometrik görünümdeki etiketlerle aynı mantık kullanıldı.

Değişiklikler:
- CSS2DRenderer import ve kurulumu (scene3d-core.js)
- labelRenderer render ve resize işlemleri (main.js)
- addPipeElevationLabels fonksiyonu ile etiket oluşturma (scene3d-update.js)
- Zemin seviyesi (z≈0) etiket göstermiyor
- En az 2 bağlantı olan noktalar (dirsek/TEE) işaretleniyor