### PR TITLE
Import hatalarını düzelt: getRenkGruplari pipe.js'den import edilmeli

### DIFF
--- a/plumbing_v2/renderer-colors.js
+++ b/plumbing_v2/renderer-colors.js
@@ -1,7 +1,8 @@
 // plumbing_v2/renderer-colors.js
 // Renk ve tema ile ilgili yardımcı metodlar
 
-import { getRenkGruplari, isLightMode as mainIsLightMode } from '../general-files/main.js';
+import { getRenkGruplari } from './objects/pipe.js';
+import { isLightMode } from '../general-files/main.js';
 import { CUSTOM_COLORS } from './renderer-utils.js';
 
 /**
@@ -27,7 +28,7 @@ export const ColorMixin = {
      */
     isLightMode() {
         // main.js'ten import edilen fonksiyonu kullan
-        return mainIsLightMode();
+        return isLightMode();
     },
 
     /**

--- a/plumbing_v2/renderer-components.js
+++ b/plumbing_v2/renderer-components.js
@@ -3,7 +3,8 @@
 
 import { SERVIS_KUTUSU_CONFIG } from './objects/service-box.js';
 import { SAYAC_CONFIG } from './objects/meter.js';
-import { state, getShadow, THEME_COLORS, isLightMode, getRenkGruplari } from '../general-files/main.js';
+import { getRenkGruplari } from './objects/pipe.js';
+import { state, getShadow, THEME_COLORS, isLightMode } from '../general-files/main.js';
 
 // Seçili eleman rengi
 const CUSTOM_COLORS = {


### PR DESCRIPTION
- renderer-colors.js: getRenkGruplari artık doğru yerden (pipe.js) import ediliyor
- renderer-components.js: aynı düzeltme uygulandı
- main.js'den yanlış import edilen getRenkGruplari düzeltildi