### PR TITLE
Gölge renkleri sabit renkte kaldı (tema değişiminden etkilenmiyor)

### DIFF
--- a/general-files/main.js
+++ b/general-files/main.js
@@ -155,12 +155,12 @@ export function getCursorWallDrawColor() {
 
 export function getShadow(ctx, shadowColor = null, shadowBlur = 3, shadowOffsetX = 0.5, shadowOffsetY = 0.5) {
     if (isLightMode()) {
-        ctx.shadowColor = 'rgba(0, 0, 0, 1)';
+        ctx.shadowColor = 'rgba(139, 139, 139, 1)';
         ctx.shadowBlur = 3;
         ctx.shadowOffsetX = 0.5;
         ctx.shadowOffsetY = 0.5;
     } else {
-        ctx.shadowColor = 'rgba(255, 255, 255, 1)';
+        ctx.shadowColor = 'rgba(139, 139, 139, 1)';
         ctx.shadowBlur = 3;
         ctx.shadowOffsetX = 0.5;
         ctx.shadowOffsetY = 0.5;

--- a/plumbing_v2/renderer/renderer-devices.js
+++ b/plumbing_v2/renderer/renderer-devices.js
@@ -224,7 +224,7 @@ export const DeviceMixin = {
         const boxSize = 15;
         const cornerRadius = 3;
 
-        ctx.shadowColor = isLightMode() ? 'rgba(0, 0, 0, 0.5)' : 'rgba(255, 255, 255, 0.5)';
+        ctx.shadowColor = 'rgba(0, 0, 0, 0.5)';
         ctx.shadowBlur = 8;
         ctx.shadowOffsetX = 2;
         ctx.shadowOffsetY = 2;
@@ -662,7 +662,7 @@ export const DeviceMixin = {
             ctx.lineJoin = 'round';
 
             // Gölge efekti
-            ctx.shadowColor = isLightMode() ? 'rgba(0, 0, 0, 0.3)' : 'rgba(255, 255, 255, 0.3)';
+            ctx.shadowColor = 'rgba(0, 0, 0, 0.3)';
             ctx.shadowBlur = 4;
 
             ctx.beginPath();


### PR DESCRIPTION
Gölge renkleri her iki temada da aynı kalıyor:
- getShadow: rgba(139, 139, 139, 1)
- Cihaz gölgeleri: rgba(0, 0, 0, 0.5) ve rgba(0, 0, 0, 0.3)

https://claude.ai/code/session_0149sApXQQiS6H8W5SRYCcHK