### PR TITLE
Fix P1/P2 overlap during drag by switching to nearest-endpoint geometry-based capture

### DIFF
--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -409,8 +409,8 @@ export class InteractionManager {
         return checkVanaAtPoint(this.manager, point, tolerance);
     }
 
-    findPipeEndpoint(pipe, point) {
-        return findPipeEndpoint(pipe, point);
+    findPipeEndpoint(pipe, point, tolerance = 2) {
+        return findPipeEndpoint(pipe, point, tolerance);
     }
 
     removeObject(obj) {

--- a/pointer/handle-pointer-down.js
+++ b/pointer/handle-pointer-down.js
@@ -330,6 +330,15 @@ export function handlePointerDown(e) {
                     hitObject.bitisBaglanti?.tip === BAGLANTI_TIPLERI.SAYAC) {
                     return true;
                 }
+                // Uca yakın tıklamalarda gövde taşıma yerine endpoint drag başlat.
+                // Böylece boru ucundan tutup çekince bağlantı kopması engellenir.
+                const endpoint = this.findPipeEndpoint(hitObject, point, worldTolerance);
+                if (endpoint) {
+                    this.selectedEndpoint = endpoint;
+                    this.startEndpointDrag(hitObject, endpoint, point);
+                    return true;
+                }
+
                 this.startBodyDrag(hitObject, point);
             } else {
                 this.startDrag(hitObject, point);


### PR DESCRIPTION
### Motivation
- A previous attempt to merge logical links into drag snapshots caused wrong-side endpoint pairing and led to neighboring pipes' `p1`/`p2` endpoints overlapping when dragging a pipe. The goal is to stop that regression while still keeping small-coordinate drift tolerant so connected neighbors move together.

### Description
- Removed the over-aggressive logical endpoint inference and replaced it with a simplified geometric collector implemented as `findConnectedPipesRobust` and `pushUniqueConnection` in `plumbing_v2/interactions/drag-handler.js`, which picks only the nearest endpoint (`p1` or `p2`) per candidate pipe.
- Increased the drift tolerance used for neighbor capture to `TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE * 3` so tiny coordinate drift still groups connected endpoints.
- Replaced the old per-anchor collection code with calls to `findConnectedPipesRobust` for both endpoint drags (`connectedPipesAtEndpoint`) and body drags (`connectedPipesAtP1` / `connectedPipesAtP2`).
- Enhanced endpoint detection in `plumbing_v2/interactions/finders.js` by changing `findPipeEndpoint` to `findPipeEndpoint(pipe, point, tolerance = 2)` and adding a projection-based fallback that treats near-axis clicks as endpoint intent when inside an expanded endpoint zone.
- Updated `plumbing_v2/interactions/interaction-manager.js` to forward an optional `tolerance` through its `findPipeEndpoint` wrapper and modified `pointer/handle-pointer-down.js` to call `this.findPipeEndpoint(hitObject, point, worldTolerance)` and start an endpoint drag when endpoint intent is detected instead of always starting a body drag.

### Testing
- Ran a syntax check: `node --check plumbing_v2/interactions/drag-handler.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850ee84bec832b8a5f8a1ecaf0df58)