### PR TITLE
3D görünüm Z koordinat sorunları düzeltildi

### DIFF
--- a/plumbing_v2/interactions/finders.js
+++ b/plumbing_v2/interactions/finders.js
@@ -10,15 +10,16 @@ import { TESISAT_CONSTANTS } from './tesisat-snap.js';
 
 /**
  * 3D Görünüm için Ekran Koordinatı Hesaplayıcı
- * Renderer'daki mantığın aynısını kullanır: (x+z, y-z)
+ * Renderer'daki mantığın aynısını kullanır: (x+z*t, y-z*t)
  */
 function getScreenPoint(point) {
     if (!state.is3DPerspectiveActive) return { x: point.x, y: point.y };
     // Z değeri yoksa 0 kabul et
     const z = point.z || 0;
+    const t = state.viewBlendFactor || 0;
     return {
-        x: point.x + z,
-        y: point.y - z
+        x: point.x + (z * t),
+        y: point.y - (z * t)
     };
 }
 

--- a/pointer/handle-pointer-move.js
+++ b/pointer/handle-pointer-move.js
@@ -36,7 +36,14 @@ export function handlePointerMove(e) {
     }
 
     // Snap hesapla
+    // 3D modda boru çizim sırasında endpoint snap'i devre dışı bırak
+    const t = state.viewBlendFactor || 0;
+    const is3DMode = t > 0.5;
+
     if (this.isDragging && this.dragObject && this.dragObject.type === 'servis_kutusu') {
+        this.activeSnap = null;
+    } else if (this.boruCizimAktif && is3DMode) {
+        // 3D modda boru çizerken endpoint snap kullanma
         this.activeSnap = null;
     } else {
         this.activeSnap = this.snapSystem.getSnapPoint(point, walls);


### PR DESCRIPTION
Düzeltilen sorunlar:

1. 3D görünümde hattın ucuna cihaz ve sayaç eklenebilir
   - finders.js getScreenPoint fonksiyonu viewBlendFactor (t) kullanıyor
   - Ekran koordinatları doğru hesaplanıyor: x' = x + z*t, y' = y - z*t

2. 3D çizim yaparken Y yönü snap offset sorunu
   - handle-pointer-move.js: 3D modda (t > 0.5) endpoint snap devre dışı
   - Sadece eksen snap'i (X, Y, Z) aktif kalıyor

3. Boru seviyesinde etiket gösterimi
   - drawPipeLabelsOnly fonksiyonu 3D izdüşüm kullanıyor
   - Etiketler artık gölge yerine boru seviyesinde görünüyor

4. Boru bölme preview 3D doğru konumda
   - drawPipeSplitPreview ve drawComponentOnPipePreview viewBlendFactor kullanıyor
   - Preview doğru Z ofsetinde görünüyor