### PR TITLE
Otomatik eksen tespiti ile kilitli taşıma (çizim gibi)

### DIFF
--- a/plumbing_v2/interactions/keyboard-handler.js
+++ b/plumbing_v2/interactions/keyboard-handler.js
@@ -143,22 +143,6 @@ export function handleKeyDown(e) {
         }
     }
 
-    // Taşıma sırasında eksen kilitleme (X, Y, Z tuşları)
-    if (this.isDragging && this.dragObject) {
-        if (e.key === 'x' || e.key === 'X') {
-            this.selectedDragAxis = this.selectedDragAxis === 'X' ? null : 'X';
-            return true;
-        }
-        if (e.key === 'y' || e.key === 'Y') {
-            this.selectedDragAxis = this.selectedDragAxis === 'Y' ? null : 'Y';
-            return true;
-        }
-        if (e.key === 'z' || e.key === 'Z') {
-            this.selectedDragAxis = this.selectedDragAxis === 'Z' ? null : 'Z';
-            return true;
-        }
-    }
-
     // ESC - iptal ve seç moduna geç
     if (e.key === 'Escape') {
         // Düşey panel açıksa önce onu kapat


### PR DESCRIPTION
Değişiklikler:
- Manuel X, Y, Z tuşları kaldırıldı
- Mouse hareket yönüne göre otomatik eksen belirleme
- En baskın eksende kilitli taşıma
- Z ekseni de destekleniyor (3D modda)
- Minimum 5 birim hareket eşiği

Kullanım:
- Bir nokta/obje taşımaya başla
- Mouse'u hareket ettir
- Otomatik olarak en çok hareket ettiğin eksende kilitlenir
- O eksen vurgulu renkte gösterilir
- X, Y veya Z ekseninde kilitli taşıma

Dosyalar:
- keyboard-handler.js: X, Y, Z tuş yöneticileri kaldırıldı
- drag-handler.js: Otomatik eksen tespiti eklendi