### PR TITLE
KRİTİK: fromJSON'da sonlanma vanaları için showEndCap = true zorla

### DIFF
--- a/plumbing_v2/objects/valve.js
+++ b/plumbing_v2/objects/valve.js
@@ -699,7 +699,13 @@ const dx = pipe.p2.x - pipe.p1.x;
         vana.rotation = data.rotation;
         vana.girisBagliBoruId = data.girisBagliBoruId;
         vana.cikisBagliBoruId = data.cikisBagliBoruId;
-        vana.showEndCap = data.showEndCap || false; // Kapama sembolü durumunu yükle
+
+        // Sonlanma vanaları için showEndCap daima true
+        if (vana.isSonlanma()) {
+            vana.showEndCap = true;
+        } else {
+            vana.showEndCap = data.showEndCap || false;
+        }
 
         return vana;
     }


### PR DESCRIPTION
SORUN: Vana JSON'dan yüklenirken showEndCap = false geliyordu
ÇÖZÜM: fromJSON'da sonlanma vanaları kontrol edilip showEndCap = true yapıldı

Bu değişiklik ile state yüklendikten sonra da kapama sembolü korunacak.

https://claude.ai/code/session_01CH1mcC3JdTRFS2UAPY5Qkp