### PR TITLE
Add interactive gizmo handles for axis-locked dragging

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -171,6 +171,12 @@ export class InteractionManager {
         // Koordinat gizmo için seçili eksen (X, Y, Z veya null)
         this.selectedDragAxis = null;
 
+        // Gizmo hover durumu (mouse gizmo ekseninin üzerindeyken)
+        this.hoveredGizmoAxis = null;
+
+        // Boru gövde taşıması için ana eksen (X, Y, Z)
+        this.bodyDragPrimaryAxis = null;
+
         // Double-click detection
         this.lastClickTime = 0;
         this.lastClickPoint = null;

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -235,6 +235,11 @@ export class PlumbingRenderer {
         if (manager.interactionManager?.isDragging) {
             this.drawDragCoordinateGizmo(ctx, manager.interactionManager);
         }
+
+        // Seçim gizmosu (seçili nesne için - sürüklemeden önce)
+        if (!manager.interactionManager?.isDragging && manager.interactionManager?.selectedObject) {
+            this.drawSelectionGizmo(ctx, manager.interactionManager);
+        }
     }
 }
 

--- a/pointer/handle-pointer-down.js
+++ b/pointer/handle-pointer-down.js
@@ -7,7 +7,7 @@ import { screenToWorld } from '../draw/geometry.js';
 import { dom, state } from '../general-files/main.js';
 import { BAGLANTI_TIPLERI } from '../plumbing_v2/objects/pipe.js';
 import { TESISAT_CONSTANTS } from '../plumbing_v2/interactions/tesisat-snap.js';
-import { pixelsToWorld } from '../plumbing_v2/interactions/finders.js';
+import { pixelsToWorld, findGizmoAxisAt } from '../plumbing_v2/interactions/finders.js';
 
 // YENİ IMPORT: 3D hesaplama fonksiyonu
 import { calculate3DSnap } from '../plumbing_v2/interactions/pipe-drawing.js';
@@ -134,6 +134,59 @@ export function handlePointerDown(e) {
             if (this.findRotationHandleAt(this.selectedObject, point, 12)) {
                 this.startRotation(this.selectedObject, point);
                 return true;
+            }
+        }
+
+        // --- GİZMO EKSENİNE TIKLAMA KONTROLÜ ---
+        if (this.selectedObject && !this.isDragging) {
+            let gizmoCenter = null;
+            let allowedAxes = ['X', 'Y', 'Z'];
+
+            if (this.selectedObject.type === 'boru') {
+                gizmoCenter = {
+                    x: (this.selectedObject.p1.x + this.selectedObject.p2.x) / 2,
+                    y: (this.selectedObject.p1.y + this.selectedObject.p2.y) / 2,
+                    z: ((this.selectedObject.p1.z || 0) + (this.selectedObject.p2.z || 0)) / 2
+                };
+
+                // Borunun uzandığı ekseni hesapla
+                const dx = Math.abs(this.selectedObject.p2.x - this.selectedObject.p1.x);
+                const dy = Math.abs(this.selectedObject.p2.y - this.selectedObject.p1.y);
+                const dz = Math.abs((this.selectedObject.p2.z || 0) - (this.selectedObject.p1.z || 0));
+
+                if (dx > dy && dx > dz) {
+                    allowedAxes = ['Y', 'Z'];
+                } else if (dy > dx && dy > dz) {
+                    allowedAxes = ['X', 'Z'];
+                } else if (dz > dx && dz > dy) {
+                    allowedAxes = ['X', 'Y'];
+                }
+            } else if (this.selectedObject.type === 'vana' || this.selectedObject.type === 'sayac' ||
+                       this.selectedObject.type === 'cihaz' || this.selectedObject.type === 'servis_kutusu') {
+                gizmoCenter = { x: this.selectedObject.x, y: this.selectedObject.y, z: this.selectedObject.z || 0 };
+            }
+
+            // Gizmo eksenine tıklandı mı kontrol et
+            if (gizmoCenter) {
+                const clickedAxis = findGizmoAxisAt(gizmoCenter, point, allowedAxes);
+                if (clickedAxis) {
+                    // Gizmo eksenine tıklandı - o eksende locked dragging başlat
+                    console.log('🎯 Gizmo eksenine tıklandı:', clickedAxis);
+
+                    // Sürüklemeyi başlat
+                    if (this.selectedObject.type === 'boru') {
+                        this.startBodyDrag(this.selectedObject, point);
+                    } else {
+                        this.startDrag(this.selectedObject, point);
+                    }
+
+                    // Ekseni kilitle
+                    this.selectedDragAxis = clickedAxis;
+                    this.axisLockDetermined = true;
+                    this.lockedAxis = clickedAxis;
+
+                    return true;
+                }
             }
         }
 


### PR DESCRIPTION
Users can now:
1. Select a pipe or object to see the gizmo
2. Click and drag gizmo handles to move along specific axes
3. Continue using direct object dragging as before

New features:
- drawSelectionGizmo(): Shows gizmo on selected objects (not during drag)
- findGizmoAxisAt(): Hit detection for gizmo axis handles
- Gizmo axis hover highlighting (hoveredGizmoAxis state)
- Click gizmo handle to start axis-locked drag immediately
- Works with pipes (body drag) and all components

The existing drag behavior is preserved - this adds an additional way to initiate axis-constrained movement via the gizmo handles.