### PR TITLE
Fix pipe selection at shared endpoints

### DIFF
--- a/plumbing_v2/interactions/finders.js
+++ b/plumbing_v2/interactions/finders.js
@@ -174,7 +174,7 @@ export function hasAncestorMeter(manager, componentId, componentType) {
     return false;
 }
 
-export function findBoruUcuAt(manager, point, tolerance = 5, onlyFreeEndpoints = false) {
+export function findBoruUcuAt(manager, point, tolerance = 5, onlyFreeEndpoints = false, preferredPipeId = null) {
     const currentFloorId = state.currentFloor?.id;
     const candidates = [];
 
@@ -200,6 +200,13 @@ export function findBoruUcuAt(manager, point, tolerance = 5, onlyFreeEndpoints =
     }
 
     if (candidates.length === 0) return null;
+
+    // Eğer tercih edilen boru adaylar arasındaysa, onu döndür
+    if (preferredPipeId) {
+        const preferredCandidate = candidates.find(c => c.boruId === preferredPipeId);
+        if (preferredCandidate) return preferredCandidate;
+    }
+
     return candidates[0]; // İlk bulunanı döndür
 }
 

--- a/pointer/handle-pointer-down.js
+++ b/pointer/handle-pointer-down.js
@@ -249,7 +249,9 @@ export function handlePointerDown(e) {
         }
 
         // Boru ucu
-        const boruUcu = this.findBoruUcuAt(point, worldTolerance);
+        // Eğer zaten bir boru seçiliyse, ortak noktalarda o boruyu tercih et
+        const preferredPipeId = (this.selectedObject?.type === 'boru') ? this.selectedObject.id : null;
+        const boruUcu = this.findBoruUcuAt(point, worldTolerance, false, preferredPipeId);
         if (boruUcu) {
             const pipe = this.manager.pipes.find(p => p.id === boruUcu.boruId);
             if (pipe) {


### PR DESCRIPTION
- Added preferredPipeId parameter to findBoruUcuAt function
- When multiple pipes share a common endpoint, prefer the already selected pipe
- Prevents unwanted pipe switching during drag operations
- User can now reliably select and drag the intended pipe at shared junction points