### PR TITLE
Fix: Prevent mode switch to line draw during undo operation

### DIFF
--- a/general-files/history.js
+++ b/general-files/history.js
@@ -228,9 +228,10 @@ export function restoreState(snapshot) {
              plumbingManager.interactionManager.snapSystem.clearStartPoint();
         }
 
-        if (snapshot.plumbingInteraction.boruCizimAktif) {
-             plumbingManager.interactionManager.manager.activeTool = 'boru';
-        }
+        // Removed: Don't change activeTool during undo - keep current mode
+        // if (snapshot.plumbingInteraction.boruCizimAktif) {
+        //      plumbingManager.interactionManager.manager.activeTool = 'boru';
+        // }
     } else if (plumbingManager && plumbingManager.interactionManager) {
         // Eski kayıtlarda veri yoksa temizle
         plumbingManager.interactionManager.boruCizimAktif = false;


### PR DESCRIPTION
When undo (Ctrl+Z) was performed, the application incorrectly switched to line draw mode (boru) if that mode was active during the saved state. This caused confusion as users expected to remain in their current mode.

Fixed by removing the automatic activeTool assignment during state restoration in history.js:232. The internal plumbing state (boruCizimAktif, boruBaslangic) is still properly restored, but the UI mode no longer changes unexpectedly.

https://claude.ai/code/session_0149GtJLrCuZLyHhQPjoWLqk