### PR TITLE
Start endpoint drag when clicking near pipe tips to avoid accidental body-move

### DIFF
--- a/plumbing_v2/interactions/finders.js
+++ b/plumbing_v2/interactions/finders.js
@@ -282,8 +282,7 @@ export function checkVanaAtPoint(manager, point, tolerance = 2) {
     return null;
 }
 
-export function findPipeEndpoint(pipe, point) {
-    const tolerance = 2; 
+export function findPipeEndpoint(pipe, point, tolerance = 2) {
     const p1Screen = getScreenPoint(pipe.p1);
     const p2Screen = getScreenPoint(pipe.p2);
     const distToP1 = Math.hypot(point.x - p1Screen.x, point.y - p1Screen.y);

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -409,8 +409,8 @@ export class InteractionManager {
         return checkVanaAtPoint(this.manager, point, tolerance);
     }
 
-    findPipeEndpoint(pipe, point) {
-        return findPipeEndpoint(pipe, point);
+    findPipeEndpoint(pipe, point, tolerance = 2) {
+        return findPipeEndpoint(pipe, point, tolerance);
     }
 
     removeObject(obj) {

--- a/pointer/handle-pointer-down.js
+++ b/pointer/handle-pointer-down.js
@@ -330,6 +330,15 @@ export function handlePointerDown(e) {
                     hitObject.bitisBaglanti?.tip === BAGLANTI_TIPLERI.SAYAC) {
                     return true;
                 }
+                // Uca yakın tıklamalarda gövde taşıma yerine endpoint drag başlat.
+                // Böylece boru ucundan tutup çekince bağlantı kopması engellenir.
+                const endpoint = this.findPipeEndpoint(hitObject, point, worldTolerance);
+                if (endpoint) {
+                    this.selectedEndpoint = endpoint;
+                    this.startEndpointDrag(hitObject, endpoint, point);
+                    return true;
+                }
+
                 this.startBodyDrag(hitObject, point);
             } else {
                 this.startDrag(hitObject, point);


### PR DESCRIPTION
### Motivation
- Prevent accidental pipe disconnection when users click-and-drag very close to a pipe endpoint by ensuring those clicks start an endpoint drag instead of a body move.
- Allow caller code to control proximity sensitivity by making the endpoint finder tolerance configurable.

### Description
- `pointer/handle-pointer-down.js`: before falling back to `startBodyDrag(...)`, the code now calls `this.findPipeEndpoint(hitObject, point, worldTolerance)` and, if an endpoint is detected, sets `selectedEndpoint` and calls `startEndpointDrag(...)` instead of starting a body drag.
- `plumbing_v2/interactions/finders.js`: changed `findPipeEndpoint(pipe, point)` to `findPipeEndpoint(pipe, point, tolerance = 2)` so callers can pass a world-space tolerance.
- `plumbing_v2/interactions/interaction-manager.js`: updated the `findPipeEndpoint` wrapper to accept and forward an optional `tolerance` parameter to the underlying finder.

### Testing
- Ran quick syntax checks with `node --check` on the modified files and they passed (`pointer/handle-pointer-down.js`, `plumbing_v2/interactions/finders.js`, `plumbing_v2/interactions/interaction-manager.js`).
- Attempted to launch a local HTTP server and capture a UI screenshot with Playwright, but the environment could not load the app (browser/file access errors), so visual confirmation was not collected.
- All automated static checks performed succeeded; UI runtime verification remains recommended in a normal browser environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850ee84bec832b8a5f8a1ecaf0df58)