### PR TITLE
Cihaz preview vana/fleks ve düşey boru vana sürükleme sorunları düzel…

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -3106,6 +3106,10 @@ drawServisKutusu(ctx, comp) {
         const { boruUcu, girisNoktasi } = connInfo;
         const boru = boruUcu.boru;
 
+        // DÜZELTME: 3D offset hesapla
+        const t = state.viewBlendFactor || 0;
+        const boruZ = boruUcu.nokta.z || 0;
+
         // Boru ucunda vana var mı kontrol et
         const vanaVarMi = manager.components.some(comp =>
             comp.type === 'vana' &&
@@ -3137,9 +3141,13 @@ drawServisKutusu(ctx, comp) {
                 vanaY = boruUcu.nokta.y - (dy / length) * VANA_CENTER_MARGIN;
             }
 
+            // DÜZELTME: 3D offset uygula
+            const vanaScreenX = vanaX + (boruZ * t);
+            const vanaScreenY = vanaY - (boruZ * t);
+
             // Vana çiz
             ctx.save();
-            ctx.translate(vanaX, vanaY);
+            ctx.translate(vanaScreenX, vanaScreenY);
             ctx.rotate(boru.aci);
             ctx.globalAlpha = 0.6;
 
@@ -3186,6 +3194,14 @@ drawServisKutusu(ctx, comp) {
             fleksBitis = merkez;
         }
 
+        // DÜZELTME: 3D offset uygula (boru ucu ve fleks bitiş noktası)
+        const boruUcScreenX = boruUcu.nokta.x + (boruZ * t);
+        const boruUcScreenY = boruUcu.nokta.y - (boruZ * t);
+
+        const cihazZ = ghost.z || 0;
+        const fleksBitisScreenX = fleksBitis.x + (cihazZ * t);
+        const fleksBitisScreenY = fleksBitis.y - (cihazZ * t);
+
         // Fleks rengini borunun colorGroup'una göre ayarla
         const colorGroup = boru?.colorGroup || 'YELLOW';
         const fleksRenk = this.getRenkByGroup(colorGroup, 'fleks', 1);
@@ -3196,8 +3212,8 @@ drawServisKutusu(ctx, comp) {
         ctx.setLineDash([5, 5]); // Kesikli çizgi
 
         ctx.beginPath();
-        ctx.moveTo(boruUcu.nokta.x, boruUcu.nokta.y);
-        ctx.lineTo(fleksBitis.x, fleksBitis.y);
+        ctx.moveTo(boruUcScreenX, boruUcScreenY);
+        ctx.lineTo(fleksBitisScreenX, fleksBitisScreenY);
         ctx.stroke();
 
         ctx.setLineDash([]); // Reset dash


### PR DESCRIPTION
…tildi

2 ek sorun daha düzeltildi:

1. Cihaz preview vana/fleks Z>0 sorunu: 3D modda z>0 kotuna cihaz eklerken vana ve fleksler zeminde görünüyordu. drawCihazGhostConnection fonksiyonuna 3D offset eklendi. Hem vana preview hem de fleks çizgisi için başlangıç ve bitiş noktalarına 3D transform uygulandı.

2. Düşey boru vana sürükleme offset sorunu: Düşey boruda vana varken, daha önce farklı Z seviyelerinde borular kullanılmışsa mouse offset yanlış hesaplanıyordu. Çözüm: startDrag'de vananın başlangıç Z değeri (dragStartZ) kaydediliyor ve düşey boru formülünde bu offset düzeltiliyor.

Değişen dosyalar:
- plumbing_v2/plumbing-renderer.js (drawCihazGhostConnection 3D offset)
- plumbing_v2/interactions/drag-handler.js (dragStartZ ve düşey formül)