### PR TITLE
Boru taşıma mantığını düzelt: dragAxis semantiği

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -2946,11 +2946,28 @@ export class PlumbingRenderer {
         const minY = -panY / zoom - 500;
         const maxY = -panY / zoom + canvas.height / zoom + 500;
 
-        // dragAxis'e göre aktif eksenleri belirle
+        // dragAxis'e göre aktif eksenleri belirle (dragAxis = taşınabilir eksenler)
         const dragAxis = interactionManager.dragAxis;
-        let isXActive = dragAxis !== 'x'; // X kilitli değilse aktif
-        let isYActive = dragAxis !== 'y'; // Y kilitli değilse aktif
-        let isZActive = dragAxis !== 'z'; // Z kilitli değilse aktif
+        let isXActive = false;
+        let isYActive = false;
+        let isZActive = false;
+
+        if (dragAxis === null) {
+            // Her yönde taşınabilir
+            isXActive = isYActive = isZActive = true;
+        } else if (dragAxis === 'x') {
+            isXActive = true;
+        } else if (dragAxis === 'y') {
+            isYActive = true;
+        } else if (dragAxis === 'z') {
+            isZActive = true;
+        } else if (dragAxis === 'yz') {
+            isYActive = isZActive = true;
+        } else if (dragAxis === 'xz') {
+            isXActive = isZActive = true;
+        } else if (dragAxis === 'xy') {
+            isXActive = isYActive = true;
+        }
 
         // X ekseni snap'i varsa dikey çizgi çiz
         if (snapLock.x !== null) {


### PR DESCRIPTION
DÜZELTME: dragAxis değişkeninin anlamını düzelt
- dragAxis = "taşınabilir eksenler" anlamında kullanılıyor
- Borunun uzandığı eksen KİLİTLİ, diğer eksenler SERBEST

3D Eksen Belirleme:
- X yönünde uzanan boru → dragAxis='yz' (Y ve Z'de taşınabilir, X kilitli)
- Y yönünde uzanan boru → dragAxis='xz' (X ve Z'de taşınabilir, Y kilitli)
- Z yönünde uzanan boru → dragAxis='xy' (X ve Y'de taşınabilir, Z kilitli)

Diagonal Borular (2 eksende uzayan):
- X-Y diagonal → dragAxis='z' (sadece Z'de taşınabilir)
- X-Z diagonal → dragAxis='y' (sadece Y'de taşınabilir)
- Y-Z diagonal → dragAxis='x' (sadece X'de taşınabilir)

Offset Uygulama:
- dragAxis değerine göre doğru eksenlerde offset sıfırla
- Renderer: Aktif eksenleri koyu renk ile göster