### PR TITLE
Vana sürükleme ve cihaz preview sorunları düzeltildi

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -379,11 +379,15 @@ export function handleDrag(interactionManager, point, event = null) {
                 // (Hesaplama aşağıda correctedPoint içinde yapılacak)
             } else {
                 // Yatay/Eğik boru: Vana için t parametresine göre Z interpolasyonu yap
-                if (obj.type === 'vana' && obj.vanaT !== undefined) {
-                    // Vana'nın boru üzerindeki pozisyonuna göre Z değerini interpolasyon ile hesapla
+                if (obj.type === 'vana') {
+                    // DÜZELTME: Mouse pozisyonunu boruya projekte edip gerçek t değerini bul
+                    // Bu sayede vana farklı yüksekliklere geçerken de doğru Z offseti kullanılır
+                    const proj = pipe.projectPoint(point);
+                    const currentT = (proj && proj.onSegment) ? proj.t : (obj.vanaT || 0);
+
                     const z1 = pipe.p1.z || 0;
                     const z2 = pipe.p2.z || 0;
-                    zOffset = z1 + obj.vanaT * (z2 - z1);
+                    zOffset = z1 + currentT * (z2 - z1);
                 } else {
                     // Diğer objeler: Başlangıç yüksekliğini baz al
                     zOffset = obj.z !== undefined ? obj.z : (pipe.p1.z || 0);

--- a/plumbing_v2/objects/valve.js
+++ b/plumbing_v2/objects/valve.js
@@ -458,7 +458,8 @@ export class Vana {
         // ------------------------------------------------
 
         // Boru ucuna yakınsa fromEnd ve fixedDistance'ı tekrar set et
-        const END_THRESHOLD_CM = 10; // 10 cm içindeyse uç sayılır
+        // DÜZELTME: Threshold'u 10cm'den 3cm'e düşürdük - vana daha az atlayacak
+        const END_THRESHOLD_CM = 3; // 3 cm içindeyse uç sayılır (eski: 10)
         const VANA_GENISLIGI = 8;
         const BORU_UCU_BOSLUK = 1;
         const fixedDistanceFromEnd = VANA_GENISLIGI / 2 + BORU_UCU_BOSLUK; // 5 cm

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -363,7 +363,14 @@ export class PlumbingRenderer {
 
                     // Manuel translate + draw
                     ctx.save();
-                    ctx.translate(manager.tempComponent.x, manager.tempComponent.y);
+
+                    // DÜZELTME: 3D modda Z offset'i uygula
+                    const z = manager.tempComponent.z || 0;
+                    const t = state.viewBlendFactor || 0;
+                    const screenX = manager.tempComponent.x + (z * t);
+                    const screenY = manager.tempComponent.y - (z * t);
+
+                    ctx.translate(screenX, screenY);
                     if (manager.tempComponent.rotation) {
                         ctx.rotate(manager.tempComponent.rotation * Math.PI / 180);
                     }


### PR DESCRIPTION
3 önemli sorun düzeltildi:

1. Vana sürükleme Z offset sorunu: Farklı yüksekliklere geçerken mouse offset'i yanlış hesaplanıyordu. Mouse pozisyonunu boruya projekte edip gerçek t değeri hesaplanarak Z interpolasyonu dinamik yapıldı.

2. Vana snap threshold azaltıldı: Vana hattın sonuna 10cm yaklaşınca diğer uca atlıyordu. END_THRESHOLD_CM değeri 10cm'den 3cm'e düşürüldü.

3. Kombi/ocak preview Z>0 sorunu: 3D modda z>0 kotunda cihaz eklerken preview z=0'da görünüyordu. Cihaz preview rendering'ine 3D offset eklendi.

Değişen dosyalar:
- plumbing_v2/interactions/drag-handler.js
- plumbing_v2/objects/valve.js
- plumbing_v2/plumbing-renderer.js