### PR TITLE
Gövde taşıma snap threshold'u artırıldı

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -483,8 +483,8 @@ export function handleDrag(interactionManager, point, event = null) {
         const screenDx = point.x - interactionManager.dragStart.x;
         const screenDy = point.y - interactionManager.dragStart.y;
 
-        // Minimum hareket eşiği (5 birim)
-        const MIN_MOVEMENT = 5;
+        // Minimum hareket eşiği - Body drag için daha yüksek
+        const MIN_MOVEMENT = interactionManager.isBodyDrag ? 15 : 5;
         const totalMovement = Math.hypot(screenDx, screenDy);
 
         if (totalMovement > MIN_MOVEMENT) {


### PR DESCRIPTION
- Body drag için MIN_MOVEMENT 5 → 15 birim oldu
- Endpoint drag için hala 5 birim (hassas kalmalı)
- Ufak oynatmalarda gövde yerinden ayrılmıyor
- Yerinden ayrıldıktan sonra yerine geri bulmak daha kolay