### PR TITLE
Sonlanma vanalarının boru ucuna tam oturması sağlandı

### DIFF
--- a/plumbing_v2/interactions/component-placement.js
+++ b/plumbing_v2/interactions/component-placement.js
@@ -300,14 +300,16 @@ export function handleVanaPlacement(vanaPreview) {
     // --- 2. UÇ NOKTALARA SABİTLEME (3D Mesafe ile) ---
     // pipe.uzunluk yerine hesapladığımız len3d (3D uzunluk) kullan
     const VANA_GENISLIGI = 8;
-    const BORU_UCU_BOSLUK = 1; // max 1 cm kalsın boru ucunda
-    const fixedDistanceFromEnd = VANA_GENISLIGI / 2 + BORU_UCU_BOSLUK; // ~5 cm
+    const BORU_UCU_BOSLUK = 1; // max 1 cm kalsın boru ucunda (ara vanalar için)
+    const BORU_UCU_BOSLUK_SONLANMA = 0; // Sonlanma vanaları için boşluk yok
+    const fixedDistanceFromEnd = VANA_GENISLIGI / 2 + BORU_UCU_BOSLUK; // ~5 cm (ara vanalar)
+    const fixedDistanceFromEndSonlanma = VANA_GENISLIGI / 2 + BORU_UCU_BOSLUK_SONLANMA; // 4 cm (sonlanma vanaları)
 
     // Boru ucuna yakın mı kontrol et
-    const END_THRESHOLD_CM = 10; 
+    const END_THRESHOLD_CM = 10;
     const distToP1 = t * len3d;
     const distToP2 = (1 - t) * len3d;
-    
+
     const isNearP1 = distToP1 < END_THRESHOLD_CM;
     const isNearP2 = distToP2 < END_THRESHOLD_CM;
 
@@ -327,18 +329,25 @@ export function handleVanaPlacement(vanaPreview) {
     }
 
     // --- 3. NESNEYİ OLUŞTUR VE AYARLA ---
-    const vana = createVana(x, y, 'AKV', vanaOptions);
-    
+    // tempComponent'ten vana tipini al (yoksa varsayılan 'AKV')
+    const vanaTipi = this.manager.tempComponent?.vanaTipi || 'AKV';
+    const vana = createVana(x, y, vanaTipi, vanaOptions);
+
     // Z Yüksekliğini Ata
     vana.z = z;
 
     // AÇI DÜZELTMESİ (Sorunu çözen kısım)
     if (isVertical) {
         // Düşey boru ise -45 derece (3D izometrikte dikey görünüm)
-        vana.rotation = -45; 
+        vana.rotation = -45;
     } else {
         // Yatay boru ise kendi açısı
         vana.rotation = pipe.aciDerece;
+    }
+
+    // Sonlanma vanaları için fixedDistance değerini güncelle (boru ucuna daha yakın)
+    if (vana.isSonlanma() && vana.fixedDistance !== null) {
+        vana.fixedDistance = fixedDistanceFromEndSonlanma;
     }
 
     // Manager'a ekle

--- a/plumbing_v2/objects/valve.js
+++ b/plumbing_v2/objects/valve.js
@@ -363,8 +363,8 @@ const dx = pipe.p2.x - pipe.p1.x;
         if (pipeLength < 0.1) return false;
         // --- DÜZELTME BİTİŞ ---
 
-        // Mesafe kontrolü: uçlardan 1cm, nesneler arası 1cm
-        const MIN_EDGE_DISTANCE = 1; // cm
+        // Mesafe kontrolü: uçlardan 1cm (ara vanalar), sonlanma vanaları için 0.5cm
+        const MIN_EDGE_DISTANCE = this.isSonlanma() ? 0.5 : 1; // cm
         const OBJECT_MARGIN = 1; // cm - Her nesnenin sağında ve solunda
 
         const minT = MIN_EDGE_DISTANCE / pipeLength;
@@ -459,8 +459,8 @@ const dx = pipe.p2.x - pipe.p1.x;
         // DÜZELTME: Threshold'u 10cm'den 3cm'e düşürdük - vana daha az atlayacak
         const END_THRESHOLD_CM = 3; // 3 cm içindeyse uç sayılır (eski: 10)
         const VANA_GENISLIGI = 8;
-        const BORU_UCU_BOSLUK = 1;
-        const fixedDistanceFromEnd = VANA_GENISLIGI / 2 + BORU_UCU_BOSLUK; // 5 cm
+        const BORU_UCU_BOSLUK = this.isSonlanma() ? 0 : 1; // Sonlanma vanaları için boşluk yok
+        const fixedDistanceFromEnd = VANA_GENISLIGI / 2 + BORU_UCU_BOSLUK; // Sonlanma: 4cm, Ara: 5cm
 
         const distToP1 = newT * pipeLength; // 3D Uzunluk kullanılıyor
         const distToP2 = (1 - newT) * pipeLength;


### PR DESCRIPTION
- Sonlanma vanaları (BRANSMAN, YAN_BINA, DOMESTIK) artık boru ucuna daha yakın yerleştiriliyor
- component-placement.js: Sonlanma vanaları için fixedDistance 4cm'ye düşürüldü (ara vanalar 5cm)
- valve.js: Sonlanma vanaları için MIN_EDGE_DISTANCE 0.5cm'ye düşürüldü (ara vanalar 1cm)
- Vana tipi artık tempComponent'ten alınıyor (önceden 'AKV' olarak sabit kodlanmıştı)

https://claude.ai/code/session_01CH1mcC3JdTRFS2UAPY5Qkp