### PR TITLE
Improve near-endpoint pipe drag detection to avoid unintended MOVE mode

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -409,8 +409,8 @@ export class InteractionManager {
         return checkVanaAtPoint(this.manager, point, tolerance);
     }
 
-    findPipeEndpoint(pipe, point) {
-        return findPipeEndpoint(pipe, point);
+    findPipeEndpoint(pipe, point, tolerance = 2) {
+        return findPipeEndpoint(pipe, point, tolerance);
     }
 
     removeObject(obj) {

--- a/pointer/handle-pointer-down.js
+++ b/pointer/handle-pointer-down.js
@@ -330,6 +330,15 @@ export function handlePointerDown(e) {
                     hitObject.bitisBaglanti?.tip === BAGLANTI_TIPLERI.SAYAC) {
                     return true;
                 }
+                // Uca yakın tıklamalarda gövde taşıma yerine endpoint drag başlat.
+                // Böylece boru ucundan tutup çekince bağlantı kopması engellenir.
+                const endpoint = this.findPipeEndpoint(hitObject, point, worldTolerance);
+                if (endpoint) {
+                    this.selectedEndpoint = endpoint;
+                    this.startEndpointDrag(hitObject, endpoint, point);
+                    return true;
+                }
+
                 this.startBodyDrag(hitObject, point);
             } else {
                 this.startDrag(hitObject, point);


### PR DESCRIPTION
### Motivation
- Reduce accidental pipe body-moves when the user clicks very close to a pipe endpoint by treating near-tip clicks as endpoint intent. 
- Make endpoint detection more forgiving along the pipe axis so short misses still start endpoint drags instead of a body drag. 

### Description
- Updated `plumbing_v2/interactions/finders.js` by changing `findPipeEndpoint` to accept an optional `tolerance` (`tolerance = 2`) and added a projection-based fallback that: projects the click onto the pipe segment, checks perpendicular distance against `tolerance`, and if the projected point lies inside an expanded `endpointZone` (`Math.max(tolerance * 2, 8)`), returns the nearest endpoint (`'p1'`/`'p2'`).
- Modified `pointer/handle-pointer-down.js` to call `this.findPipeEndpoint(hitObject, point, worldTolerance)` before falling back to `startBodyDrag(...)`, and to start an endpoint drag (`startEndpointDrag(...)`) when an endpoint intent is detected.
- Updated `plumbing_v2/interactions/interaction-manager.js` to forward an optional `tolerance` parameter in its `findPipeEndpoint` wrapper so callers can control sensitivity.

### Testing
- Ran syntax checks with `node --check plumbing_v2/interactions/finders.js`, `node --check pointer/handle-pointer-down.js`, and `node --check plumbing_v2/interactions/interaction-manager.js`, and they all passed. 
- No automated UI/visual tests were run in this environment; runtime verification in a browser is recommended to confirm interaction behavior visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850ee84bec832b8a5f8a1ecaf0df58)