### PR TITLE
Gizmo düzeltmeleri: Z ekseni, UI iyileştirmeleri, ayarlara bağlama

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -468,18 +468,21 @@ export function handleDrag(interactionManager, point, event = null) {
     const totalMovement = Math.hypot(screenDx, screenDy);
 
     if (totalMovement > MIN_MOVEMENT) {
-        // Hareket açısını hesapla
+        // Hareket açısını hesapla (derece cinsinden)
         const angle = Math.atan2(screenDy, screenDx) * 180 / Math.PI;
 
-        // Z ekseni için diagonal hareket tespiti (45 derece veya 135 derece yönünde)
-        // screenDx ve screenDy'nin mutlak değerleri yakınsa → diagonal hareket → Z ekseni
-        const isDiagonal = Math.abs(Math.abs(screenDx) - Math.abs(screenDy)) < totalMovement * 0.3;
+        // Z ekseni için diagonal hareket tespiti (açı bazlı)
+        // 45 derece (sağ-alt) veya -135 derece (sol-üst) → Z ekseni
+        const ANGLE_TOLERANCE = 25; // ±25 derece tolerans
+        const isZDiagonal =
+            (Math.abs(angle - 45) < ANGLE_TOLERANCE) ||      // Sağ-alt diagonal
+            (Math.abs(angle + 135) < ANGLE_TOLERANCE);       // Sol-üst diagonal
 
         // World koordinatlarında değişim
         const worldDx = Math.abs(correctedPoint.x - dragStartPos.x);
         const worldDy = Math.abs(correctedPoint.y - dragStartPos.y);
 
-        if (isDiagonal && t > 0.1) {
+        if (isZDiagonal && t > 0.1) {
             // Diagonal hareket → Z ekseni (3D modda)
             interactionManager.selectedDragAxis = 'Z';
         } else if (worldDx > worldDy) {

--- a/plumbing_v2/renderer/renderer-interaction.js
+++ b/plumbing_v2/renderer/renderer-interaction.js
@@ -103,6 +103,9 @@ export const InteractionMixin = {
      * @param {Object} interactionManager - InteractionManager instance
      */
     drawDragCoordinateGizmo(ctx, interactionManager) {
+        // 3D Eksen ayarı kapalıysa gösterme
+        if (!state.show3DAxis) return;
+
         if (!interactionManager.isDragging || !interactionManager.dragObject) return;
 
         let point = null;

--- a/plumbing_v2/renderer/renderer-previews.js
+++ b/plumbing_v2/renderer/renderer-previews.js
@@ -477,6 +477,7 @@ export const PreviewMixin = {
 
         // Z ekseni (yukarı - mavi)
         ctx.save();
+        ctx.globalAlpha = selectedAxis === 'Z' ? 1.0 : 0.3;
         ctx.strokeStyle = selectedAxis === 'Z' ? '#00FFFF' : '#0088FF';
         ctx.fillStyle = selectedAxis === 'Z' ? '#00FFFF' : '#0088FF';
         ctx.lineWidth = selectedAxis === 'Z' ? lineWidth * 1.5 : lineWidth;
@@ -502,6 +503,7 @@ export const PreviewMixin = {
 
         // X ekseni (sağa - kırmızı)
         ctx.save();
+        ctx.globalAlpha = selectedAxis === 'X' ? 1.0 : 0.3;
         ctx.strokeStyle = selectedAxis === 'X' ? '#FF00FF' : '#FF0000';
         ctx.fillStyle = selectedAxis === 'X' ? '#FF00FF' : '#FF0000';
         ctx.lineWidth = selectedAxis === 'X' ? lineWidth * 1.5 : lineWidth;
@@ -526,6 +528,7 @@ export const PreviewMixin = {
 
         // Y ekseni (aşağı - yeşil)
         ctx.save();
+        ctx.globalAlpha = selectedAxis === 'Y' ? 1.0 : 0.3;
         ctx.strokeStyle = selectedAxis === 'Y' ? '#00FF00' : '#00AA00';
         ctx.fillStyle = selectedAxis === 'Y' ? '#00FF00' : '#00AA00';
         ctx.lineWidth = selectedAxis === 'Y' ? lineWidth * 1.5 : lineWidth;
@@ -556,24 +559,6 @@ export const PreviewMixin = {
         ctx.arc(screenX, screenY, 4 / zoom, 0, Math.PI * 2);
         ctx.fill();
         ctx.stroke();
-
-        // Koordinat bilgisi göster
-        ctx.save();
-        ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
-        ctx.fillRect(screenX + 10 / zoom, screenY - 40 / zoom, 120 / zoom, 36 / zoom);
-
-        ctx.fillStyle = '#FFFFFF';
-        ctx.font = `${11 / zoom}px monospace`;
-        ctx.textAlign = 'left';
-        ctx.textBaseline = 'top';
-
-        const coordText = `X: ${Math.round(point.x)}\nY: ${Math.round(point.y)}\nZ: ${Math.round(z)}`;
-        const lines = coordText.split('\n');
-        lines.forEach((line, i) => {
-            ctx.fillText(line, screenX + 15 / zoom, screenY - 35 / zoom + (i * 12 / zoom));
-        });
-
-        ctx.restore();
 
         ctx.restore();
 


### PR DESCRIPTION
Değişiklikler:

1. Z EKSENİ DÜZELTMESİ (KRİTİK):
   - Açı bazlı diagonal hareket tespiti
   - 45° (sağ-alt) veya -135° (sol-üst) → Z ekseni
   - ±25° tolerans ile hassas tespit
   - Z ekseni artık düzgün çalışıyor

2. UI İYİLEŞTİRMELERİ:
   - Koordinat değerleri kaldırıldı (X: Y: Z: yazıları)
   - Pasif eksenler soluklaştırıldı (opacity: 0.3)
   - Aktif eksen tam parlak (opacity: 1.0)
   - Görsel ayrım çok daha belirgin

3. AYARLARA BAĞLAMA:
   - Gizmo "3D Eksen" ayarına bağlandı
   - state.show3DAxis kontrolü eklendi
   - Ayar kapalıysa gizmo gösterilmez

Kullanım:
- Diagonal sürükle (↘ veya ↖) → Z ekseni
- Görünüm → 3D Eksen ile gizmo aç/kapat
- Aktif eksen parlak, pasifler soluk

Dosyalar:
- drag-handler.js: Açı bazlı diagonal tespit
- renderer-previews.js: Opacity, koordinat kutusu kaldırıldı
- renderer-interaction.js: show3DAxis kontrolü