### PR TITLE
Add real-time pipe shadow display during drawing

### DIFF
--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -46,6 +46,12 @@ export class PlumbingRenderer {
         // Sadece 3D modunda gölge çiz (Zemine izdüşüm)
         if (state.viewBlendFactor > 0.1 && state.tempVisibility && state.tempVisibility.showPipeShadows) {
             this.drawShadows(ctx, manager);
+
+            // Geçici boru gölgesini de çiz
+            const geciciBoru = manager.interactionManager?.getGeciciBoruCizgisi();
+            if (geciciBoru) {
+                this.drawGeciciBoruShadow(ctx, geciciBoru);
+            }
         }
 
         // Borular

--- a/plumbing_v2/renderer/renderer-pipes.js
+++ b/plumbing_v2/renderer/renderer-pipes.js
@@ -766,6 +766,33 @@ drawPipes(ctx, pipes) {
         });
     },
 
+    drawGeciciBoruShadow(ctx, geciciBoru) {
+        // Geçici borunun gölgesini çiz (zemin seviyesinde)
+        const isLight = this.isLightMode();
+        const shadowColor = isLight ? 'rgba(0, 0, 0, 0.1)' : 'rgba(255, 255, 255, 0.05)';
+
+        ctx.save();
+        ctx.strokeStyle = shadowColor;
+        ctx.lineCap = 'round';
+        ctx.lineJoin = 'round';
+
+        // Zoom'a göre kalınlık ayarı
+        const zoom = state.zoom || 1;
+        let width = 4;
+        if (zoom < 1) {
+            width = 4 / zoom;
+        }
+
+        ctx.lineWidth = width;
+        ctx.beginPath();
+        // Gölge zemin seviyesinde (sadece X, Y koordinatları)
+        ctx.moveTo(geciciBoru.p1.x, geciciBoru.p1.y);
+        ctx.lineTo(geciciBoru.p2.x, geciciBoru.p2.y);
+        ctx.stroke();
+
+        ctx.restore();
+    },
+
     drawGeciciBoru(ctx, geciciBoru, colorGroup = 'YELLOW') {
         ctx.save();
 


### PR DESCRIPTION
- Added drawGeciciBoruShadow method to render temporary pipe shadows at ground level
- Updated plumbing-renderer to show shadows for pipes being drawn in real-time
- Shadow visibility controlled by existing showPipeShadows setting
- Provides better spatial awareness in 3D mode during pipe drawing