### PR TITLE
Gizmo iyileştirmeleri: boyut, hover ve dik snap

### DIFF
--- a/plumbing_v2/interactions/finders.js
+++ b/plumbing_v2/interactions/finders.js
@@ -719,7 +719,7 @@ export function findTranslateGizmoAxisAt(gizmoCenter, mousePoint, allowedAxes = 
     if (t < 0.1) return null;
 
     const zoom = state.zoom || 1;
-    const armLength = 50 / zoom; // Ekranda 50px (zoom'a göre ayarlanır)
+    const armLength = 30 * Math.min(1, zoom); // Uzaklaşınca küçülür, yaklaşınca büyümez
     const hitTolerance = 12 / zoom; // Biraz daha geniş tolerans (tutulabilmesi için)
 
     // Gizmo merkez noktasının ekran koordinatları

--- a/plumbing_v2/renderer/renderer-interaction.js
+++ b/plumbing_v2/renderer/renderer-interaction.js
@@ -208,17 +208,23 @@ export const InteractionMixin = {
                     z: ((obj.p1.z || 0) + (obj.p2.z || 0)) / 2
                 };
                 if (this.drawTranslateGizmo) {
-                    this.drawTranslateGizmo(ctx, centerPoint, interactionManager.hoveredGizmoAxis, bodyAllowedAxes);
+                    // Sadece merkez gizmo hover edilmişse eksen aktif
+                    const centerSelectedAxis = interactionManager.hoveredGizmoId === 'center' ? interactionManager.hoveredGizmoAxis : null;
+                    this.drawTranslateGizmo(ctx, centerPoint, centerSelectedAxis, bodyAllowedAxes);
                 }
 
                 // p1 endpoint gizmo (tüm eksenler)
                 if (this.drawTranslateGizmo) {
-                    this.drawTranslateGizmo(ctx, obj.p1, interactionManager.hoveredGizmoAxis, ['X', 'Y', 'Z']);
+                    // Sadece p1 gizmo hover edilmişse eksen aktif
+                    const p1SelectedAxis = interactionManager.hoveredGizmoId === 'p1' ? interactionManager.hoveredGizmoAxis : null;
+                    this.drawTranslateGizmo(ctx, obj.p1, p1SelectedAxis, ['X', 'Y', 'Z']);
                 }
 
                 // p2 endpoint gizmo (tüm eksenler)
                 if (this.drawTranslateGizmo) {
-                    this.drawTranslateGizmo(ctx, obj.p2, interactionManager.hoveredGizmoAxis, ['X', 'Y', 'Z']);
+                    // Sadece p2 gizmo hover edilmişse eksen aktif
+                    const p2SelectedAxis = interactionManager.hoveredGizmoId === 'p2' ? interactionManager.hoveredGizmoAxis : null;
+                    this.drawTranslateGizmo(ctx, obj.p2, p2SelectedAxis, ['X', 'Y', 'Z']);
                 }
             }
         } else if (obj.type === 'vana' || obj.type === 'sayac' || obj.type === 'cihaz' || obj.type === 'servis_kutusu') {

--- a/plumbing_v2/renderer/renderer-previews.js
+++ b/plumbing_v2/renderer/renderer-previews.js
@@ -582,10 +582,10 @@ export const PreviewMixin = {
 
         ctx.save();
 
-        // Kol uzunluğu: 50px ekranda (zoom'a göre ayarlanır)
-        const armLength = 50 / zoom;
+        // Kol uzunluğu: uzaklaşınca küçülür, yaklaşınca büyümez
+        const armLength = 30 * Math.min(1, zoom);
         const lineWidth = 1.5 / zoom;
-        const arrowSize = 8 / zoom; // Ok başı boyutu
+        const arrowSize = 6 * Math.min(1, zoom); // Ok başı boyutu
 
         // Yardımcı fonksiyon: Ok başı çiz
         const drawArrowHead = (x, y, angle, color, alpha) => {

--- a/pointer/handle-pointer-move.js
+++ b/pointer/handle-pointer-move.js
@@ -63,8 +63,20 @@ export function handlePointerMove(e) {
                 // p2 gizmo kontrolü
                 const p2Axis = findTranslateGizmoAxisAt(this.selectedObject.p2, point, ['X', 'Y', 'Z']);
 
-                // Herhangi biri hover edilmişse onu kullan (öncelik sırasıyla: p1, p2, center)
-                this.hoveredGizmoAxis = p1Axis || p2Axis || centerAxis;
+                // Sadece mouse'un gerçekten üzerinde olduğu gizmoda eksen aktif olsun
+                if (p1Axis) {
+                    this.hoveredGizmoAxis = p1Axis;
+                    this.hoveredGizmoId = 'p1';
+                } else if (p2Axis) {
+                    this.hoveredGizmoAxis = p2Axis;
+                    this.hoveredGizmoId = 'p2';
+                } else if (centerAxis) {
+                    this.hoveredGizmoAxis = centerAxis;
+                    this.hoveredGizmoId = 'center';
+                } else {
+                    this.hoveredGizmoAxis = null;
+                    this.hoveredGizmoId = null;
+                }
             }
         } else if (this.selectedObject.type === 'vana' || this.selectedObject.type === 'sayac' ||
                    this.selectedObject.type === 'cihaz' || this.selectedObject.type === 'servis_kutusu') {


### PR DESCRIPTION
1. Gizmo boyutu ayarlandı:
   - armLength: 50/zoom -> 30*Math.min(1,zoom)
   - Uzaklaşınca küçülür, yaklaşınca büyümez
   - Genel olarak %40 daha küçük (30px vs 50px)

2. Çoklu gizmo hover detection düzeltildi:
   - hoveredGizmoId eklendi ('p1', 'p2', 'center')
   - Her gizmo için ayrı hover kontrolü
   - Sadece mouse'un üzerindeki gizmoda eksen aktif

3. Body drag için dik snap eklendi:
   - Bağlı kollar drag eksenine dik olunca snap yapar
   - 5px tolerans ile dik kontrolü
   - X/Y/Z eksenlerine göre offset ayarlaması