### PR TITLE
Z ekseni düzeltmesi: t kontrolü kaldırıldı

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -489,8 +489,8 @@ export function handleDrag(interactionManager, point, event = null) {
             minDist = distY;
         }
 
-        // Z eksenini de adaylara ekle (3D modda)
-        if (distZ < minDist && t > 0.1) {
+        // Z eksenini de adaylara ekle
+        if (distZ < minDist) {
             bestAxis = 'Z';
         }
 
@@ -508,7 +508,8 @@ export function handleDrag(interactionManager, point, event = null) {
         correctedPoint.x = dragStartPos.x;
         correctedPoint.y = dragStartPos.y;
         // Z değişimini diagonal hareketten hesapla
-        const deltaZ = (screenDx - screenDy) / (2 * (t || 1));
+        const safeT = Math.max(0.1, t);
+        const deltaZ = (screenDx - screenDy) / (2 * safeT);
         correctedPoint.z = dragStartPos.z + deltaZ;
     }
 


### PR DESCRIPTION
KRİTİK DÜZELTME:

- t > 0.1 kontrolü KALDIRILDI
- Z ekseni artık her viewBlendFactor değerinde seçilebilir
- Çizim kodu ile tamamen aynı davranış
- deltaZ hesaplaması daha güvenli (safeT kullanımı)

Sorun:
- "if (distZ < minDist && t > 0.1)" kontrolü Z eksenini engelliyor
- Kullanıcı diagonal sürüklese bile Z seçilmiyordu

Çözüm:
- t kontrolü kaldırıldı
- "if (distZ < minDist)" artık yeterli
- safeT = Math.max(0.1, t) ile güvenli hesaplama

Dosya:
- drag-handler.js: t kontrolü kaldırıldı, safeT eklendi