### PR TITLE
Fix vertical pipe thickness in 3D drawing mode

### DIFF
--- a/plumbing_v2/renderer/renderer-pipes.js
+++ b/plumbing_v2/renderer/renderer-pipes.js
@@ -282,6 +282,11 @@ drawPipes(ctx, pipes) {
             // Zoom ayarı
             const zoom = state.zoom || 1;
             let width = config.lineWidth;
+            // 3D çizim görünümünde (katı model dışı) düşey borular, yataylarla aynı
+            // görsel kalınlıkta olmalı. Bu yüzden düşeylerde standart lineWidth kullan.
+            if (isVerticalPipe) {
+                width = BORU_TIPLERI.STANDART.lineWidth;
+            }
             if (zoom < 1) width = 4 / zoom;
 
             ctx.save();


### PR DESCRIPTION
### Motivation
- Vertical (V) pipes were rendered visually thicker than horizontal (H) pipes in the 3D (non-solid) pipe renderer, causing inconsistent appearance in the 3D drawing view.

### Description
- Normalize vertical pipe line width to use the standard pipe width by applying the override in `plumbing_v2/renderer/renderer-pipes.js` so V pipes render with the same visual thickness as H pipes while preserving zoom behavior.

### Testing
- Ran `node --check plumbing_v2/renderer/renderer-pipes.js` which completed successfully; and executed a smoke test by serving the app (`python3 -m http.server 4173`) and running a Playwright capture script to verify the visual change, which produced a screenshot for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852984dc4c832b84b29e9500cd7062)