### PR TITLE
3D modda vana sürükleme ve snap sorunları düzeltildi

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -361,7 +361,7 @@ export function handleDrag(interactionManager, point, event = null) {
             const dy = pipe.p2.y - pipe.p1.y;
             const dz = (pipe.p2.z || 0) - (pipe.p1.z || 0);
             const len2d = Math.hypot(dx, dy);
-            
+
             // Düşey boru tespiti (3D modunda ve dik boru)
             if (t > 0.1 && (len2d < 2.0 || Math.abs(dz) > len2d)) {
                 isVerticalDrag = true;
@@ -369,8 +369,16 @@ export function handleDrag(interactionManager, point, event = null) {
                 // Düşey sürüklemede Z'yi mouse hareketinden hesaplayacağız, o yüzden şimdilik offset 0 alıyoruz
                 // (Hesaplama aşağıda correctedPoint içinde yapılacak)
             } else {
-                // Yatay/Eğik boru: Başlangıç yüksekliğini baz al
-                zOffset = obj.z !== undefined ? obj.z : (pipe.p1.z || 0);
+                // Yatay/Eğik boru: Vana için t parametresine göre Z interpolasyonu yap
+                if (obj.type === 'vana' && obj.vanaT !== undefined) {
+                    // Vana'nın boru üzerindeki pozisyonuna göre Z değerini interpolasyon ile hesapla
+                    const z1 = pipe.p1.z || 0;
+                    const z2 = pipe.p2.z || 0;
+                    zOffset = z1 + obj.vanaT * (z2 - z1);
+                } else {
+                    // Diğer objeler: Başlangıç yüksekliğini baz al
+                    zOffset = obj.z !== undefined ? obj.z : (pipe.p1.z || 0);
+                }
             }
         }
     }

--- a/pointer/handle-pointer-move.js
+++ b/pointer/handle-pointer-move.js
@@ -251,32 +251,26 @@ export function handlePointerMove(e) {
                 vanaT = Math.max(0, Math.min(1, vanaT));
 
                 // Uçlara yapışma (Snap to End) Kontrolü
+                // KRITIK: 3D modda snap kontrolü T parametresine göre yapılmalı (ekran mesafesi değil)
                 let snapToEnd = false;
-                const END_SNAP_DISTANCE = 10; // cm
+                const END_SNAP_T_THRESHOLD = 0.05; // Boru uzunluğunun %5'i
                 const VANA_GENISLIGI = 8;
                 const BORU_UCU_BOSLUK = 1;
                 const vanaMesafesi = VANA_GENISLIGI / 2 + BORU_UCU_BOSLUK; // ~5cm
 
-                // P1'e yakınlık (3D mesafe kullanıyoruz)
-                if (distToP1_3D < END_SNAP_DISTANCE) {
+                // T parametresine göre snap kontrolü (0'a yakın = P1, 1'e yakın = P2)
+                if (vanaT < END_SNAP_T_THRESHOLD) {
+                    // P1'e çok yakın
                     const adjustedT = totalLen > 0 ? Math.min(vanaMesafesi / totalLen, 0.95) : 0;
                     vanaPoint = hoveredPipe.getPointAt(adjustedT);
                     vanaT = 0; // Mantıksal olarak uçta
                     snapToEnd = true;
-                } else {
-                    // P2'ye yakınlık kontrolü
-                    const distToP2_3D = Math.hypot(
-                        vanaPoint.x - hoveredPipe.p2.x,
-                        vanaPoint.y - hoveredPipe.p2.y,
-                        (vanaPoint.z || 0) - (hoveredPipe.p2.z || 0)
-                    );
-
-                    if (distToP2_3D < END_SNAP_DISTANCE) {
-                        const adjustedT = totalLen > 0 ? Math.max(1 - (vanaMesafesi / totalLen), 0.05) : 1;
-                        vanaPoint = hoveredPipe.getPointAt(adjustedT);
-                        vanaT = 1; // Mantıksal olarak uçta
-                        snapToEnd = true;
-                    }
+                } else if (vanaT > (1 - END_SNAP_T_THRESHOLD)) {
+                    // P2'ye çok yakın
+                    const adjustedT = totalLen > 0 ? Math.max(1 - (vanaMesafesi / totalLen), 0.05) : 1;
+                    vanaPoint = hoveredPipe.getPointAt(adjustedT);
+                    vanaT = 1; // Mantıksal olarak uçta
+                    snapToEnd = true;
                 }
 
                 // Preview nesnesini güncelle


### PR DESCRIPTION
Sorun 1: Vana Sürükleme Z Offseti
- Yükseliş sonrası farklı yükselişe vana koyunca sürüklemede sorun
- Mouse ilk yükseklik kadar çekilmeden vana sürüklenemiyordu

Neden:
- Drag handler vana için pipe.p1.z kullanıyordu (sabit)
- Vana boru üzerinde t parametresine göre interpolasyon gerekiyor
- Z = p1.z + t * (p2.z - p1.z)

Çözüm:
- drag-handler.js: Vana için vanaT parametresine göre Z interpolasyonu
- zOffset = z1 + obj.vanaT * (z2 - z1)

Sorun 2: Vana Snap Atlama
- Vana hattın sonuna yaklaşınca diğer uca atlıyordu
- Tersi de geçerliydi (başa yakın → sona atlıyor)

Neden:
- Snap kontrolü world mesafesi ile yapılıyordu (distToP1_3D < 10cm)
- 3D modda Z=100 olunca, 10cm world = 141cm ekran mesafesi
- Her iki uç da aynı anda snap threshold'da görünüyordu

Çözüm:
- handle-pointer-move.js: T parametresi ile snap kontrolü
- vanaT < 0.05 → P1'e snap
- vanaT > 0.95 → P2'ye snap
- Mesafe yerine oran kullanımı, Z'den bağımsız çalışır

Değişiklikler:
- drag-handler.js: Vana Z interpolasyonu eklendi
- handle-pointer-move.js: Snap threshold mesafe → T parametresi