### PR TITLE
3D sürükleme: Gizmo ile kilitli eksen artık mouse bırakılana kadar sa…

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -475,7 +475,8 @@ export function handleDrag(interactionManager, point, event = null) {
         const MIN_MOVEMENT = interactionManager.isBodyDrag ? 2 : 5;
         const totalMovement = Math.hypot(screenDx, screenDy);
 
-        if (totalMovement > MIN_MOVEMENT) {
+        // Otomatik eksen belirleme sadece manuel kilit yoksa çalışmalı
+        if (totalMovement > MIN_MOVEMENT && !interactionManager.axisLockDetermined) {
             // Çizim algoritması ile aynı: Her eksene olan uzaklığı hesapla
 
             // X Ekseni (y=0 doğrusu): Ekranda yatay. Uzaklık = |dy|


### PR DESCRIPTION
…bit kalıyor

Kullanıcı gizmo eksenine tıklayarak manuel olarak bir ekseni kilitlediğinde, otomatik eksen belirleme mantığı artık devre dışı kalıyor. Bu sayede sürükleme sırasında eksen değişmiyor ve kullanıcı mouse'u bırakana kadar seçili eksende kalıyor.

https://claude.ai/code/session_01934Kqx1Cax9F8h9iE5M9QZ