### PR TITLE
Fix undo/redo to prevent unwanted switch to line drawing mode

### DIFF
--- a/general-files/history.js
+++ b/general-files/history.js
@@ -216,26 +216,16 @@ export function restoreState(snapshot) {
         ? restoredNodes[snapshot.startPointIndex]
         : null;
 
-    // --- YENİ: Tesisat etkileşim durumunu (boruBaslangic) geri yükle ---
-    if (snapshot.plumbingInteraction && plumbingManager && plumbingManager.interactionManager) {
-        plumbingManager.interactionManager.boruCizimAktif = snapshot.plumbingInteraction.boruCizimAktif;
-        plumbingManager.interactionManager.boruBaslangic = snapshot.plumbingInteraction.boruBaslangic;
-
-        if (snapshot.plumbingInteraction.boruBaslangic) {
-             // Snap sistemine de başlangıç noktasını bildir
-             plumbingManager.interactionManager.snapSystem.setStartPoint(snapshot.plumbingInteraction.boruBaslangic.nokta);
-        } else {
-             plumbingManager.interactionManager.snapSystem.clearStartPoint();
-        }
-
-        if (snapshot.plumbingInteraction.boruCizimAktif) {
-             plumbingManager.interactionManager.manager.activeTool = 'boru';
-        }
-    } else if (plumbingManager && plumbingManager.interactionManager) {
-        // Eski kayıtlarda veri yoksa temizle
+    // --- Tesisat etkileşim durumunu undo/redo sırasında geri yükleme ---
+    // NOT: Undo/redo yapıldığında devam eden boru çizim etkileşimini geri yüklememeliyiz.
+    // Sadece objeleri (borular, bloklar) geri yükleriz, yarım kalmış çizim durumunu değil.
+    // Bu sayede kullanıcı undo yaptığında istenmeyen şekilde hat çizim moduna geçmez.
+    if (plumbingManager && plumbingManager.interactionManager) {
+        // Her undo/redo sonrası etkileşim durumunu temizle
         plumbingManager.interactionManager.boruCizimAktif = false;
         plumbingManager.interactionManager.boruBaslangic = null;
         plumbingManager.interactionManager.snapSystem.clearStartPoint();
+        plumbingManager.interactionManager.manager.activeTool = null;
     }
 
     setState({


### PR DESCRIPTION
When undo/redo was called, the system was restoring the in-progress pipe drawing state (boruCizimAktif), which caused the application to switch to line drawing mode even when the user didn't intend to. This was confusing and disruptive to the workflow.

The fix: During undo/redo, we now clear the pipe drawing interaction state instead of restoring it. We still restore all the actual objects (pipes, blocks, walls, etc.) but we don't restore in-progress drawing actions. This ensures that undo/redo only restores the saved state of objects, not temporary interaction states.

Changes:
- Modified restoreState() in history.js to clear pipe drawing state after restore
- Clear boruCizimAktif, boruBaslangic, snap start point, and activeTool
- Added explanatory comments in Turkish

https://claude.ai/code/session_01QhGp1CFSajMQzwi4Xq8Fhq