### PR TITLE
Vana taşırken hat parent bağlantısının koparılması sorunu düzeltildi

### DIFF
--- a/plumbing_v2/interactions/component-placement.js
+++ b/plumbing_v2/interactions/component-placement.js
@@ -792,6 +792,16 @@ function redistributePipeComponentsInline(oldPipe, boru1, boru2, splitPoint) {
         }
     });
 
+    // Parent boruyu güncelle - eski boruya bağlı olan parent pipe'ın referansını boru1'e güncelle
+    const parentPipe = this.manager.pipes.find(p =>
+        p.bitisBaglanti &&
+        p.bitisBaglanti.tip === 'boru' &&
+        p.bitisBaglanti.hedefId === oldPipe.id
+    );
+    if (parentPipe) {
+        parentPipe.bitisBaglanti.hedefId = boru1.id;
+    }
+
     this.manager.saveToState();
 }
 


### PR DESCRIPTION
Vana taşınırken boru bölünmesi (split) sonrası parent borunun bitisBaglanti referansı güncellenmiyordu. redistributePipeComponentsInline fonksiyonuna parent boru güncellemesi eklendi.

https://claude.ai/code/session_01CSFFrQt5a9uKUbNfgSgJCg