### PR TITLE
Boru sürükleme sırasında kopma sorunları düzeltildi

### DIFF
--- a/plumbing_v2/interactions/drag-handler.js
+++ b/plumbing_v2/interactions/drag-handler.js
@@ -827,10 +827,15 @@ export function handleDrag(interactionManager, point, event = null) {
             if (connectedMeter) {
                 const dx = finalPos.x - oldPoint.x;
                 const dy = finalPos.y - oldPoint.y;
+                const dz = (finalPos.z || 0) - (oldPoint.z || 0); // DÜZELTME: Z eksenini de hesapla
                 connectedMeter.x += dx; connectedMeter.y += dy;
                 if (connectedMeter.cikisBagliBoruId) {
                     const cikisBoru = interactionManager.manager.pipes.find(p => p.id === connectedMeter.cikisBagliBoruId);
-                    if (cikisBoru) { cikisBoru.p1.x += dx; cikisBoru.p1.y += dy; }
+                    if (cikisBoru) {
+                        cikisBoru.p1.x += dx;
+                        cikisBoru.p1.y += dy;
+                        cikisBoru.p1.z = (cikisBoru.p1.z || 0) + dz; // DÜZELTME: Z eksenini de güncelle (3D'de kopma önleme)
+                    }
                 }
             }
 
@@ -1121,8 +1126,8 @@ export function handleDrag(interactionManager, point, event = null) {
             // Borunun mevcut iki ucuna bağlı olan TÜM elemanları bul ve ağacı kur
             // (Burada boru henüz hareket etmediği için geometrik kontroller çalışır)
             const startPipes = [];
-            const tolerance = 1;
-            
+            const tolerance = TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE; // DÜZELTME: Tutarlı tolerance kullan
+
             interactionManager.manager.pipes.forEach(otherPipe => {
                 if (otherPipe.id === pipe.id) return;
 
@@ -1463,15 +1468,15 @@ function getRecursiveConnectedObjects(manager, startPipes, excludePipeIds = []) 
         // 1. Find geometric connections (pipes connected to endpoints)
         manager.pipes.forEach(p => {
              if(visitedPipes.has(p.id)) return;
-             
-             // Check connection with current pipe
-             const tolerance = 1.0;
-             const isConnected = 
+
+             // Check connection with current pipe - DÜZELTME: CONNECTED_PIPES_TOLERANCE kullan (tutarlılık için)
+             const tolerance = TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE;
+             const isConnected =
                 Math.hypot(p.p1.x - curr.p1.x, p.p1.y - curr.p1.y, (p.p1.z||0) - (curr.p1.z||0)) < tolerance ||
                 Math.hypot(p.p1.x - curr.p2.x, p.p1.y - curr.p2.y, (p.p1.z||0) - (curr.p2.z||0)) < tolerance ||
                 Math.hypot(p.p2.x - curr.p1.x, p.p2.y - curr.p1.y, (p.p2.z||0) - (curr.p1.z||0)) < tolerance ||
                 Math.hypot(p.p2.x - curr.p2.x, p.p2.y - curr.p2.y, (p.p2.z||0) - (curr.p2.z||0)) < tolerance;
-             
+
              if(isConnected) addPipe(p);
         });
 

--- a/plumbing_v2/interactions/finders.js
+++ b/plumbing_v2/interactions/finders.js
@@ -517,7 +517,7 @@ export function findVerticalPipeSymbolAt(manager, point, tolerance = 10) {
  */
 export function findVerticalPipeChain(manager, basePipe) {
     const chain = [];
-    const tolerance = 1; // cm
+    const tolerance = TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE; // DÜZELTME: Tutarlı tolerance kullan (kopma önleme)
 
     // Baz borunun X,Y koordinatlarını al
     const baseX = basePipe.p1.x;
@@ -560,7 +560,7 @@ export function findVerticalPipeChain(manager, basePipe) {
 export function findAlignedPipeChain(manager, basePipe, primaryAxis) {
     const chain = [basePipe];
     const visited = new Set([basePipe.id]);
-    const tolerance = 1; // cm
+    const tolerance = TESISAT_CONSTANTS.CONNECTED_PIPES_TOLERANCE; // DÜZELTME: Tutarlı tolerance kullan (kopma önleme)
     const angleTolerance = 10; // derece
 
     // BFS ile bağlı boruları bul

--- a/plumbing_v2/interactions/tesisat-snap.js
+++ b/plumbing_v2/interactions/tesisat-snap.js
@@ -26,7 +26,7 @@ export const TESISAT_CONSTANTS = {
     MIN_BORU_UZUNLUGU: 5,       // cm
     ACI_TOLERANSI: 30,            // derece - 90° snap toleransı (X ve Y yönü)
     SELECTION_TOLERANCE_PIXELS: 12, // piksel - Seçim için tolerance (ZOOM BAĞIMSIZ - ekranda her zaman 12 piksel)
-    CONNECTED_PIPES_TOLERANCE: 7, // cm - Bağlı boruları bulmak için tolerance (world coordinates - fiziksel mesafe)
+    CONNECTED_PIPES_TOLERANCE: 2, // cm - Bağlı boruları bulmak için tolerance (world coordinates - fiziksel mesafe) - DÜŞÜRÜLDÜ: 7→2cm (daha sıkı bağlantı, kopma önleme)
 };
 
 // Snap Tipleri


### PR DESCRIPTION
SORUN:
- Boruların bağlantı noktaları (p1, p2) bazen sürükleme sırasında kopuyordu
- Aynı noktada birbirine bağlı borular birlikte sürüklenmeliydi ama bazen tek başlarına hareket ediyordu
- Özellikle bir borunun ucuna yakın ama dışarıda bir noktaya tıklandığında kopma oluşuyordu

KÖK NEDENLER:
1. Tolerance uyumsuzluğu: Başlangıçta 7cm, hareket sırasında 1cm tolerance kullanılıyordu
2. Z ekseni güncelleme eksikliği: Sayaç çıkış boruları 3D'de Z ekseni güncellenmiyordu
3. Aligned chain tolerance uyumsuzluğu: findAlignedPipeChain() 1cm kullanıyordu

ÇÖZÜMLER:
- CONNECTED_PIPES_TOLERANCE değeri 7cm → 2cm (daha sıkı bağlantı)
- Tüm bağlantı kontrollerinde CONNECTED_PIPES_TOLERANCE kullanılıyor (tutarlılık)
- getRecursiveConnectedObjects() tolerance: 1.0cm → CONNECTED_PIPES_TOLERANCE
- Body drag CTRL mode tolerance: 1cm → CONNECTED_PIPES_TOLERANCE
- findAlignedPipeChain() tolerance: 1cm → CONNECTED_PIPES_TOLERANCE
- findVerticalPipeChain() tolerance: 1cm → CONNECTED_PIPES_TOLERANCE
- Sayaç çıkış borusu Z ekseni güncellemesi eklendi (endpoint drag)

Artık borular sürüklenirken birbirine bağlı noktalar tutarlı şekilde birlikte hareket eder.

https://claude.ai/code/session_018RrgjX6otRDmTSDQC4htTD