### PR TITLE
Tesisat parçalarını kopyala/kes/yapıştır özelliği eklendi

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -182,6 +182,13 @@ export class InteractionManager {
         this.lastClickPoint = null;
         this.DOUBLE_CLICK_THRESHOLD = 300; // ms
         this.DOUBLE_CLICK_DISTANCE = 10; // world units
+
+        // Copy/Paste/Cut state
+        this.copiedPipes = null; // Kopyalanan pipe'lar ve bileşenler
+        this.cutPipes = null; // Kesilen pipe'lar ve bileşenler
+        this.cutPipesOriginalIds = null; // Kesilen pipe'ların orijinal ID'leri
+        this.pastePreviewPipes = null; // Yapıştırma preview'ı
+        this.pastePreviewComponents = null; // Yapıştırma preview bileşenleri
     }
 
     /**

--- a/plumbing_v2/plumbing-renderer.js
+++ b/plumbing_v2/plumbing-renderer.js
@@ -232,6 +232,11 @@ export class PlumbingRenderer {
             this.drawComponentOnPipePreview(ctx, manager.interactionManager.componentOnPipePreview);
         }
 
+        // Copy/Paste Preview (CTRL+C veya CTRL+X sonrası)
+        if (manager.interactionManager && (manager.interactionManager.copiedPipes || manager.interactionManager.cutPipes)) {
+            this.drawPastePreview(ctx, manager.interactionManager);
+        }
+
         // Seçili borunun yolunu sağ üstte göster
         if (state.tempVisibility.showPipePath && window._selectedPipePath && window._selectedPipePath.length > 0) {
             this.drawSelectedPipePath(ctx);


### PR DESCRIPTION
Yeni Özellikler:
- CTRL+C: Seçili boru ve sonrasındaki tüm parçaları kopyalar
- CTRL+X: Seçili boru ve sonrasındaki tüm parçaları keser
- CTRL+V: Kopyalanan/kesilen parçaları mouse pozisyonuna yapıştırır
- Mouse ucunda kesilmiş/kopyalanmış tesisat ön izlemesi gösterilir
- BFS algoritması ile downstream (sonrasındaki) tüm boru ve bileşenler bulunur

Dosya Değişiklikleri:
- plumbing_v2/interactions/keyboard-handler.js: Copy/Cut/Paste handler'lar eklendi
- plumbing_v2/interactions/interaction-manager.js: Copy/paste state yönetimi eklendi
- plumbing_v2/renderer/renderer-previews.js: Paste preview rendering fonksiyonu eklendi
- plumbing_v2/plumbing-renderer.js: Paste preview render entegrasyonu yapıldı

https://claude.ai/code/session_iD3eX