### PR TITLE
Fix intermittent pipe detachment by combining logical links with geometric proximity during drag

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -409,8 +409,8 @@ export class InteractionManager {
         return checkVanaAtPoint(this.manager, point, tolerance);
     }
 
-    findPipeEndpoint(pipe, point) {
-        return findPipeEndpoint(pipe, point);
+    findPipeEndpoint(pipe, point, tolerance = 2) {
+        return findPipeEndpoint(pipe, point, tolerance);
     }
 
     removeObject(obj) {

--- a/pointer/handle-pointer-down.js
+++ b/pointer/handle-pointer-down.js
@@ -330,6 +330,15 @@ export function handlePointerDown(e) {
                     hitObject.bitisBaglanti?.tip === BAGLANTI_TIPLERI.SAYAC) {
                     return true;
                 }
+                // Uca yakın tıklamalarda gövde taşıma yerine endpoint drag başlat.
+                // Böylece boru ucundan tutup çekince bağlantı kopması engellenir.
+                const endpoint = this.findPipeEndpoint(hitObject, point, worldTolerance);
+                if (endpoint) {
+                    this.selectedEndpoint = endpoint;
+                    this.startEndpointDrag(hitObject, endpoint, point);
+                    return true;
+                }
+
                 this.startBodyDrag(hitObject, point);
             } else {
                 this.startDrag(hitObject, point);


### PR DESCRIPTION
### Motivation
- Fix intermittent detachment when dragging a pipe near its endpoint where logically-linked neighbor pipes were omitted from the drag snapshot due to tiny coordinate/3D drift.
- Ensure endpoints that are the same logical connection (`baslangicBaglanti` / `bitisBaglanti`) are moved together as a tree instead of allowing a single pipe to appear to “break” off.
- Reduce unintended body-drag when the user clicks very close to a pipe endpoint by giving near-axis clicks endpoint intent where appropriate.

### Description
- Added helpers in `plumbing_v2/interactions/drag-handler.js`: `pushUniqueConnection`, `getLogicalEndpointConnections`, and `findConnectedPipesRobust` to merge geometric proximity checks with ID-based logical links when collecting connected endpoints.
- Replaced the previous geometric-only collection logic in `startEndpointDrag` and `startBodyDrag` to use `findConnectedPipesRobust`, populating `connectedPipesAtEndpoint`, `connectedPipesAtP1`, and `connectedPipesAtP2` so drag propagation includes logically-linked neighbors.
- Enhanced `plumbing_v2/interactions/finders.js` by changing `findPipeEndpoint` to accept an optional `tolerance` (`tolerance = 2`) and adding a projection-based fallback that treats near-axis clicks as endpoint intent when within an expanded endpoint zone.
- Updated `plumbing_v2/interactions/interaction-manager.js` to forward an optional `tolerance` through its `findPipeEndpoint` wrapper and modified `pointer/handle-pointer-down.js` to call `this.findPipeEndpoint(hitObject, point, worldTolerance)` and start an endpoint drag when endpoint intent is detected.

### Testing
- Ran a syntax check: `node --check plumbing_v2/interactions/drag-handler.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850ee84bec832b8a5f8a1ecaf0df58)