### PR TITLE
isFreeEndpoint koordinat sistemi düzeltmesi - cihaz/sayaç ekleme fix

### DIFF
--- a/plumbing_v2/interactions/component-placement.js
+++ b/plumbing_v2/interactions/component-placement.js
@@ -383,7 +383,7 @@ export function handleSayacEndPlacement(meter) {
     }
 
     // T JUNCTION KONTROLÜ: Sayaç sadece gerçek uçlara bağlanabilir, T noktasına değil
-    if (!this.isFreeEndpoint(boruUcu.nokta, 1)) {
+    if (!this.isFreeEndpoint(boruUcu.nokta, 5)) {
         // console.error('[handleSayacEndPlacement] ✗ T-junction kontrolü başarısız!');
         // alert('⚠️ Sayaç T-bağlantısına yerleştirilemez!\n\nLütfen serbest bir hat ucuna yerleştirin.');
         return false;
@@ -503,7 +503,7 @@ export function handleCihazEkleme(cihaz) {
     }
 
     // T JUNCTION KONTROLÜ: Cihaz sadece gerçek uçlara bağlanabilir, T noktasına değil
-    if (!this.isFreeEndpoint(boruUcu.nokta, 1)) {
+    if (!this.isFreeEndpoint(boruUcu.nokta, 5)) {
         // console.error('[handleCihazEkleme] ✗ T-junction kontrolü başarısız!');
         // alert('⚠️ Cihaz T-bağlantısına yerleştirilemez!\n\nLütfen serbest bir hat ucuna yerleştirin.');
         return false;

--- a/plumbing_v2/interactions/finders.js
+++ b/plumbing_v2/interactions/finders.js
@@ -112,9 +112,12 @@ export function findObjectAt(manager, point) {
  * KRITIK: Cihazlar SADECE gerçek boş uçlara (1 borulu) bağlanabilir
  * Dirsek (2 boru), TE (3+ boru) = DOLU UÇ
  */
-export function isFreeEndpoint(manager, point, tolerance = 1) {
+export function isFreeEndpoint(manager, point, tolerance = 5) {
     const currentFloorId = state.currentFloor?.id;
     let pipeCount = 0;
+
+    // Point'i ekran koordinatına çevir (3D izdüşüm için)
+    const pointScreen = getScreenPoint(point);
 
     for (const boru of manager.pipes) {
         if (currentFloorId && boru.floorId && boru.floorId !== currentFloorId) {
@@ -125,8 +128,9 @@ export function isFreeEndpoint(manager, point, tolerance = 1) {
         const p1Screen = getScreenPoint(boru.p1);
         const p2Screen = getScreenPoint(boru.p2);
 
-        const distP1 = Math.hypot(point.x - p1Screen.x, point.y - p1Screen.y);
-        const distP2 = Math.hypot(point.x - p2Screen.x, point.y - p2Screen.y);
+        // Ekran koordinatlarında mesafe ölç
+        const distP1 = Math.hypot(pointScreen.x - p1Screen.x, pointScreen.y - p1Screen.y);
+        const distP2 = Math.hypot(pointScreen.x - p2Screen.x, pointScreen.y - p2Screen.y);
 
         if (distP1 < tolerance || distP2 < tolerance) {
             pipeCount++;

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -351,7 +351,7 @@ export class InteractionManager {
         return findObjectAt(this.manager, point);
     }
 
-    isFreeEndpoint(point, tolerance = 1) {
+    isFreeEndpoint(point, tolerance = 5) {
         return isFreeEndpoint(this.manager, point, tolerance);
     }
 


### PR DESCRIPTION
Sorun:
- Mouse boru ucunda olmasına rağmen cihaz/sayaç eklenemiyordu
- Ghost görünüyordu ama placement çalışmıyordu

Kök Neden:
- isFreeEndpoint fonksiyonuna world koordinatı veriliyordu
- Ama fonksiyon ekran koordinatlarıyla (getScreenPoint) karşılaştırma yapıyordu
- point.x (world) - p1Screen.x (screen) = yanlış mesafe!
- Tolerance 1 cm çok küçüktü

Çözüm:
1. isFreeEndpoint fonksiyonunda point'i de ekran koordinatına çevir
   - pointScreen = getScreenPoint(point)
   - Artık ekran koordinatlarında karşılaştırma: pointScreen - p1Screen

2. Tolerance 1 cm → 5 cm artırıldı
   - Default tolerance hem finders.js hem interaction-manager.js'de 5 cm
   - component-placement.js'deki çağrılar da 5 cm tolerance kullanıyor

Değişiklikler:
- finders.js: isFreeEndpoint point'i ekran koordinatına çevirme, tolerance 5
- interaction-manager.js: isFreeEndpoint wrapper default tolerance 5
- component-placement.js: isFreeEndpoint çağrılarında tolerance 5

Sonuç: Artık 3D modda Z≠0 olduğunda cihaz ve sayaç eklenebilir