### PR TITLE
Fix drag boundaries for pipes and points

### DIFF
--- a/plumbing_v2/interactions/finders.js
+++ b/plumbing_v2/interactions/finders.js
@@ -64,8 +64,9 @@ export function findObjectAt(manager, point) {
     }
 
     // ÖNCELİK 2: Borular
-    const worldTolerance = pixelsToWorld(TESISAT_CONSTANTS.SELECTION_TOLERANCE_PIXELS);
-    
+    const endpointTolerance = pixelsToWorld(TESISAT_CONSTANTS.SELECTION_TOLERANCE_PIXELS);
+    const bodyTolerance = pixelsToWorld(TESISAT_CONSTANTS.PIPE_BODY_TOLERANCE_PIXELS);
+
     for (const pipe of manager.pipes) {
         const p1Screen = getScreenPoint(pipe.p1);
         const p2Screen = getScreenPoint(pipe.p2);
@@ -73,7 +74,7 @@ export function findObjectAt(manager, point) {
         const distP1 = Math.hypot(point.x - p1Screen.x, point.y - p1Screen.y);
         const distP2 = Math.hypot(point.x - p2Screen.x, point.y - p2Screen.y);
 
-        if (distP1 < worldTolerance || distP2 < worldTolerance) {
+        if (distP1 < endpointTolerance || distP2 < endpointTolerance) {
             return pipe;
         }
 
@@ -87,7 +88,7 @@ export function findObjectAt(manager, point) {
                 const projX = p1Screen.x + t * dx;
                 const projY = p1Screen.y + t * dy;
                 const dist = Math.hypot(point.x - projX, point.y - projY);
-                if (dist < worldTolerance) {
+                if (dist < bodyTolerance) {
                     return pipe;
                 }
             }
@@ -210,7 +211,7 @@ export function findBoruUcuAt(manager, point, tolerance = 5, onlyFreeEndpoints =
     return candidates[0]; // İlk bulunanı döndür
 }
 
-export function findBoruGovdeAt(manager, point, tolerance = 5) {
+export function findBoruGovdeAt(manager, point, tolerance = 3) {
     for (const boru of manager.pipes) {
         const p1Screen = getScreenPoint(boru.p1);
         const p2Screen = getScreenPoint(boru.p2);

--- a/plumbing_v2/interactions/interaction-manager.js
+++ b/plumbing_v2/interactions/interaction-manager.js
@@ -389,7 +389,7 @@ export class InteractionManager {
         return findBoruUcuAt(this.manager, point, tolerance, onlyFreeEndpoints, preferredPipeId);
     }
 
-    findBoruGovdeAt(point, tolerance = 5) {
+    findBoruGovdeAt(point, tolerance = 3) {
         return findBoruGovdeAt(this.manager, point, tolerance);
     }
 
@@ -397,7 +397,7 @@ export class InteractionManager {
         return findPipeAt(this.manager, point, tolerance);
     }
 
-    findBoruGovdeAt(point, tolerance = 5) {
+    findBoruGovdeAt(point, tolerance = 3) {
         return findBoruGovdeAt(this.manager, point, tolerance);
     }
 

--- a/plumbing_v2/interactions/tesisat-snap.js
+++ b/plumbing_v2/interactions/tesisat-snap.js
@@ -25,7 +25,8 @@ export const TESISAT_CONSTANTS = {
     SNAP_MESAFESI: 20,          // cm - Snap yakalama mesafesi
     MIN_BORU_UZUNLUGU: 5,       // cm
     ACI_TOLERANSI: 30,            // derece - 90° snap toleransı (X ve Y yönü)
-    SELECTION_TOLERANCE_PIXELS: 12, // piksel - Seçim için tolerance (ZOOM BAĞIMSIZ - ekranda her zaman 12 piksel)
+    SELECTION_TOLERANCE_PIXELS: 5, // piksel - Seçim için tolerance (ZOOM BAĞIMSIZ - ekranda her zaman 5 piksel)
+    PIPE_BODY_TOLERANCE_PIXELS: 3, // piksel - Boru gövdesi seçim toleransı (boru görsel genişliğinin yarısı)
     CONNECTED_PIPES_TOLERANCE: 7, // cm - Bağlı boruları bulmak için tolerance (world coordinates - fiziksel mesafe)
 };
 

--- a/pointer/handle-pointer-down.js
+++ b/pointer/handle-pointer-down.js
@@ -371,8 +371,8 @@ export function handlePointerDown(e) {
         return true;
     }
 
-    const worldTolerance3 = pixelsToWorld(TESISAT_CONSTANTS.SELECTION_TOLERANCE_PIXELS);
-    const boruGovde = this.findBoruGovdeAt(point, worldTolerance3);
+    const bodyTolerance = pixelsToWorld(TESISAT_CONSTANTS.PIPE_BODY_TOLERANCE_PIXELS);
+    const boruGovde = this.findBoruGovdeAt(point, bodyTolerance);
     if (boruGovde) {
         this.startBoruCizim(boruGovde.nokta, boruGovde.boruId, BAGLANTI_TIPLERI.BORU);
         return true;


### PR DESCRIPTION
Reduce selection tolerances to ensure pipes and points can only be dragged when clicking inside their actual boundaries:

- Reduce endpoint selection tolerance from 12px to 5px
- Add pipe body tolerance of 3px (matching visual pipe width)
- Update findObjectAt to use separate tolerances for endpoints vs body
- Update all related finder functions and their default parameters

This ensures users must click precisely on points and within pipe boundaries to initiate dragging, preventing accidental selection from outside.

https://claude.ai/code/session_012HXL7zUFMBHPGDmmn7twWP