### PR TITLE
Implement intuitive line movement with SHIFT toggle

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -177,6 +177,10 @@ export class InteractionManager {
         // Boru gövde taşıması için ana eksen (X, Y, Z)
         this.bodyDragPrimaryAxis = null;
 
+        // Sezgisel endpoint drag için tercih edilen eksen (X, Y, Z veya null)
+        this.endpointDragPreferredAxis = null;
+        this.endpointDragAlternativeAxes = [];
+
         // Double-click detection
         this.lastClickTime = 0;
         this.lastClickPoint = null;

--- a/plumbing_v2/renderer/renderer-interaction.js
+++ b/plumbing_v2/renderer/renderer-interaction.js
@@ -113,8 +113,15 @@ export const InteractionMixin = {
         const obj = interactionManager.dragObject;
 
         if (obj.type === 'boru' && interactionManager.dragEndpoint) {
-            // Boru endpoint taşıması - Tüm eksenler
+            // Boru endpoint taşıması
             point = interactionManager.dragEndpoint === 'p1' ? obj.p1 : obj.p2;
+
+            // ✨✨✨ SEZGİSEL EKSEN GÖSTERİMİ (INTUITIVE AXIS DISPLAY) ✨✨✨
+            // Eğer tercih edilen eksen varsa, sadece seçili ekseni göster
+            if (interactionManager.endpointDragPreferredAxis && selectedAxis) {
+                allowedAxes = [selectedAxis]; // Sadece aktif olan ekseni göster
+            }
+            // ✨✨✨ SON ✨✨✨
         } else if (obj.type === 'boru' && interactionManager.isBodyDrag) {
             // Boru gövde taşıması - Borunun ortası
             point = {


### PR DESCRIPTION
When moving line endpoints (hatlar), the system now intelligently determines a preferred movement direction based on the parent pipe's orientation. By default, only the preferred axis is shown and active. When SHIFT is pressed, the alternative axes become available.

Key changes:
- Determine preferred axis based on parent pipe orientation in startEndpointDrag
- Add SHIFT key detection to axis selection logic during drag
- Modify endpoint drag to prioritize parent-aligned axis by default
- Update gizmo rendering to show only active axis for endpoint drag
- Body (gövde) drag continues to show both perpendicular axes as before

This improves the user experience by making line movement more intuitive and predictable based on the piping hierarchy.

https://claude.ai/code/session_01H3Z2cxm8nyXvcFTcUfbKkH