### PR TITLE
D2 ekranda gizmo ve Z ekseni devre dışı bırakıldı

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -489,8 +489,8 @@ export function handleDrag(interactionManager, point, event = null) {
             minDist = distY;
         }
 
-        // Z eksenini de adaylara ekle
-        if (distZ < minDist) {
+        // Z eksenini de adaylara ekle (sadece 3D modda)
+        if (distZ < minDist && t > 0.1) {
             bestAxis = 'Z';
         }
 

--- a/plumbing_v2/renderer/renderer-previews.js
+++ b/plumbing_v2/renderer/renderer-previews.js
@@ -461,6 +461,10 @@ export const PreviewMixin = {
         if (!point) return;
 
         const t = state.viewBlendFactor || 0;
+
+        // D2 ekranda gizmo görünmemeli
+        if (t < 0.1) return;
+
         const zoom = state.zoom || 1;
 
         // 3D offset uygula


### PR DESCRIPTION
- Gizmo sadece 3D modda (t > 0.1) görünecek
- Z ekseni seçimi sadece 3D modda yapılabilecek
- D2 ekran için eski davranış geri getirildi