### PR TITLE
3D sahnede cihaz/sayaç ekleme ve baca Z koordinatı sorunları düzeltildi

### DIFF
--- a/plumbing_v2/interactions/component-placement.js
+++ b/plumbing_v2/interactions/component-placement.js
@@ -165,13 +165,16 @@ export function placeComponent(point) {
                                 const snappedAngleRad = snappedAngle * Math.PI / 180;
                                 snappedPoint = {
                                     x: component.currentSegmentStart.x + distance * Math.cos(snappedAngleRad),
-                                    y: component.currentSegmentStart.y + distance * Math.sin(snappedAngleRad)
+                                    y: component.currentSegmentStart.y + distance * Math.sin(snappedAngleRad),
+                                    z: component.currentSegmentStart.z || component.z || 0 // Z koordinatını koru
                                 };
                             }
                         }
                     }
 
-                    const success = component.addSegment(snappedPoint.x, snappedPoint.y);
+                    // Z koordinatını garanti et
+                    const segmentZ = snappedPoint.z !== undefined ? snappedPoint.z : (component.z || 0);
+                    const success = component.addSegment(snappedPoint.x, snappedPoint.y, segmentZ);
                     if (success) {
                         this.manager.saveToState();
                         // tempComponent'i tutuyoruz - çizim devam edecek
@@ -596,20 +599,19 @@ export function handleCihazEkleme(cihaz) {
     // Baca gerektiren cihazlar için otomatik baca oluştur
     if (cihaz.bacaGerekliMi()) {
         // Baca oluştur - cihaz merkezinden başlayarak sağa doğru 100cm
+        const cihazZ = cihaz.z || 0;
         const baca = createBaca(cihaz.x, cihaz.y, cihaz.id, {
-            floorId: cihaz.floorId
+            floorId: cihaz.floorId,
+            z: cihazZ // Z değerini options'a ekle
         });
-        baca.z = cihaz.z || 0;
-        // İlk segment: Sağa doğru 100cm (1m)
-        // Segment noktalarına da Z eklemek gerekebilir, ancak baca genellikle
-        // 2D düzlemde (XY) çizilip Z'si tüm baca için sabit tutulur.
-        // Eğer segment noktaları 3D ise, onlara da z eklenmeli.
+
+        // İlk segment: Sağa doğru 100cm (1m) - Z koordinatıyla birlikte
         const ilkSegmentBitis = {
             x: cihaz.x + 100, // 1m = 100cm
             y: cihaz.y,
-            z: cihaz.z || 0 // Z değerini ekle
+            z: cihazZ // Z değerini ekle
         };
-        baca.addSegment(ilkSegmentBitis.x, ilkSegmentBitis.y); // addSegment fonksiyonu Z destekliyorsa
+        baca.addSegment(ilkSegmentBitis.x, ilkSegmentBitis.y, ilkSegmentBitis.z);
 
         // Çizimi bitir - böylece baca seçilebilir ve düzenlenebilir olur
         baca.finishDrawing();

--- a/plumbing_v2/interactions/ghost-updater.js
+++ b/plumbing_v2/interactions/ghost-updater.js
@@ -23,8 +23,10 @@ export function updateGhostPosition(ghost, point, snap) {
     // Cihaz için: boru ucuna snap yap, fleks etrafında mouse ile hareket et
     if (ghost.type === 'cihaz') {
         // En yakın SERBEST boru ucunu bul (T-junction'ları atla)
-        // DÜZELTME: Tolerance 72 → 15 (boru ortasına ekleme için)
-        const boruUcu = this.findBoruUcuAt(point, 15, true); // onlyFreeEndpoints = true
+        // 3D modda tolerance artır (Z kaymasını hesaba kat)
+        const baseTolerance = 15;
+        const tolerance3D = t > 0.5 ? baseTolerance + (100 * t) : baseTolerance;
+        const boruUcu = this.findBoruUcuAt(point, tolerance3D, true); // onlyFreeEndpoints = true
 
         if (boruUcu && boruUcu.boru) {
             // Cihaz rotation'u sabit - tutamacı her zaman kuzeyde
@@ -135,8 +137,10 @@ export function updateGhostPosition(ghost, point, snap) {
         }
     }
     else if (ghost.type === 'sayac') {
-        // DÜZELTME: Tolerance 72 → 15 (boru ortasına ekleme için)
-        const boruUcu = this.findBoruUcuAt(point, 15, true);
+        // 3D modda tolerance artır (Z kaymasını hesaba kat)
+        const baseTolerance = 15;
+        const tolerance3D = t > 0.5 ? baseTolerance + (100 * t) : baseTolerance;
+        const boruUcu = this.findBoruUcuAt(point, tolerance3D, true);
 
         if (boruUcu && boruUcu.boru) {
             const boru = boruUcu.boru;

--- a/plumbing_v2/objects/chimney.js
+++ b/plumbing_v2/objects/chimney.js
@@ -33,16 +33,17 @@ export class Baca {
         this.floorId = options.floorId || null;
 
         // Segment listesi - her segment bir dikdörtgen boru parçası
-        // Her segment: { x1, y1, x2, y2 }
+        // Her segment: { x1, y1, z1, x2, y2, z2 }
         this.segments = [];
 
         // İlk segment başlangıcı (cihaz üstü)
         this.startX = x;
         this.startY = y;
+        this.z = options.z || 0; // Z koordinatı ekle
 
         // Aktif çizim durumu
         this.isDrawing = true;
-        this.currentSegmentStart = { x, y };
+        this.currentSegmentStart = { x, y, z: this.z };
 
         // Havalandırma ızgarası (ESC basılınca eklenir)
         this.havalandirma = null;
@@ -51,7 +52,7 @@ export class Baca {
     /**
      * Yeni segment ekle (mouse click)
      */
-    addSegment(x, y) {
+    addSegment(x, y, z) {
         const dx = x - this.currentSegmentStart.x;
         const dy = y - this.currentSegmentStart.y;
         const uzunluk = Math.hypot(dx, dy);
@@ -61,16 +62,21 @@ export class Baca {
             return false;
         }
 
-        // Segment ekle
+        // Z değeri verilmemişse current segment'in Z'sini kullan
+        const endZ = z !== undefined ? z : (this.currentSegmentStart.z || this.z || 0);
+
+        // Segment ekle (Z koordinatlarıyla birlikte)
         this.segments.push({
             x1: this.currentSegmentStart.x,
             y1: this.currentSegmentStart.y,
+            z1: this.currentSegmentStart.z || this.z || 0,
             x2: x,
-            y2: y
+            y2: y,
+            z2: endZ
         });
 
         // Yeni segment başlangıcı
-        this.currentSegmentStart = { x, y };
+        this.currentSegmentStart = { x, y, z: endZ };
         return true;
     }
 
@@ -535,6 +541,7 @@ export class Baca {
             floorId: this.floorId,
             startX: this.startX,
             startY: this.startY,
+            z: this.z || 0, // Z koordinatını ekle
             segments: this.segments.map(s => ({ ...s })),
             isDrawing: this.isDrawing,
             currentSegmentStart: { ...this.currentSegmentStart },
@@ -547,7 +554,8 @@ export class Baca {
      */
     static fromJSON(data) {
         const baca = new Baca(data.startX, data.startY, data.parentCihazId, {
-            floorId: data.floorId
+            floorId: data.floorId,
+            z: data.z || 0 // Z koordinatını ekle
         });
 
         baca.id = data.id;


### PR DESCRIPTION
Düzeltilen sorunlar:

1. 3D sahnede sayaç ve kombi-ocak eklenemiyor:
   - ghost-updater.js: Tolerance dinamik olarak artırıldı (3D modda Z kayması için)
   - Cihaz ve sayaç için tolerance = 15 + (100 * t) formülü kullanılıyor
   - Z değeri büyük olduğunda ekran mesafesi de büyüyor, tolerance bunu kompanse ediyor

2. 2D sahnede eklenen kombi/ocakın bacası Z=0'da görünüyor:
   - chimney.js: Baca class'ına Z koordinat desteği eklendi
   - Constructor'a z parametresi eklendi (options.z)
   - Segment yapısı güncellendi: {x1, y1, z1, x2, y2, z2}
   - addSegment fonksiyonu artık z parametresi alıyor
   - toJSON/fromJSON fonksiyonları Z koordinatını serileştiriyor
   - component-placement.js: Baca oluşturulurken cihazın Z değeri aktarılıyor
   - Segment eklenirken Z koordinatı korunuyor