### PR TITLE
3D modda Z≠0 boru uçlarına cihaz/sayaç ekleme tolerance düzeltmesi

### DIFF
--- a/plumbing_v2/interactions/ghost-updater.js
+++ b/plumbing_v2/interactions/ghost-updater.js
@@ -23,9 +23,10 @@ export function updateGhostPosition(ghost, point, snap) {
     // Cihaz için: boru ucuna snap yap, fleks etrafında mouse ile hareket et
     if (ghost.type === 'cihaz') {
         // En yakın SERBEST boru ucunu bul (T-junction'ları atla)
-        // 3D modda tolerance artır (Z kaymasını hesaba kat)
+        // 3D modda tolerance artır (Z kayması diagonal olarak sqrt(2)*Z*t olabilir)
+        // Z=100cm, t=1 için kayma ~141cm, tolerance en az 200cm olmalı
         const baseTolerance = 15;
-        const tolerance3D = t > 0.5 ? baseTolerance + (100 * t) : baseTolerance;
+        const tolerance3D = t > 0.5 ? baseTolerance * (1 + 15 * t) : baseTolerance;
         const boruUcu = this.findBoruUcuAt(point, tolerance3D, true); // onlyFreeEndpoints = true
 
         if (boruUcu && boruUcu.boru) {
@@ -137,9 +138,10 @@ export function updateGhostPosition(ghost, point, snap) {
         }
     }
     else if (ghost.type === 'sayac') {
-        // 3D modda tolerance artır (Z kaymasını hesaba kat)
+        // 3D modda tolerance artır (Z kayması diagonal olarak sqrt(2)*Z*t olabilir)
+        // Z=100cm, t=1 için kayma ~141cm, tolerance en az 200cm olmalı
         const baseTolerance = 15;
-        const tolerance3D = t > 0.5 ? baseTolerance + (100 * t) : baseTolerance;
+        const tolerance3D = t > 0.5 ? baseTolerance * (1 + 15 * t) : baseTolerance;
         const boruUcu = this.findBoruUcuAt(point, tolerance3D, true);
 
         if (boruUcu && boruUcu.boru) {


### PR DESCRIPTION
Sorun:
- 2D'de ve 3D'de Z=0'da cihaz/sayaç eklenebiliyordu
- 3D'de Z≠0 olunca eklenemiyordu

Neden:
- 3D modda Z kayması diagonal: sqrt(2) * Z * t
- Z=100cm, t=1 için ekran kayması ~141cm
- Önceki tolerance = 15 + 100*t = 115cm (yetersiz)

Çözüm:
- Yeni tolerance formülü: baseTolerance * (1 + 15 * t)
- t=1 için: 15 * 16 = 240cm (yeterli)
- t=0.5 için: 15 * 8.5 = 127.5cm

Değişiklik:
- ghost-updater.js: tolerance3D formülü güncellendi
- Hem cihaz hem sayaç için aynı düzeltme uygulandı