### PR TITLE
3D sahnede taşıma sırasında koordinat gizmo ve eksen kilitli taşıma e…

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -146,6 +146,7 @@ export function startEndpointDrag(interactionManager, pipe, endpoint, point) {
     interactionManager.dragObject = pipe;
     interactionManager.dragEndpoint = endpoint;
     interactionManager.dragStart = { ...point };
+    interactionManager.selectedDragAxis = null; // Reset axis selection
 
     const draggedPoint = endpoint === 'p1' ? pipe.p1 : pipe.p2;
 
@@ -183,6 +184,7 @@ export function startDrag(interactionManager, obj, point) {
     interactionManager.dragObject = obj;
     interactionManager.dragEndpoint = null;
     interactionManager.dragStart = { ...point };
+    interactionManager.selectedDragAxis = null; // Reset axis selection
 
     if (obj.type === 'vana' && obj.bagliBoruId) {
         interactionManager.dragObjectPipe = interactionManager.manager.pipes.find(p => p.id === obj.bagliBoruId);
@@ -436,6 +438,51 @@ export function handleDrag(interactionManager, point, event = null) {
         correctedPoint = { x: verticalPipeBase.x, y: verticalPipeBase.y, z: clampedZ };
     } else {
         correctedPoint = { x: point.x - (zOffset * t), y: point.y + (zOffset * t), z: zOffset };
+    }
+
+    // Axis-locked dragging (koordinat eksenine kilitli taşıma)
+    if (interactionManager.selectedDragAxis) {
+        const startPoint = {
+            x: interactionManager.dragStart.x - (zOffset * t),
+            y: interactionManager.dragStart.y + (zOffset * t),
+            z: zOffset
+        };
+
+        // Taşınan noktanın başlangıç pozisyonu
+        let originalPoint = startPoint;
+        if (obj.type === 'boru' && interactionManager.dragEndpoint) {
+            const ep = interactionManager.dragEndpoint === 'p1' ? obj.p1 : obj.p2;
+            originalPoint = { x: ep.x, y: ep.y, z: ep.z || 0 };
+        } else if (obj.x !== undefined) {
+            originalPoint = { x: obj.x, y: obj.y, z: obj.z || 0 };
+        }
+
+        // İlk taşımadaysa, başlangıç pozisyonunu kaydet
+        if (!interactionManager.dragStartWorldPos) {
+            interactionManager.dragStartWorldPos = { ...originalPoint };
+        }
+
+        const dragStartPos = interactionManager.dragStartWorldPos;
+
+        // Seçili eksende kilitli taşıma
+        if (interactionManager.selectedDragAxis === 'X') {
+            correctedPoint.y = dragStartPos.y;
+            correctedPoint.z = dragStartPos.z;
+        } else if (interactionManager.selectedDragAxis === 'Y') {
+            correctedPoint.x = dragStartPos.x;
+            correctedPoint.z = dragStartPos.z;
+        } else if (interactionManager.selectedDragAxis === 'Z') {
+            correctedPoint.x = dragStartPos.x;
+            correctedPoint.y = dragStartPos.y;
+            // Z değişimini hesapla
+            const screenDx = point.x - interactionManager.dragStart.x;
+            const screenDy = point.y - interactionManager.dragStart.y;
+            const deltaZ = (screenDx - screenDy) / (2 * t || 1);
+            correctedPoint.z = dragStartPos.z + deltaZ;
+        }
+    } else {
+        // Axis seçili değilse, başlangıç pozisyonunu sıfırla
+        interactionManager.dragStartWorldPos = null;
     }
 
     if (interactionManager.dragBacaEndpoint && interactionManager.dragObject.type === 'baca') {
@@ -1127,6 +1174,8 @@ export function endDrag(interactionManager) {
     interactionManager.dragBacaEndpoint = null;
     interactionManager.dragStart = null;
     interactionManager._bacaDragLogged = false;
+    interactionManager.selectedDragAxis = null; // Eksen seçimini sıfırla
+    interactionManager.dragStartWorldPos = null; // Başlangıç pozisyonunu sıfırla
     interactionManager.dragStartObjectPos = null;
     interactionManager.isBodyDrag = false;
     interactionManager.bodyDragInitialP1 = null;

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -168,6 +168,9 @@ export class InteractionManager {
         this.axisLockDetermined = false;
         this.lockedAxis = null;
 
+        // Koordinat gizmo için seçili eksen (X, Y, Z veya null)
+        this.selectedDragAxis = null;
+
         // Double-click detection
         this.lastClickTime = 0;
         this.lastClickPoint = null;

--- a/plumbing_v2/interactions/keyboard-handler.js
+++ b/plumbing_v2/interactions/keyboard-handler.js
@@ -143,6 +143,22 @@ export function handleKeyDown(e) {
         }
     }
 
+    // Taşıma sırasında eksen kilitleme (X, Y, Z tuşları)
+    if (this.isDragging && this.dragObject) {
+        if (e.key === 'x' || e.key === 'X') {
+            this.selectedDragAxis = this.selectedDragAxis === 'X' ? null : 'X';
+            return true;
+        }
+        if (e.key === 'y' || e.key === 'Y') {
+            this.selectedDragAxis = this.selectedDragAxis === 'Y' ? null : 'Y';
+            return true;
+        }
+        if (e.key === 'z' || e.key === 'Z') {
+            this.selectedDragAxis = this.selectedDragAxis === 'Z' ? null : 'Z';
+            return true;
+        }
+    }
+
     // ESC - iptal ve seç moduna geç
     if (e.key === 'Escape') {
         // Düşey panel açıksa önce onu kapat

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -228,8 +228,15 @@ export class PlumbingRenderer {
         if (state.tempVisibility.showPipePath && window._selectedPipePath && window._selectedPipePath.length > 0) {
             this.drawSelectedPipePath(ctx);
         }
+
+        // Koordinat gizmo (taşıma sırasında)
+        if (manager.interactionManager?.isDragging) {
+            this.drawDragCoordinateGizmo(ctx, manager.interactionManager);
+        }
     }
 }
+
+
 
 // Tüm mixin'leri PlumbingRenderer sınıfına ekle
 Object.assign(PlumbingRenderer.prototype, ColorMixin);

--- a/plumbing_v2/renderer/renderer-interaction.js
+++ b/plumbing_v2/renderer/renderer-interaction.js
@@ -95,5 +95,35 @@ export const InteractionMixin = {
         ctx.fillText(pathText, x, y);
 
         ctx.restore();
+    },
+
+    /**
+     * Koordinat gizmo'yu göster (taşıma sırasında)
+     * @param {CanvasRenderingContext2D} ctx - Canvas context
+     * @param {Object} interactionManager - InteractionManager instance
+     */
+    drawDragCoordinateGizmo(ctx, interactionManager) {
+        if (!interactionManager.isDragging || !interactionManager.dragObject) return;
+
+        let point = null;
+        let selectedAxis = interactionManager.selectedDragAxis || null;
+
+        // Hangi nokta taşınıyor?
+        const obj = interactionManager.dragObject;
+
+        if (obj.type === 'boru' && interactionManager.dragEndpoint) {
+            // Boru endpoint taşıması
+            point = interactionManager.dragEndpoint === 'p1' ? obj.p1 : obj.p2;
+        } else if (obj.type === 'vana' || obj.type === 'sayac' || obj.type === 'cihaz' || obj.type === 'servis_kutusu') {
+            // Obje taşıması
+            point = { x: obj.x, y: obj.y, z: obj.z || 0 };
+        }
+
+        if (!point) return;
+
+        // Gizmo'yu çiz (PreviewMixin'den)
+        if (this.drawCoordinateGizmo) {
+            this.drawCoordinateGizmo(ctx, point, selectedAxis);
+        }
     }
 };

--- a/plumbing_v2/renderer/renderer-previews.js
+++ b/plumbing_v2/renderer/renderer-previews.js
@@ -451,5 +451,148 @@ export const PreviewMixin = {
         ctx.fillText(text, midX, midY - 10);
 
         ctx.restore();
+    },
+
+    /**
+     * 3D Koordinat Gizmo - Taşıma sırasında gösterilir
+     * X, Y, Z eksenlerini ve mevcut koordinatları gösterir
+     */
+    drawCoordinateGizmo(ctx, point, selectedAxis = null) {
+        if (!point) return;
+
+        const t = state.viewBlendFactor || 0;
+        const zoom = state.zoom || 1;
+
+        // 3D offset uygula
+        const z = point.z || 0;
+        const screenX = point.x + (z * t);
+        const screenY = point.y - (z * t);
+
+        ctx.save();
+
+        // Gizmo uzunluğu (eksen okları)
+        const axisLength = 60 / zoom;
+        const arrowSize = 8 / zoom;
+        const lineWidth = 2 / zoom;
+
+        // Z ekseni (yukarı - mavi)
+        ctx.save();
+        ctx.strokeStyle = selectedAxis === 'Z' ? '#00FFFF' : '#0088FF';
+        ctx.fillStyle = selectedAxis === 'Z' ? '#00FFFF' : '#0088FF';
+        ctx.lineWidth = selectedAxis === 'Z' ? lineWidth * 1.5 : lineWidth;
+
+        // Z ekseni çizgisi (3D görünümde yukarı-sol yönü)
+        const zEndX = screenX - (axisLength * t);
+        const zEndY = screenY + (axisLength * t);
+
+        ctx.beginPath();
+        ctx.moveTo(screenX, screenY);
+        ctx.lineTo(zEndX, zEndY);
+        ctx.stroke();
+
+        // Z ok ucu
+        drawArrow(ctx, screenX, screenY, zEndX, zEndY, arrowSize);
+
+        // Z etiketi
+        ctx.font = `bold ${12 / zoom}px Arial`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('Z', zEndX - 10 / zoom, zEndY + 10 / zoom);
+        ctx.restore();
+
+        // X ekseni (sağa - kırmızı)
+        ctx.save();
+        ctx.strokeStyle = selectedAxis === 'X' ? '#FF00FF' : '#FF0000';
+        ctx.fillStyle = selectedAxis === 'X' ? '#FF00FF' : '#FF0000';
+        ctx.lineWidth = selectedAxis === 'X' ? lineWidth * 1.5 : lineWidth;
+
+        const xEndX = screenX + axisLength;
+        const xEndY = screenY;
+
+        ctx.beginPath();
+        ctx.moveTo(screenX, screenY);
+        ctx.lineTo(xEndX, xEndY);
+        ctx.stroke();
+
+        // X ok ucu
+        drawArrow(ctx, screenX, screenY, xEndX, xEndY, arrowSize);
+
+        // X etiketi
+        ctx.font = `bold ${12 / zoom}px Arial`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('X', xEndX + 15 / zoom, xEndY);
+        ctx.restore();
+
+        // Y ekseni (aşağı - yeşil)
+        ctx.save();
+        ctx.strokeStyle = selectedAxis === 'Y' ? '#00FF00' : '#00AA00';
+        ctx.fillStyle = selectedAxis === 'Y' ? '#00FF00' : '#00AA00';
+        ctx.lineWidth = selectedAxis === 'Y' ? lineWidth * 1.5 : lineWidth;
+
+        const yEndX = screenX;
+        const yEndY = screenY + axisLength;
+
+        ctx.beginPath();
+        ctx.moveTo(screenX, screenY);
+        ctx.lineTo(yEndX, yEndY);
+        ctx.stroke();
+
+        // Y ok ucu
+        drawArrow(ctx, screenX, screenY, yEndX, yEndY, arrowSize);
+
+        // Y etiketi
+        ctx.font = `bold ${12 / zoom}px Arial`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText('Y', yEndX, yEndY + 15 / zoom);
+        ctx.restore();
+
+        // Merkez nokta
+        ctx.fillStyle = '#FFFFFF';
+        ctx.strokeStyle = '#000000';
+        ctx.lineWidth = 2 / zoom;
+        ctx.beginPath();
+        ctx.arc(screenX, screenY, 4 / zoom, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+
+        // Koordinat bilgisi göster
+        ctx.save();
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+        ctx.fillRect(screenX + 10 / zoom, screenY - 40 / zoom, 120 / zoom, 36 / zoom);
+
+        ctx.fillStyle = '#FFFFFF';
+        ctx.font = `${11 / zoom}px monospace`;
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'top';
+
+        const coordText = `X: ${Math.round(point.x)}\nY: ${Math.round(point.y)}\nZ: ${Math.round(z)}`;
+        const lines = coordText.split('\n');
+        lines.forEach((line, i) => {
+            ctx.fillText(line, screenX + 15 / zoom, screenY - 35 / zoom + (i * 12 / zoom));
+        });
+
+        ctx.restore();
+
+        ctx.restore();
+
+        // Ok çizme yardımcı fonksiyonu
+        function drawArrow(ctx, x1, y1, x2, y2, size) {
+            const angle = Math.atan2(y2 - y1, x2 - x1);
+
+            ctx.beginPath();
+            ctx.moveTo(x2, y2);
+            ctx.lineTo(
+                x2 - size * Math.cos(angle - Math.PI / 6),
+                y2 - size * Math.sin(angle - Math.PI / 6)
+            );
+            ctx.moveTo(x2, y2);
+            ctx.lineTo(
+                x2 - size * Math.cos(angle + Math.PI / 6),
+                y2 - size * Math.sin(angle + Math.PI / 6)
+            );
+            ctx.stroke();
+        }
     }
 };


### PR DESCRIPTION
…klendi

Değişiklikler:
- Taşıma sırasında X, Y, Z koordinat eksenleri görsel olarak gösteriliyor
- Mevcut koordinatlar (X, Y, Z) ekranda gösteriliyor
- X, Y, Z tuşları ile eksen seçimi yapılabiliyor
- Seçili eksende kilitli taşıma (axis-locked dragging)
- Seçili eksen vurgulu renkte gösteriliyor

Kullanım:
- Bir nokta/obje taşımaya başla
- Koordinat gizmo otomatik görünür
- X tuşu: X ekseninde kilitli taşıma
- Y tuşu: Y ekseninde kilitli taşıma
- Z tuşu: Z ekseninde kilitli taşıma
- Tekrar aynı tuşa bas: kilidi kaldır

Dosyalar:
- renderer-previews.js: drawCoordinateGizmo() eklendi
- renderer-interaction.js: drawDragCoordinateGizmo() eklendi
- plumbing-renderer.js: Gizmo render çağrısı eklendi
- drag-handler.js: Axis-locked dragging mantığı eklendi
- keyboard-handler.js: X, Y, Z tuş yöneticileri eklendi
- interaction-manager.js: selectedDragAxis state'i eklendi